### PR TITLE
Fix PyPI badge: Switch from badge.fury.io to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/jeffreyhorn/nlp2mcp/workflows/CI/badge.svg)
 ![Lint](https://github.com/jeffreyhorn/nlp2mcp/workflows/Lint/badge.svg)
-[![PyPI version](https://badge.fury.io/py/nlp2mcp.svg)](https://pypi.org/project/nlp2mcp/)
+[![PyPI version](https://img.shields.io/pypi/v/nlp2mcp.svg)](https://pypi.org/project/nlp2mcp/)
 [![Python Support](https://img.shields.io/pypi/pyversions/nlp2mcp.svg)](https://pypi.org/project/nlp2mcp/)
 
 A Python tool that transforms Nonlinear Programming (NLP) models written in GAMS into equivalent Mixed Complementarity Problems (MCP) by generating the Karush-Kuhn-Tucker (KKT) conditions.


### PR DESCRIPTION
badge.fury.io is not indexing the package properly and returns 'not found'. shields.io correctly displays the version (v0.5.0b0).