### PR TITLE
Document remaining tier 2 blocking issues (#455, #456)

### DIFF
--- a/docs/issues/parser-execute-statement.md
+++ b/docs/issues/parser-execute-statement.md
@@ -1,0 +1,147 @@
+# Parser: Execute Statement Not Supported
+
+**GitHub Issue:** [#456](https://github.com/jeffreyhorn/nlp2mcp/issues/456)
+**Status:** Open  
+**Priority:** Low  
+**Blocking Model:** inscribedsquare.gms (tier 2)
+
+---
+
+## Problem Summary
+
+The GAMS parser does not support the `execute` statement. The `execute` statement is used to run external programs or shell commands from within a GAMS model. This is commonly used for post-processing, visualization, or integration with other tools.
+
+---
+
+## Reproduction
+
+### Test Case
+
+```gams
+execute 'gnuplot input.txt';
+execute 'rm tempfile.txt';
+```
+
+### Error Message
+
+```
+Error: Parse error at line 105, column 9: Unexpected character: '''
+  execute 'gnuplot %gams.scrdir%gnuplot.in'
+          ^
+
+Suggestion: This character is not valid in this context
+```
+
+### Affected Model
+
+**File:** `tests/fixtures/tier2_candidates/inscribedsquare.gms`  
+**Lines:** 105-106
+
+```gams
+  execute 'gnuplot %gams.scrdir%gnuplot.in'
+  execute 'rm %gams.scrdir%gnuplot.in'
+```
+
+The model uses `execute` statements to run gnuplot for visualization and to clean up temporary files.
+
+---
+
+## Technical Analysis
+
+### GAMS Execute Statement Syntax
+
+The `execute` statement has several forms:
+
+1. **Basic execute:** `execute 'command';`
+2. **Execute with return code:** `execute.checkaliashell 'command';`
+3. **Execute with options:** `execute.async 'command';`
+
+### Related Constructs
+
+- `execute_load`: Load data from GDX files
+- `execute_unload`: Save data to GDX files
+- `execute_loadpoint`: Load solution point
+
+### Root Cause
+
+The grammar does not include a rule for the `execute` statement. Since `execute` runs external programs, it's not directly relevant to NLP model extraction, but it needs to be parsed (and skipped) to allow the model to load.
+
+---
+
+## Suggested Fix
+
+Add `execute_stmt` rule to `src/gams/gams_grammar.lark`:
+
+```lark
+// Execute statement (Sprint 12 - mock/skip for external program execution)
+// Syntax: execute 'command';
+// We parse but don't process since external execution is not relevant for NLP model extraction
+execute_stmt: "execute"i ("." ID)? STRING SEMI?
+```
+
+Note: The semicolon may be optional in some GAMS contexts (especially inside if blocks).
+
+Also add to the `stmt` rule and `exec_stmt` rule for use inside if/loop blocks.
+
+---
+
+## Testing Requirements
+
+1. **Unit test:** Verify execute statements parse correctly
+2. **Integration test:** Verify `inscribedsquare.gms` parses completely after fix
+3. **Edge cases:**
+   - Basic: `execute 'command';`
+   - With modifier: `execute.async 'command';`
+   - Without semicolon (in if block context)
+   - With compile-time variables: `execute '%gams.scrdir%script.sh';`
+
+### Example Test Cases
+
+```python
+def test_execute_basic():
+    code = "execute 'echo hello';"
+    model = parse_model_text(code)
+    assert model is not None
+
+def test_execute_with_modifier():
+    code = "execute.async 'long_running_script.sh';"
+    model = parse_model_text(code)
+    assert model is not None
+
+def test_execute_in_if_block():
+    code = '''
+    Scalar x / 1 /;
+    if(x > 0, execute 'script.sh');
+    '''
+    model = parse_model_text(code)
+    assert model is not None
+```
+
+---
+
+## Impact
+
+- **Severity:** Low - The execute statement doesn't affect the mathematical model
+- **Workaround:** Comment out or remove execute statements (model will still solve correctly)
+- **Scope:** Any GAMS code using external program execution
+
+---
+
+## Related Issues
+
+- Issue #447: put statement support (already implemented)
+- The execute statement is often used alongside put statements for visualization pipelines
+
+---
+
+## GAMS Reference
+
+From GAMS documentation:
+
+> The execute statement allows calling external programs. The string argument is passed to the operating system's command processor.
+
+Common uses:
+- Running visualization tools (gnuplot, matplotlib scripts)
+- Post-processing results with external programs
+- File management (copy, move, delete)
+- Integration with other modeling tools

--- a/docs/issues/parser-variable-bounds-subset-indexing.md
+++ b/docs/issues/parser-variable-bounds-subset-indexing.md
@@ -1,0 +1,130 @@
+# Parser: Variable Bounds with Subset Indexing Not Supported
+
+**GitHub Issue:** [#455](https://github.com/jeffreyhorn/nlp2mcp/issues/455)
+**Status:** Open  
+**Priority:** Medium  
+**Blocking Model:** gastrans.gms (tier 2)
+
+---
+
+## Problem Summary
+
+The parser does not correctly handle variable bounds when using subset indexing. When a variable is defined with multiple indices (e.g., `f(a,i,j)`) but bounds are set using a subset that maps to those indices (e.g., `f.lo(aij(as,i,j))`), the parser incorrectly reports an index count mismatch.
+
+---
+
+## Reproduction
+
+### Test Case
+
+```gams
+Set i / 1*3 /, j / 1*3 /;
+Set a / a1, a2 /;
+Set aij(a,i,j) "arc subset";
+Set as(a) / a1 /;
+
+Variable f(a,i,j);
+
+* This should work - aij(as,i,j) expands to the 3 indices (a,i,j)
+f.lo(aij(as,i,j)) = 0;
+```
+
+### Error Message
+
+```
+Variable 'f' bounds expect 3 indices but received 1 [context: expression] (line 145, column 1)
+```
+
+### Affected Model
+
+**File:** `tests/fixtures/tier2_candidates/gastrans.gms`  
+**Line:** 145
+
+```gams
+f.lo(aij(as,i,j)) = 0;
+```
+
+The variable `f` is defined with domain `(a,i,j)` and `aij` is a subset over `(a,i,j)`. The syntax `f.lo(aij(as,i,j))` sets the lower bound for all elements of `f` where the indices are in the subset `aij` and the first index is in `as`.
+
+---
+
+## Technical Analysis
+
+### GAMS Subset Indexing Semantics
+
+In GAMS, when you write `f.lo(aij(as,i,j))`, this means:
+- `aij` is a subset defined over domain `(a,i,j)`
+- The expression `aij(as,i,j)` filters to only those tuples where `a` is in `as`
+- The result is a valid 3-dimensional index into variable `f`
+
+### Current Behavior
+
+The parser sees `aij(as,i,j)` as a single reference and counts it as 1 index, when it should recognize that:
+1. `aij` is a subset over `(a,i,j)` 
+2. The expression expands to provide all 3 indices needed for `f`
+
+### Root Cause
+
+The variable bounds assignment handler doesn't properly expand subset references to determine the actual index count. It's counting the number of top-level tokens rather than understanding the dimensional semantics of subset indexing.
+
+---
+
+## Suggested Fix
+
+Modify the bounds assignment handler in `src/ir/parser.py` to:
+
+1. When encountering a reference like `aij(as,i,j)` in a bounds context
+2. Look up the definition of `aij` to determine its domain dimensions
+3. Use the subset's domain dimension count rather than the syntactic argument count
+
+Alternatively, for a mock/skip approach:
+- Recognize this pattern and skip validation of index counts for bounds assignments involving subset indexing
+- Log a warning that the bounds assignment is being accepted without full validation
+
+---
+
+## Testing Requirements
+
+1. **Unit test:** Verify bounds with subset indexing parse correctly
+2. **Integration test:** Verify `gastrans.gms` parses completely after fix
+
+### Example Test Cases
+
+```python
+def test_bounds_with_subset_indexing():
+    code = '''
+    Set i / 1*3 /, j / 1*3 /;
+    Set a / a1, a2 /;
+    Set aij(a,i,j);
+    Set as(a) / a1 /;
+    Variable f(a,i,j);
+    f.lo(aij(as,i,j)) = 0;
+    '''
+    model = parse_model_text(code)
+    assert model is not None
+
+def test_bounds_with_simple_subset():
+    code = '''
+    Set i / 1*3 /, j / 1*3 /;
+    Set aij(i,j);
+    Variable f(i,j);
+    f.lo(aij) = 0;
+    '''
+    model = parse_model_text(code)
+    assert model is not None
+```
+
+---
+
+## Impact
+
+- **Severity:** Medium - Blocks one tier 2 model
+- **Workaround:** None practical - the bounds are semantically important
+- **Scope:** Any GAMS code using subset-indexed variable bounds
+
+---
+
+## Related Issues
+
+- This is a semantic/validation issue, not a grammar issue
+- The grammar correctly parses the syntax; the issue is in index count validation


### PR DESCRIPTION
## Summary
Documents the 2 remaining blocking issues preventing tier 2 models from parsing completely.

## Current Tier 2 Status
- **16/18 models parse completely (89%)**
- **2 models blocked:**
  - gastrans.gms (line 145)
  - inscribedsquare.gms (line 105)

## Issues Documented

### Issue #455: Variable bounds with subset indexing
- **Model:** gastrans.gms
- **Line:** 145
- **Problem:** `f.lo(aij(as,i,j))` fails because parser counts subset reference as 1 index instead of expanding to 3
- **File:** `docs/issues/parser-variable-bounds-subset-indexing.md`

### Issue #456: Execute statement not supported
- **Model:** inscribedsquare.gms
- **Line:** 105
- **Problem:** `execute 'gnuplot ...'` not recognized by grammar
- **File:** `docs/issues/parser-execute-statement.md`

## Files Added
- `docs/issues/parser-variable-bounds-subset-indexing.md`
- `docs/issues/parser-execute-statement.md`