### PR TITLE
Document 5 tier 2 blocking issues

### DIFF
--- a/docs/issues/parser-file-statement.md
+++ b/docs/issues/parser-file-statement.md
@@ -1,0 +1,57 @@
+# Parser: `file` Statement Not Supported
+
+## GitHub Issue
+- **Issue #:** 434
+- **URL:** https://github.com/jeffreyhorn/nlp2mcp/issues/434
+
+## Summary
+The parser does not support the GAMS `file` statement for file I/O operations.
+
+## Affected Model
+- **inscribedsquare.gms** (Tier 2) - Inscribed Square Problem
+
+## Error
+```
+Error: Parse error at line 84, column 6: Unexpected character: 'f'
+  file f / '%gams.scrdir%gnuplot.in' /;
+       ^
+```
+
+## Root Cause
+The grammar does not include a rule for `file` statements. GAMS uses `file` to declare file handles for output operations.
+
+## GAMS Code Pattern
+```gams
+file f / '%gams.scrdir%gnuplot.in' /;
+if( %gnuplot% and
+ (m.modelstat = %modelStat.optimal% or
+  m.modelstat = %modelStat.locallyOptimal% or
+  m.modelstat = %modelStat.feasibleSolution%),
+  f.nd=6;
+  f.nw=0;
+  ...
+);
+```
+
+The `file` statement declares a file handle `f` with a path, used for writing output (typically for plotting or reporting).
+
+## Suggested Fix
+Option 1 (Skip/Ignore): Add `file` to the list of ignored directives since file I/O is not relevant for NLP model extraction.
+
+Option 2 (Parse but don't process): Add a grammar rule that parses the file statement but doesn't create IR nodes:
+```lark
+file_stmt: "file"i ID "/" STRING "/" SEMI
+```
+
+## Complexity
+Low - can be handled by ignoring or adding a simple skip rule.
+
+## Test Case
+```gams
+file f / 'output.txt' /;
+```
+
+Expected: Statement is parsed (or skipped) without error.
+
+## Notes
+The `file` statement is typically used for post-solve reporting and visualization, which is outside the scope of NLP model extraction. Ignoring it is the simplest solution.

--- a/docs/issues/parser-level-attribute-access.md
+++ b/docs/issues/parser-level-attribute-access.md
@@ -1,0 +1,58 @@
+# Parser: Level Attribute `.l` Access Not Supported
+
+## GitHub Issue
+- **Issue #:** 432
+- **URL:** https://github.com/jeffreyhorn/nlp2mcp/issues/432
+
+## Summary
+The parser does not support accessing variable level attributes (`.l`) for reading solution values in assignment statements.
+
+## Affected Model
+- **chenery.gms** (Tier 2) - Substitution and Structural Change
+
+## Error
+```
+Error: Parse error at line 199, column 1: Unexpected character: 'l'
+  l.l(i) = (((del(i)/vv.l(i) + (1 - del(i)))**(1/rho(i)))$(sig(i) <> 0)
+  ^
+```
+
+## Root Cause
+The grammar supports `.lo`, `.up`, `.fx`, `.l`, `.m` as bound/attribute setters on the left-hand side of assignments (via `BOUND_K`), but does not support reading `.l` (level) values on the right-hand side of expressions.
+
+## GAMS Code Pattern
+```gams
+h.l(t) = gam(t) - alp(t)*e.l(t);
+pd.l   = 0.3;
+p.l(i) = 3;
+pk.l   = 3.5;
+pi.l   = pk.l/plab;
+
+vv.l(i)$sig(i) = (pi.l*(1 - del(i))/del(i))**(-rho(i)/(1 + rho(i)));
+
+l.l(i) = (((del(i)/vv.l(i) + (1 - del(i)))**(1/rho(i)))$(sig(i) <> 0)
+         + 1$(sig(i) = 0))/efy(i);
+```
+
+The `.l` suffix is used both:
+1. On the LHS to set initial level values
+2. On the RHS to read current level values (e.g., `vv.l(i)` in the expression)
+
+## Suggested Fix
+Extend `ref_bound` or add a new rule to allow `.l` attribute access in expressions:
+
+1. Current `ref_bound` handles LHS: `ID "." BOUND_K "(" index_list ")"`
+2. Need to allow `ID "." BOUND_K` in `atom` rule for RHS expressions
+
+## Complexity
+Medium - grammar already has `BOUND_K` pattern, need to allow it in expression context.
+
+## Test Case
+```gams
+Variable x;
+x.l = 5;
+Parameter p;
+p = x.l * 2;
+```
+
+Expected: `p = 10`

--- a/docs/issues/parser-not-operator.md
+++ b/docs/issues/parser-not-operator.md
@@ -1,0 +1,49 @@
+# Parser: `not` Operator Not Supported
+
+## GitHub Issue
+- **Issue #:** 431
+- **URL:** https://github.com/jeffreyhorn/nlp2mcp/issues/431
+
+## Summary
+The parser does not support the GAMS `not` operator for boolean negation.
+
+## Affected Model
+- **gastrans.gms** (Tier 2) - Gas Transmission Problem - Belgium
+
+## Error
+```
+Error: Parse error at line 110, column 13: Unexpected character: 'a'
+  ap(a) = not as(a);
+              ^
+```
+
+## Root Cause
+The grammar does not include a `not` operator for boolean negation. GAMS supports `not` as a unary operator that negates a boolean expression.
+
+## GAMS Code Pattern
+```gams
+as(a) = sum(aij(a,i,j), adata(aij,'act'));
+ap(a) = not as(a);
+```
+
+In this context, `as(a)` is a boolean parameter indicating active arcs, and `ap(a)` is the negation (passive arcs).
+
+## Suggested Fix
+Add `not` as a unary operator in the grammar, similar to how `MINUS` is handled for numeric negation:
+
+1. Add `NOT_K` terminal: `NOT_K: /(?i:not)\b/`
+2. Add to factor rule: `?factor: ... | NOT_K factor -> unaryop`
+3. Handle in parser to produce boolean negation
+
+## Complexity
+Medium - requires grammar change and parser handling for boolean expressions.
+
+## Test Case
+```gams
+Set a / a1, a2 /;
+Parameter as(a) / a1 1, a2 0 /;
+Parameter ap(a);
+ap(a) = not as(a);
+```
+
+Expected: `ap('a1') = 0`, `ap('a2') = 1`

--- a/docs/issues/parser-set-member-validation-strict.md
+++ b/docs/issues/parser-set-member-validation-strict.md
@@ -1,0 +1,56 @@
+# Parser: Set Member Validation Too Strict (Case Sensitivity)
+
+## GitHub Issue
+- **Issue #:** 435
+- **URL:** https://github.com/jeffreyhorn/nlp2mcp/issues/435
+
+## Summary
+The semantic validation for parameter data is too strict when checking set member references, failing on case mismatches that GAMS accepts.
+
+## Affected Model
+- **chem.gms** (Tier 2) - Chemical Equilibrium Problem
+
+## Error
+```
+Parameter 'mix' references member 'h' not present in set 'i' [context: expression] (line 25, column 47)
+```
+
+## Root Cause
+The validation checks if parameter data keys reference valid set members, but the comparison is case-sensitive. GAMS identifiers are case-insensitive.
+
+## GAMS Code Pattern
+```gams
+Set c  'species' / H, H2, H2O, N, N2, NH, NO, O, O2, OH /;
+
+Parameter
+   mix(i)   'number of elements in mixture' / h 2, n 1, o 1 /
+   gibbs(c) 'gibbs free energy at 3500 k and 750 psi'
+            / H  -10.021, H2  -21.096, H2O -37.986, N   -9.846, N2 -28.653
+              NH -18.918, NO -28.032 , O   -14.640, o2 -30.594, OH -26.11  /;
+```
+
+Note that:
+- Set `c` defines `H` (uppercase)
+- Parameter `mix` references `h` (lowercase)
+- Parameter `gibbs` uses `o2` (lowercase) while set has `O2` (uppercase)
+
+GAMS treats these as equivalent due to case-insensitivity.
+
+## Current Behavior
+The parser/validator compares set members with exact case matching, causing `'h'` to not match `'H'`.
+
+## Suggested Fix
+Make set member validation case-insensitive:
+1. Normalize both set member names and parameter data keys to lowercase during comparison
+2. Or use a case-insensitive comparison function
+
+## Complexity
+Low - simple string comparison change in validation logic.
+
+## Test Case
+```gams
+Set i / A, B, C /;
+Parameter p(i) / a 1, b 2, c 3 /;
+```
+
+Expected: Parse succeeds with case-insensitive matching of `a`→`A`, `b`→`B`, `c`→`C`.

--- a/docs/issues/parser-unquoted-parameter-description.md
+++ b/docs/issues/parser-unquoted-parameter-description.md
@@ -1,0 +1,55 @@
+# Parser: Unquoted Parameter Descriptions Not Supported
+
+## GitHub Issue
+- **Issue #:** 433
+- **URL:** https://github.com/jeffreyhorn/nlp2mcp/issues/433
+
+## Summary
+The parser does not support unquoted text descriptions after parameter declarations.
+
+## Affected Model
+- **gasoil.gms** (Tier 2) - Catalytic Cracking of Gas Oil (via `copspart.inc` include file)
+
+## Error
+```
+Error: Parse error at line 96, column 1: Unexpected character: 'r'
+  rho(nc) roots of k-th degree Legendre polynomial
+  ^
+```
+
+## Root Cause
+The grammar expects parameter descriptions to be quoted strings, but GAMS allows unquoted descriptions after the parameter name/domain declaration.
+
+## GAMS Code Pattern (from copspart.inc)
+```gams
+Parameter t(nh)   partition
+          rho(nc) roots of k-th degree Legendre polynomial
+          itau(nm) "itau[i] is the largest integer k with t[k] <= tau[i]";
+```
+
+Here:
+- `partition` is an unquoted description for `t(nh)`
+- `roots of k-th degree Legendre polynomial` is an unquoted description for `rho(nc)`
+- The third parameter uses a quoted description (which works)
+
+## Current Grammar
+```lark
+param_single_item: ID "(" id_or_wildcard_list ")" (STRING | desc_text)? ...
+```
+
+The `desc_text` pattern may not be matching multi-word unquoted descriptions correctly in parameter context.
+
+## Suggested Fix
+Ensure `desc_text` or a similar pattern captures unquoted multi-word descriptions in parameter declarations, similar to how it works for variables and sets.
+
+## Complexity
+Low - grammar already has `desc_text` pattern for other declarations, may need adjustment for parameter context.
+
+## Test Case
+```gams
+Parameter
+   x(i)   cost coefficient
+   y(j)   demand level;
+```
+
+Expected: Both parameters parsed with their unquoted descriptions.


### PR DESCRIPTION
## Summary
Documents the remaining 5 blocking issues preventing tier 2 models from parsing completely.

## Current Status
- **Tier 2 Parsing:** 13/18 models (72%) parse completely
- **Blocking Issues:** 5 models fail due to specific parser limitations

## Issues Created

| Issue | Model | Blocking Issue | Complexity |
|-------|-------|----------------|------------|
| #431 | gastrans.gms | `not` operator not supported | Medium |
| #432 | chenery.gms | `.l` level attribute access not supported | Medium |
| #433 | gasoil.gms | Unquoted parameter descriptions not supported | Low |
| #434 | inscribedsquare.gms | `file` statement not supported | Low |
| #435 | chem.gms | Set member validation too strict (case sensitivity) | Low |

## Files Added
- `docs/issues/parser-not-operator.md`
- `docs/issues/parser-level-attribute-access.md`
- `docs/issues/parser-unquoted-parameter-description.md`
- `docs/issues/parser-file-statement.md`
- `docs/issues/parser-set-member-validation-strict.md`

## Recommended Fix Priority (by ROI)
1. **#435** - Case sensitivity fix (Low effort, unlocks chem.gms)
2. **#434** - Ignore `file` statement (Low effort, unlocks inscribedsquare.gms)
3. **#433** - Unquoted descriptions (Low effort, unlocks gasoil.gms)
4. **#431** - `not` operator (Medium effort, unlocks gastrans.gms)
5. **#432** - `.l` attribute (Medium effort, unlocks chenery.gms)