### PR TITLE
Update sprint numbering in PROJECT_PLAN.md

### DIFF
--- a/docs/planning/EPIC_2/PROJECT_PLAN.md
+++ b/docs/planning/EPIC_2/PROJECT_PLAN.md
@@ -159,7 +159,7 @@ This plan translates `GOALS_REVISED.md` into sprint-ready guidance for Sprints�
 
 ---
 
-# Sprint 8b (Weeks 7–8): Advanced Parser Features & Conversion Pipeline
+# Sprint 9 (Weeks 7–8): Advanced Parser Features & Conversion Pipeline
 
 **Goal:** Implement advanced parser features requiring grammar changes and begin conversion pipeline work. Builds on Sprint 8's foundation with higher-complexity features.
 
@@ -224,7 +224,7 @@ This plan translates `GOALS_REVISED.md` into sprint-ready guidance for Sprints�
 
 ---
 
-# Sprint 9 (Weeks 9–10): Aggressive Simplification, Regression Guardrails, UX Diagnostics
+# Sprint 10 (Weeks 9–10): Aggressive Simplification, Regression Guardrails, UX Diagnostics
 
 **Goal:** Deliver `--simplification aggressive` informed by telemetry, integrate CI regression hooks (GAMSLib sampling, PATH smoke, performance alerts), and expand diagnostics features.
 
@@ -250,7 +250,7 @@ This plan translates `GOALS_REVISED.md` into sprint-ready guidance for Sprints�
 
 ---
 
-# Sprint 10 (Weeks 11–12): Final UX Polish, Documentation Wrap, Release Readiness, v1.0.0
+# Sprint 11 (Weeks 11–12): Final UX Polish, Documentation Wrap, Release Readiness, v1.0.0
 
 **Goal:** Complete diagnostics/progress UI, finalize documentation (advanced usage, GAMSLib handbook, tutorials), close outstanding bugs, and ship v1.0.0 meeting all KPIs.
 


### PR DESCRIPTION
## Summary

Updates sprint numbering in PROJECT_PLAN.md to reflect the current sprint schedule after Sprint 8 completion.

## Changes

- **Sprint 8b → Sprint 9** (Weeks 7-8): Advanced Parser Features & Conversion Pipeline
- **Sprint 9 → Sprint 10** (Weeks 9-10): Aggressive Simplification, Regression Guardrails, UX Diagnostics  
- **Sprint 10 → Sprint 11** (Weeks 11-12): Final UX Polish, Documentation Wrap, Release Readiness, v1.0.0
- **Document header**: Updated from "Sprints 6-10" to "Sprints 6-11"
- **Fixed reference**: Sprint 8 retrospective mentions "Sprint 9 recommendations" (not Sprint 10)

## Rationale

With Sprint 8 complete, the original "Sprint 8b" is now the next sprint (Sprint 9). This renumbering maintains sequential sprint numbers and clarifies the remaining schedule through the v1.0.0 release.

## Sprint Schedule

| Sprint | Weeks | Focus |
|--------|-------|-------|
| Sprint 6 | 1-2 | Convexity Heuristics, GAMSLib Bootstrapping ✅ |
| Sprint 7 | 3-4 | Parser Enhancements Wave 1 ✅ |
| Sprint 8 | 5-6 | Parser Maturity & Developer Experience ✅ |
| **Sprint 9** | **7-8** | **Advanced Parser Features & Conversion Pipeline** |
| Sprint 10 | 9-10 | Aggressive Simplification, Regression Guardrails |
| Sprint 11 | 11-12 | Final UX Polish, v1.0.0 Release |

## Files Modified

- 

## Testing

No code changes - documentation only.