### PR TITLE
Fix #109: Resolve smooth abs() parenthesization and initialization is…

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -264,7 +264,9 @@ def main(
             click.echo("Generating GAMS MCP code...")
 
         add_comments = not no_comments
-        gams_code = emit_gams_mcp(kkt, model_name=model_name, add_comments=add_comments)
+        gams_code = emit_gams_mcp(
+            kkt, model_name=model_name, add_comments=add_comments, config=config
+        )
 
         # Step 7: Write output
         if output:

--- a/src/emit/expr_to_gams.py
+++ b/src/emit/expr_to_gams.py
@@ -32,6 +32,7 @@ PRECEDENCE = {
     "*": 5,
     "/": 5,
     "^": 6,  # Power operator (highest precedence)
+    "**": 6,  # Alternative power operator syntax (same precedence as ^)
 }
 
 
@@ -188,7 +189,8 @@ def expr_to_gams(expr: Expr, parent_op: str | None = None, is_right: bool = Fals
 
         case Binary(op, left, right):
             # Convert power operator to GAMS syntax
-            if op == "^":
+            # Handle both ^ and ** (term collection may generate **)
+            if op in ("^", "**"):
                 # GAMS uses ** for exponentiation
                 left_str = expr_to_gams(left, parent_op=op, is_right=False)
                 right_str = expr_to_gams(right, parent_op=op, is_right=True)


### PR DESCRIPTION
…sues

This commit fixes two bugs in the smooth abs() feature:

1. Parenthesization Bug (src/emit/expr_to_gams.py):
   - Added '**' operator to PRECEDENCE table
   - Changed power operator check from 'op == "^"' to 'op in ("^", "**")'
   - Fixes incorrect output like '(x - 2 ** 2)' -> '(x - 2) ** 2'

2. Initialization Issue (src/emit/emit_gams.py):
   - Added 'config' parameter to emit_gams_mcp()
   - Added automatic variable initialization when smooth_abs is enabled
   - Emits '{var}.l = 1;' for all primal variables to avoid GAMS domain errors

3. CLI Integration (src/cli.py):
   - Pass config object to emit_gams_mcp()

4. Documentation (docs/issues/smooth-abs-initialization-issues.md):
   - Updated with resolution details and testing results

All 694 unit tests passing. Generated MCP code now has correct parentheses and initialization to prevent GAMS domain errors.