### PR TITLE
docs: Document comment handling in input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ The `examples/` directory contains sample GAMS NLP models:
 ### Preprocessing
 - ✅ `$include` directive (nested, relative paths) *(Sprint 4)*
 
+### Comments
+- ✅ GAMS inline comments (`* comment`)
+- ✅ C-style line comments (`// comment`)
+- ✅ Block comments (`$ontext ... $offtext`)
+
+**Note:** Input file comments are stripped during parsing and do not appear in the output. However, the emitter can add explanatory comments to the output (controlled by `--no-comments` flag).
+
 ### Expressions
 - ✅ Arithmetic: `+`, `-`, `*`, `/`, `^`
 - ✅ Functions: `exp`, `log`, `sqrt`, `sin`, `cos`, `tan`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -162,6 +162,41 @@ nlp2mcp input.gms -o output.gms --no-comments
 nlp2mcp input.gms -o output.gms --show-excluded
 ```
 
+### Comment Handling
+
+**Your input files can contain comments** - you don't need to strip them!
+
+nlp2mcp supports all three GAMS comment styles:
+
+```gams
+* GAMS inline comment (line starting with asterisk)
+x.lo = 0;  * Lower bound comment
+
+// C-style line comment
+y.up = 100;  // Upper bound
+
+$ontext
+Block comment spanning
+multiple lines - useful for
+documentation sections
+$offtext
+```
+
+**Important notes:**
+- ✅ All comment types are handled correctly during parsing
+- ❌ Input comments are **not** preserved in the output file (they are stripped)
+- ℹ️ Output files can optionally include **generated** explanatory comments about the KKT system structure (use `--no-comments` to disable)
+
+**Example:**
+
+```bash
+# Input file with comments → Output without input comments
+nlp2mcp model_with_comments.gms -o output.gms
+
+# Disable generated explanatory comments in output
+nlp2mcp model_with_comments.gms -o output.gms --no-comments
+```
+
 ---
 
 ## Sprint 4 Features


### PR DESCRIPTION
- Add 'Comments' section to README.md showing supported comment types
- Add 'Comment Handling' section to USER_GUIDE.md with examples
- Clarify that input comments are stripped but output comments can be generated
- Users don't need to strip comments from their GAMS models

Addresses user question about whether parser handles GAMS comments.