### PR TITLE
Sprint 15 Day 9: Pipeline Integration Complete [Checkpoint 4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Sprint 15 Day 9: Pipeline Integration Complete [Checkpoint 4] - 2026-01-15
+
+**Branch:** `sprint15-day9-pipeline-complete`  
+**Status:** ✅ COMPLETE
+
+#### Summary
+
+Enhanced `run_full_test.py` with comprehensive summary generation including timing statistics (mean, median, p90), JSON output format for machine-readable results, and improved dry-run mode. Ran full pipeline on all 160 models to establish baseline metrics. Checkpoint 4 completed.
+
+#### Changes
+
+**Modified Files:**
+- `scripts/gamslib/run_full_test.py` - Added summary generation, JSON output, enhanced dry-run
+
+#### Key Features
+
+**Summary Generation:**
+- `compute_timing_stats()` - Calculates mean, median, stddev, min, max, p90, p99
+- `generate_summary()` - Produces structured dictionary for reporting
+- Per-stage timing and error tracking
+- Error category breakdown per stage
+
+**Output Formats:**
+- `--json` flag for machine-readable JSON output
+- JSON includes full timing stats, error breakdowns, success rates
+- JSON mode implies quiet mode (no progress logging)
+
+**Enhanced Dry-Run:**
+- Shows models by type (NLP: 94, LP: 57, QCP: 9)
+- Shows pipeline stages that would run
+- Lists models when verbose or <=20 models
+- Supports JSON output for dry-run
+
+#### Full Pipeline Results (160 models)
+
+| Stage | Attempted | Success | Failure | Rate |
+|-------|-----------|---------|---------|------|
+| Parse | 160 | 34 | 126 | 21.3% |
+| Translate | 34 | 17 | 17 | 50.0% |
+| Solve | 17 | 3 | 14 | 17.6% |
+| Compare | 3 | 1 match | 2 mismatch | 33.3% |
+
+**Full Pipeline Success:** 1/160 (0.6%) - hs62
+
+#### Timing Statistics
+
+| Stage | Mean | Median | P90 | Max |
+|-------|------|--------|-----|-----|
+| Parse | 0.30s | 0.17s | 0.66s | 2.32s |
+| Translate | 1.35s | 1.14s | 2.09s | 4.10s |
+| Solve | 0.21s | 0.18s | 0.32s | 0.38s |
+
+#### Error Breakdown
+
+**Parse Errors (126):**
+- lexer_invalid_char: 109
+- internal_error: 17
+
+**Translate Errors (17):**
+- model_no_objective_def: 5
+- diff_unsupported_func: 5
+- unsup_index_offset: 3
+- model_domain_mismatch: 2
+- unsup_dollar_cond: 1
+- codegen_numerical_error: 1
+
+**Solve Errors (14):**
+- path_syntax_error: 14
+
+#### Usage Examples
+
+```bash
+# Run full pipeline with JSON output
+python scripts/gamslib/run_full_test.py --json > results.json
+
+# Preview what would run
+python scripts/gamslib/run_full_test.py --dry-run
+
+# Dry-run for LP models only
+python scripts/gamslib/run_full_test.py --type LP --dry-run
+```
+
+---
+
 ### Sprint 15 Day 8: Pipeline Orchestrator - 2026-01-15
 
 **Branch:** `sprint15-day8-pipeline-orchestrator`  

--- a/data/gamslib/gamslib_status.json
+++ b/data/gamslib/gamslib_status.json
@@ -28,13 +28,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:45.788218+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.461,
+        "parse_date": "2026-01-15T16:56:50.414436+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4181,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 18, column 24: Unexpected character: '-'\n  k     'horizon'  / 1964-i, 1964-ii, 1964-iii, 1964-iv,\n                         ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:50.472986+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:50.472986+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:50.472986+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -61,13 +74,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:45.852927+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.064,
+        "parse_date": "2026-01-15T16:56:50.493667+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0205,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 17, column 46: Unexpected character: '''\n  c       'crops'               / 'cotton-h'   'cotton-herbaceo',\n                                               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:50.495385+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:50.495385+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:50.495385+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -94,13 +120,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:46.503770+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.651,
+        "parse_date": "2026-01-15T16:56:50.669960+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1745,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 54, column 51: Unexpected character: '('\n  k(j)       'revenue lost (1000 per 100 bumped)' / ('route-1','route-2') 13,\n                                                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:50.672926+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:50.672926+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:50.672926+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -169,13 +208,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:46.589005+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.085,
+        "parse_date": "2026-01-15T16:56:50.697798+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0247,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 19, column 27: Unexpected character: '-'\n  g 'paper grades'      / 20-'bond-wt', 25-'bond-wt', 'c-bond-ext', 'tissue-wrp' /;\n                            ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:50.699536+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:50.699536+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:50.699536+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -226,21 +278,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:52:48.120069+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.531,
+        "parse_date": "2026-01-15T16:56:51.136942+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4373,
         "variables_count": 15,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:11:52.885120+00:00",
+        "translate_date": "2026-01-15T16:56:52.322769+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.422,
+        "translate_time_seconds": 1.1823,
         "error": {
           "category": "model_no_objective_def",
           "message": "Error: Invalid model - Objective variable 'f' is not defined by any equation. ObjectiveIR.expr is None and no defining equation found. Available equations: ['objective', 'alkylshrnk', 'acidbal', 'isobutbal', 'alkyldef', 'octdef', 'aciddef', 'f4def']\n"
         }
+      },
+      "model_statistics": {
+        "variables": 15,
+        "equations": 8,
+        "parameters": 0,
+        "sets": 0
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:52.326034+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:52.326034+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -267,13 +334,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:48.831737+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.711,
+        "parse_date": "2026-01-15T16:56:52.502808+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1765,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 58, column 1: Unexpected character: 'M'\n  Model ampl 'maximum revenue production problem' / all /;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:52.504619+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:52.504619+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:52.504619+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -321,13 +401,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:49.215926+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.377,
+        "parse_date": "2026-01-15T16:56:52.598832+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0941,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 43, column 6: Parse error at line 43, column 6: Unexpected character: 'V'\n  Free Variable tcost 'total cost';\n       ^\n  Free Variable tcost 'total cost';\n       ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 42. Add ';' after: * -----------------------------------------------"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:52.600546+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:52.600546+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:52.600546+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -354,13 +447,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:49.601092+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.385,
+        "parse_date": "2026-01-15T16:56:52.702636+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.102,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 46, column 6: Parse error at line 46, column 6: Unexpected character: 'V'\n  Free Variable tcost 'total cost';\n       ^\n  Free Variable tcost 'total cost';\n       ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 45. Add ';' after: * -----------------------------------------------"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:52.704768+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:52.704768+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:52.704768+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -408,21 +514,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:52:52.383635+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 2.782,
+        "parse_date": "2026-01-15T16:56:53.419455+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.7145,
         "variables_count": 14,
         "equations_count": 13
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:11:55.795466+00:00",
+        "translate_date": "2026-01-15T16:56:54.894739+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.9096,
+        "translate_time_seconds": 1.4732,
         "error": {
           "category": "model_no_objective_def",
           "message": "Error: Invalid model - Objective variable 'pl' is not defined by any equation. ObjectiveIR.expr is None and no defining equation found. Available equations: ['power_loss', 'pumping_energy', 'friction', 'temp_rise', 'load_capacity', 'inlet_pressure', 'oil_viscosity', 'temperature', 'radius', 'limit1', 'limit2', 'temp1', 'temp2']\n"
         }
+      },
+      "model_statistics": {
+        "variables": 14,
+        "equations": 13,
+        "parameters": 0,
+        "sets": 0
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:54.897887+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:54.897887+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -449,13 +570,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:53.428077+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.043,
+        "parse_date": "2026-01-15T16:56:55.198938+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3008,
         "error": {
           "category": "internal_error",
           "message": "Invalid range start 'a': must be a number (e.g., 1) or identifier followed by number (e.g., i1) [context: expression] (line 15, column 37)"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:55.200696+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:55.200696+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:55.200696+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -482,13 +616,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:53.828648+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.093,
+        "parse_date": "2026-01-15T16:56:55.240266+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0221,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 18, column 41: Unexpected character: '''\n  i     'sectors'          / 'ag-subsist' 'food crops',\n                                          ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:55.242162+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:55.242162+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:55.242162+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -515,13 +662,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:55.728475+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.899,
+        "parse_date": "2026-01-15T16:56:55.705244+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4629,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:55.707209+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:55.707209+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:55.707209+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -548,13 +708,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:55.908953+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.18,
+        "parse_date": "2026-01-15T16:56:55.752645+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0453,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:55.754837+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:55.754837+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:55.754837+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -581,13 +754,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:52:56.225985+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.317,
+        "parse_date": "2026-01-15T16:56:55.815044+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.06,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 39, column 49: Unexpected character: ','\n  abort$(b0 <  0) 'b0 should be a positive number', b0;\n                                                  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:55.816814+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:55.816814+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:55.816814+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -614,13 +800,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:01.353657+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 5.127,
+        "parse_date": "2026-01-15T16:56:57.308225+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.4913,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 362, column 1: Unexpected character: 'T'\n  TSAM(ii,jj) =e= A(ii,jj)*(X(jj) + ERR1(jj));\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:57.310733+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:57.310733+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:57.310733+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -647,13 +846,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:02.324954+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.971,
+        "parse_date": "2026-01-15T16:56:57.604324+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2934,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 108, column 67: Unexpected character: '/'\n  stderr1  'standard error of measurement for column sums'   / .05  /\n                                                                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:57.606471+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:57.606471+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:57.606471+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -680,13 +892,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:03.408960+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.084,
+        "parse_date": "2026-01-15T16:56:57.947288+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3406,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:57.949142+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:57.949142+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:57.949142+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -713,13 +938,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:05.113805+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.705,
+        "parse_date": "2026-01-15T16:56:58.478132+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5288,
         "error": {
           "category": "internal_error",
           "message": "Error: Circular dependency detected: 'y' and 'k' define each other\n\nSuggestion: Equations 'yd' and 'kb' create a circular definition:\n  yd: y depends on k\n  kb: k depends on y\n\nReformulate your model to break the cycle."
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:56:58.480177+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:56:58.480177+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:56:58.480177+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -770,22 +1008,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-09T06:10:52.326649+00:00",
+        "parse_date": "2026-01-15T16:56:58.802254+00:00",
         "nlp2mcp_version": "0.1.0",
-        "parse_time_seconds": 1.24,
+        "parse_time_seconds": 0.3218,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:11:57.904404+00:00",
+        "translate_date": "2026-01-15T16:56:59.969811+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.1069,
+        "translate_time_seconds": 1.1651,
         "output_file": "data/gamslib/mcp/chem_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:05.941691+00:00",
+        "solve_date": "2026-01-15T16:57:00.194015+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -793,7 +1031,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6102,
+        "solve_time_seconds": 0.2039,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -802,22 +1040,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:05.944182+00:00",
-        "nlp_objective": -47.7065,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:00.194090+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 2
       }
     },
     {
@@ -844,21 +1075,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:10.695899+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 4.53,
+        "parse_date": "2026-01-15T16:57:01.683334+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.4889,
         "variables_count": 15,
         "equations_count": 14
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:02.654551+00:00",
+        "translate_date": "2026-01-15T16:57:04.478206+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 4.7494,
+        "translate_time_seconds": 2.7924,
         "error": {
           "category": "unsup_dollar_cond",
           "message": "Error: Invalid model - Unknown expression type: DollarConditional\n"
         }
+      },
+      "model_statistics": {
+        "variables": 15,
+        "equations": 14,
+        "parameters": 0,
+        "sets": 4
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:04.481390+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:04.481390+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -885,13 +1131,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:10.800455+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.076,
+        "parse_date": "2026-01-15T16:57:04.528855+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0277,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 20, column 13: Unexpected character: '''\n  'e-rice'    'early rice',            'amm-water'  'ammonia water',\n              ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:04.531130+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:04.531130+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:04.531130+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -918,21 +1177,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:11.934338+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.134,
+        "parse_date": "2026-01-15T16:57:04.885892+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3546,
         "variables_count": 3,
         "equations_count": 1
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:04.689166+00:00",
+        "translate_date": "2026-01-15T16:57:05.993491+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.0333,
+        "translate_time_seconds": 1.1055,
         "error": {
           "category": "model_no_objective_def",
           "message": "Error: Invalid model - Objective variable 'r' is not defined by any equation. ObjectiveIR.expr is None and no defining equation found. Available equations: ['e']\n"
         }
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 1,
+        "parameters": 0,
+        "sets": 1
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:05.996584+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:05.996584+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -983,13 +1257,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:12.168352+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.234,
+        "parse_date": "2026-01-15T16:57:06.064067+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0672,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 42, column 50: Unexpected character: '('\n  tw(t,w)  'relates months to weather conditions' /(jan,feb).wet,\n                                                   ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:06.066129+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:06.066129+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:06.066129+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1016,21 +1303,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:12.914095+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.745,
+        "parse_date": "2026-01-15T16:57:06.290220+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2239,
         "variables_count": 3,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:06.589374+00:00",
+        "translate_date": "2026-01-15T16:57:07.325917+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.8626,
+        "translate_time_seconds": 1.0328,
         "error": {
           "category": "model_no_objective_def",
           "message": "Error: Invalid model - Objective variable 'r' is not defined by any equation. ObjectiveIR.expr is None and no defining equation found. Available equations: ['circumscribe', 'nooverlap']\n"
         }
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 2,
+        "parameters": 0,
+        "sets": 2
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:07.328952+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:07.328952+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -1057,13 +1359,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:13.367529+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.453,
+        "parse_date": "2026-01-15T16:57:07.471469+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1423,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:07.474201+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:07.474201+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:07.474201+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1090,13 +1405,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:13.584942+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.217,
+        "parse_date": "2026-01-15T16:57:07.540377+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.066,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 33, column 36: Unexpected character: '9'\n  a(i)   'availability'  / 'plant-1' 9, 'plant-2' 8 /\n                                     ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:07.542832+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:07.542832+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:07.542832+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1123,13 +1451,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:15.722854+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 2.138,
+        "parse_date": "2026-01-15T16:57:08.280497+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.7375,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 135, column 1: Unexpected character: '\"'\n  \"output  -- tons     \"\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:08.282373+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:08.282373+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:08.282373+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1180,13 +1521,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:15.890550+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.167,
+        "parse_date": "2026-01-15T16:57:08.316566+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0341,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 20, column 17: Unexpected character: '''\n  / 'agri-ka'     'agriculture - capital-labor substitution',\n                  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:08.318775+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:08.318775+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:08.318775+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1213,22 +1567,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-09T06:10:54.074872+00:00",
+        "parse_date": "2026-01-15T16:57:08.786049+00:00",
         "nlp2mcp_version": "0.1.0",
-        "parse_time_seconds": 1.227,
+        "parse_time_seconds": 0.4671,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:08.918974+00:00",
+        "translate_date": "2026-01-15T16:57:09.999578+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.3277,
+        "translate_time_seconds": 1.2109,
         "output_file": "data/gamslib/mcp/dispatch_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:06.383016+00:00",
+        "solve_date": "2026-01-15T16:57:10.187938+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -1236,7 +1590,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.43,
+        "solve_time_seconds": 0.181,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -1245,22 +1599,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:06.383112+00:00",
-        "nlp_objective": 7.9546,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:10.188016+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 5
       }
     },
     {
@@ -1308,13 +1655,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:24.610223+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 7.301,
+        "parse_date": "2026-01-15T16:57:12.512308+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 2.324,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 301, column 33: Unexpected character: '*'\n  a         = CC00/prod(j, Xp00(j)**alpha(j));\n                                  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:12.515179+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:12.515179+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:12.515179+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1341,13 +1701,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:25.108770+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.467,
+        "parse_date": "2026-01-15T16:57:12.619537+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0865,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 32, column 46: Unexpected character: '''\n  zr(z,r) 'map from zones to regions'  / upper.'u-egypt',\n                                               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:12.621303+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:12.621303+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:12.621303+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1374,13 +1747,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:25.282627+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.174,
+        "parse_date": "2026-01-15T16:57:12.660534+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0391,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:12.662139+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:12.662139+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:12.662139+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1473,21 +1859,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:32.683172+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 7.4,
+        "parse_date": "2026-01-15T16:57:14.817746+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 2.1553,
         "variables_count": 12,
         "equations_count": 13
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:17.016809+00:00",
+        "translate_date": "2026-01-15T16:57:18.918367+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 8.0966,
+        "translate_time_seconds": 4.0984,
         "error": {
           "category": "unsup_index_offset",
           "message": "Error: Unexpected error - IndexOffset not yet supported in this context: IndexOffset(base='t', offset=SymbolRef(+), circular=False)\n"
         }
+      },
+      "model_statistics": {
+        "variables": 12,
+        "equations": 13,
+        "parameters": 0,
+        "sets": 6
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:18.921373+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:18.921373+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -1514,13 +1915,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:32.829023+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.145,
+        "parse_date": "2026-01-15T16:57:18.946505+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0249,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 23, column 38: Unexpected character: '''\n  c       'commodities' / 'arabian-l'  'crude',\n                                       ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:18.948535+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:18.948535+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:18.948535+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1547,13 +1961,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:33.361383+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.532,
+        "parse_date": "2026-01-15T16:57:19.101628+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.153,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 66, column 1: Unexpected character: '2'\n  2*sum(k$[ord(k) < card(k)], h(k)*cosomega(i,k)) =l= t;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:19.103442+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:19.103442+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:19.103442+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1580,13 +2007,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:33.734060+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.372,
+        "parse_date": "2026-01-15T16:57:19.195769+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0922,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:19.197794+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:19.197794+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:19.197794+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1613,13 +2053,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:37.731977+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 3.998,
+        "parse_date": "2026-01-15T16:57:20.412666+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.2147,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 259, column 1: Unexpected character: '-'\n  -  v(i-1)*y(i-1,j) - (feed(i)*xf(j))$floc(i)    =e= 0;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:20.414809+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:20.414809+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:20.414809+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1646,13 +2099,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:37.927762+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.195,
+        "parse_date": "2026-01-15T16:57:20.453101+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0381,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 27, column 15: Unexpected character: '''\n  'kafr-el-sh'  'kare el-sheikh',\n                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:20.454759+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:20.454759+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:20.454759+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1702,13 +2168,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:38.051145+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.123,
+        "parse_date": "2026-01-15T16:57:20.484327+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0294,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 18, column 13: Unexpected character: '''\n  'cons-good' 'consumer goods sector',\n              ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:20.486124+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:20.486124+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:20.486124+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1735,13 +2214,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:38.282665+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.231,
+        "parse_date": "2026-01-15T16:57:20.542389+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0562,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 72, column 14: Unexpected character: '''\n  'cons-good'  'consumer goods sector',\n               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:20.544231+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:20.544231+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:20.544231+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1789,21 +2281,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:43.906943+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 5.588,
+        "parse_date": "2026-01-15T16:57:22.107536+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.5472,
         "variables_count": 7,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:21.535094+00:00",
+        "translate_date": "2026-01-15T16:57:24.435410+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 4.5161,
+        "translate_time_seconds": 2.3246,
         "error": {
           "category": "codegen_numerical_error",
           "message": "Error: Unexpected error - Error: Numerical error in parameter 'Ndata[Antwerpen,slo]': Invalid value (value is -Inf)\n\nSuggestion: Check your GAMS model or data file for:\n  - Uninitialized parameters\n  - Division by zero in parameter calculations\n  - Invalid mathematical operations\n  - Correct definition of parameter 'Ndata'\n"
         }
+      },
+      "model_statistics": {
+        "variables": 7,
+        "equations": 11,
+        "parameters": 0,
+        "sets": 7
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:24.438786+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:24.438786+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -1830,13 +2337,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:46.643599+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 2.736,
+        "parse_date": "2026-01-15T16:57:25.418206+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.9791,
         "error": {
           "category": "internal_error",
           "message": "Error: Circular dependency detected: 'v_dot' and 'vel' define each other\n\nSuggestion: Equations 'vy_dot_def' and 'vel_eqn' create a circular definition:\n  vy_dot_def: v_dot depends on vel\n  vel_eqn: vel depends on v_dot\n\nReformulate your model to break the cycle."
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:25.420334+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:25.420334+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:25.420334+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1884,13 +2404,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:50.462478+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 3.818,
+        "parse_date": "2026-01-15T16:57:26.651591+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.2311,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 157, column 1: Unexpected character: 'x'\n  x.up(i,j) = pc(i,j);\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:26.653326+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:26.653326+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:26.653326+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -1986,13 +2519,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:50.643661+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.181,
+        "parse_date": "2026-01-15T16:57:26.704736+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0513,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 21, column 38: Unexpected character: '/'\n  funds 'total investable funds' / 500 /;\n                                       ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:26.706532+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:26.706532+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:26.706532+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2019,13 +2565,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:53.361761+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 2.717,
+        "parse_date": "2026-01-15T16:57:27.662668+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.9558,
         "error": {
-          "category": "validation_error",
+          "category": "internal_error",
           "message": "Variable 't' expects 2 indices but received 1 [context: equation 'nbal' LHS] [domain: ('n',)] (line 88, column 38)"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:27.664611+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:27.664611+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:27.664611+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2052,13 +2611,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:54.111716+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.75,
+        "parse_date": "2026-01-15T16:57:27.870125+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2053,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 62, column 39: Unexpected character: '*'\n  objective..    obj    =e= prod(t, u(t)**ufact(t));\n                                        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:27.871888+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:27.871888+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:27.871888+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2085,13 +2657,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:53:54.459713+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.348,
+        "parse_date": "2026-01-15T16:57:27.978082+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1061,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 34, column 31: Unexpected character: '*'\n  obj..    UU   =e= prod(i, X(i)**alpha(i));\n                                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:27.979732+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:27.979732+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:27.979732+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2118,22 +2703,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:55.352476+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.892,
+        "parse_date": "2026-01-15T16:57:28.343298+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3634,
         "variables_count": 10,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:23.577959+00:00",
+        "translate_date": "2026-01-15T16:57:29.420056+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.0404,
+        "translate_time_seconds": 1.0746,
         "output_file": "data/gamslib/mcp/himmel11_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:06.825411+00:00",
+        "solve_date": "2026-01-15T16:57:29.601263+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2141,7 +2726,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4305,
+        "solve_time_seconds": 0.173,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -2150,22 +2735,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:06.825518+00:00",
-        "nlp_objective": -30665.5387,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:29.601336+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 10,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -2192,21 +2770,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:56.098275+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.746,
+        "parse_date": "2026-01-15T16:57:29.826205+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2246,
         "variables_count": 4,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:25.661524+00:00",
+        "translate_date": "2026-01-15T16:57:30.946046+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.058,
+        "translate_time_seconds": 1.1168,
         "error": {
           "category": "model_domain_mismatch",
           "message": "Error: Invalid model - Incompatible domains for summation: variable domain ('i',), multiplier domain ('i', 'j'). Multiplier domain must be either a subset of variable domain or completely disjoint.\n"
         }
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 4,
+        "parameters": 0,
+        "sets": 1
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:30.950306+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:30.950306+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -2233,22 +2826,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:56.736899+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.638,
+        "parse_date": "2026-01-15T16:57:31.192115+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2416,
         "variables_count": 9,
         "equations_count": 9
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:27.593853+00:00",
+        "translate_date": "2026-01-15T16:57:32.273375+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.9313,
+        "translate_time_seconds": 1.0784,
         "output_file": "data/gamslib/mcp/house_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:07.256890+00:00",
+        "solve_date": "2026-01-15T16:57:32.457131+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2256,7 +2849,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.422,
+        "solve_time_seconds": 0.1765,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -2265,22 +2858,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:07.256983+00:00",
-        "nlp_objective": 4500.0,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:32.457252+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 9,
+        "equations": 9,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -2307,22 +2893,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:57.416247+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.647,
+        "parse_date": "2026-01-15T16:57:32.668961+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1944,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:29.466948+00:00",
+        "translate_date": "2026-01-15T16:57:33.685993+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.872,
+        "translate_time_seconds": 1.0146,
         "output_file": "data/gamslib/mcp/hs62_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-01-14T17:59:08.194313+00:00",
+        "solve_date": "2026-01-15T16:57:34.034540+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -2330,13 +2916,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -26272.5145,
-        "solve_time_seconds": 0.9182,
+        "solve_time_seconds": 0.3371,
         "iterations": 27,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-01-14T17:59:08.194417+00:00",
+        "comparison_date": "2026-01-15T16:57:34.034651+00:00",
         "nlp_objective": -26272.5168,
         "mcp_objective": -26272.5145,
         "absolute_difference": 0.002300000000104774,
@@ -2351,6 +2937,12 @@
         "status_match": true,
         "comparison_result": "compare_objective_match",
         "notes": "Match within tolerance (diff=2.30e-03, tol=2.63e-02)"
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -2377,21 +2969,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:53:58.328351+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.912,
+        "parse_date": "2026-01-15T16:57:34.306199+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2713,
         "variables_count": 6,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:31.516653+00:00",
+        "translate_date": "2026-01-15T16:57:35.445331+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.0491,
+        "translate_time_seconds": 1.1364,
         "error": {
           "category": "diff_unsupported_func",
           "message": "Error: Invalid model - Differentiation not yet implemented for function 'card'. Supported functions: power, exp, log, sqrt, sin, cos, tan, abs, sqr. Note: abs() requires --smooth-abs flag (non-differentiable at x=0).\n"
         }
+      },
+      "model_statistics": {
+        "variables": 6,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 2
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:35.448875+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:35.448875+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -2418,13 +3025,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:00.602669+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 2.272,
+        "parse_date": "2026-01-15T16:57:36.134560+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.6854,
         "error": {
           "category": "internal_error",
           "message": "Invalid range start ''bin-1'': must be a number (e.g., 1) or identifier followed by number (e.g., i1) [context: expression] (line 14, column 40)"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:36.136383+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:36.136383+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:36.136383+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2475,13 +3095,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:01.091963+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.489,
+        "parse_date": "2026-01-15T16:57:36.361750+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2252,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 36, column 44: Unexpected character: ','\n  abort$[0 <> mod(k,1)] 'k should be integer', k;\n                                             ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:36.364204+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:36.364204+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:36.364204+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2508,13 +3141,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:01.387849+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.296,
+        "parse_date": "2026-01-15T16:57:36.405484+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.041,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 28, column 12: Unexpected character: '''\n  'sc-mill'  'sugar cane for mill',\n             ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:36.407463+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:36.407463+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:36.407463+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2562,13 +3208,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:01.869705+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.482,
+        "parse_date": "2026-01-15T16:57:36.548862+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1412,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 58, column 1: Unexpected character: 'o'\n  oldr(i)  = r(i);\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:36.550937+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:36.550937+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:36.550937+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2595,13 +3254,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:03.813634+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.944,
+        "parse_date": "2026-01-15T16:57:37.134576+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5835,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 88, column 1: Unexpected character: 'F'\n  FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.139606+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.139606+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.139606+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2628,13 +3300,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:03.944648+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.13,
+        "parse_date": "2026-01-15T16:57:37.166877+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0271,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 19, column 16: Unexpected character: '''\n  / 'feroz-b'    'ferozepur barrage                 - sutlej river',\n                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.168725+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.168725+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.168725+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2682,13 +3367,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:04.326166+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.381,
+        "parse_date": "2026-01-15T16:57:37.346748+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1779,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 39, column 6: Unexpected character: 'V'\n  Free Variable phi 'total cost ($)';\n       ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.352013+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.352013+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.352013+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2715,13 +3413,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:04.659803+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.333,
+        "parse_date": "2026-01-15T16:57:37.402961+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0508,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 25, column 58: Unexpected character: '2'\n  Parameter c(i) 'present cost of raw materials' / 'raw-1' 2, 'raw-2' 3 /;\n                                                           ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.404843+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.404843+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.404843+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2748,13 +3459,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:04.811793+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.119,
+        "parse_date": "2026-01-15T16:57:37.451617+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0295,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 21, column 39: Unexpected character: '''\n  hh    'household type'   / 'lab-hh'   'labor households',\n                                        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.453459+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.453459+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.453459+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2802,13 +3526,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:04.938653+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.127,
+        "parse_date": "2026-01-15T16:57:37.488598+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.035,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 30, column 36: Unexpected character: '1'\n  c(i) 'investment cost' / 'plant-1' 10, 'plant-2' 7, 'plant-3' 16, 'plant-4' 6 /\n                                     ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.490784+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.490784+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.490784+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2835,13 +3572,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:05.233987+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.295,
+        "parse_date": "2026-01-15T16:57:37.570862+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.08,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 37, column 43: Unexpected character: '.'\n  iwf(s)  'weight fraction'    /  'stage-1' .5, 'stage-2' .6, 'stage-3' .7           /\n                                            ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:37.572848+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:37.572848+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:37.572848+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -2868,22 +3618,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:05.889025+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.655,
+        "parse_date": "2026-01-15T16:57:37.735045+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.162,
         "variables_count": 5,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:33.410039+00:00",
+        "translate_date": "2026-01-15T16:57:38.721610+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.891,
+        "translate_time_seconds": 0.9845,
         "output_file": "data/gamslib/mcp/least_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:08.668064+00:00",
+        "solve_date": "2026-01-15T16:57:38.899775+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2891,7 +3641,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4298,
+        "solve_time_seconds": 0.1711,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -2900,22 +3650,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:08.668335+00:00",
-        "nlp_objective": 14085.1398,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:38.899848+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 5,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 1
       }
     },
     {
@@ -2942,21 +3685,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:07.212508+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.323,
+        "parse_date": "2026-01-15T16:57:39.231063+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.331,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:35.668760+00:00",
+        "translate_date": "2026-01-15T16:57:40.426901+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.231,
+        "translate_time_seconds": 1.1929,
         "error": {
           "category": "unsup_index_offset",
           "message": "Error: Unexpected error - IndexOffset not yet supported in this context: IndexOffset(base='g', offset=SymbolRef(+), circular=False)\n"
         }
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 2
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:40.430270+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:40.430270+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -3007,13 +3765,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:08.107943+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.895,
+        "parse_date": "2026-01-15T16:57:40.674516+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.244,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 88, column 9: Unexpected character: '='\n  f(p)    =  uniform(0,1);\n          ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:40.678874+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:40.678874+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:40.678874+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3064,13 +3835,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:09.100339+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.992,
+        "parse_date": "2026-01-15T16:57:40.975433+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2963,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:40.977498+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:40.977498+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:40.977498+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3097,13 +3881,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:10.053689+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.953,
+        "parse_date": "2026-01-15T16:57:41.297654+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.32,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 57, column 3: Unexpected character: '('\n  / (Ehv,Gn,Gvc,Hgl,Lls,Rsdg,Std)       5.0,\n    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:41.299448+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:41.299448+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:41.299448+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3130,13 +3927,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:11.875281+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.821,
+        "parse_date": "2026-01-15T16:57:41.834229+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5347,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 84, column 1: Unexpected character: 'F'\n  FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:41.836181+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:41.836181+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:41.836181+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3163,13 +3973,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:11.959683+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.084,
+        "parse_date": "2026-01-15T16:57:41.860684+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0244,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 21, column 15: Unexpected character: '''\n  'mid-c'       'mid continent crude',\n                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:41.863124+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:41.863124+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:41.863124+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3196,21 +4019,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:13.227603+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.099,
+        "parse_date": "2026-01-15T16:57:42.251295+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3721,
         "variables_count": 2,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:38.625692+00:00",
+        "translate_date": "2026-01-15T16:57:43.700832+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.9553,
+        "translate_time_seconds": 1.4475,
         "error": {
           "category": "diff_unsupported_func",
           "message": "Error: Invalid model - Differentiation not yet implemented for function 'ord'. Supported functions: power, exp, log, sqrt, sin, cos, tan, abs, sqr. Note: abs() requires --smooth-abs flag (non-differentiable at x=0).\n"
         }
+      },
+      "model_statistics": {
+        "variables": 2,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 2
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:43.703706+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:43.703706+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -3237,22 +4075,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:13.882658+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.655,
+        "parse_date": "2026-01-15T16:57:43.878829+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1749,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:40.706840+00:00",
+        "translate_date": "2026-01-15T16:57:44.840171+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.0799,
+        "translate_time_seconds": 0.9589,
         "output_file": "data/gamslib/mcp/mathopt1_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:09.103782+00:00",
+        "solve_date": "2026-01-15T16:57:45.017636+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3260,7 +4098,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4158,
+        "solve_time_seconds": 0.1703,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -3269,22 +4107,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:09.103868+00:00",
-        "nlp_objective": 1.0,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:45.017703+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -3311,22 +4142,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:14.334965+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.452,
+        "parse_date": "2026-01-15T16:57:45.171189+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1533,
         "variables_count": 3,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:42.579043+00:00",
+        "translate_date": "2026-01-15T16:57:46.103839+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.8711,
+        "translate_time_seconds": 0.9296,
         "output_file": "data/gamslib/mcp/mathopt2_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:09.528728+00:00",
+        "solve_date": "2026-01-15T16:57:46.285370+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3334,7 +4165,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4131,
+        "solve_time_seconds": 0.1739,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -3343,22 +4174,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:09.528849+00:00",
-        "nlp_objective": 0.0,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:46.285435+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -3385,13 +4209,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:14.546013+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.21,
+        "parse_date": "2026-01-15T16:57:46.357415+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0717,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 27, column 23: Unexpected character: '+'\n  +  10*sqr(sin[x5 - x6 + x1]);\n                        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:46.359369+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:46.359369+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:46.359369+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3418,13 +4255,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:15.418281+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.872,
+        "parse_date": "2026-01-15T16:57:46.680215+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3207,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 81, column 9: Unexpected character: 'g'\n  Acronym global;\n          ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:46.682778+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:46.682778+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:46.682778+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3472,21 +4322,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:16.610190+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.192,
+        "parse_date": "2026-01-15T16:57:47.067433+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3844,
         "variables_count": 3,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:45.002183+00:00",
+        "translate_date": "2026-01-15T16:57:48.287704+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.4214,
+        "translate_time_seconds": 1.2183,
         "error": {
           "category": "diff_unsupported_func",
           "message": "Error: Invalid model - Differentiation not yet implemented for function 'smin'. Supported functions: power, exp, log, sqrt, sin, cos, tan, abs, sqr. Note: abs() requires --smooth-abs flag (non-differentiable at x=0).\n"
         }
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 3
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:48.290901+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:48.290901+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -3513,13 +4378,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:17.868651+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.258,
+        "parse_date": "2026-01-15T16:57:48.809813+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5187,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 136, column 12: Unexpected character: 'm'\n  solve var1 maximize m using nlp;\n             ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:48.811751+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:48.811751+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:48.811751+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3567,13 +4445,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:18.079143+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.21,
+        "parse_date": "2026-01-15T16:57:48.879096+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0672,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 84, column 18: Unexpected character: '''\n  / 'p-colorada'   'pena colorada colima',\n                   ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:48.880918+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:48.880918+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:48.880918+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3600,13 +4491,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:18.196169+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.117,
+        "parse_date": "2026-01-15T16:57:48.959536+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0785,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 30, column 14: Unexpected character: '''\n  'nat-gas'    'natural gas - 1000 n cubic meters',\n               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:48.961639+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:48.961639+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:48.961639+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3633,22 +4537,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:18.776996+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.58,
+        "parse_date": "2026-01-15T16:57:49.147253+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1855,
         "variables_count": 6,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:46.862733+00:00",
+        "translate_date": "2026-01-15T16:57:50.175783+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.8289,
+        "translate_time_seconds": 1.0245,
         "output_file": "data/gamslib/mcp/mhw4d_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:09.969621+00:00",
+        "solve_date": "2026-01-15T16:57:50.363974+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3656,7 +4560,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4273,
+        "solve_time_seconds": 0.1816,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -3665,22 +4569,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:09.969710+00:00",
-        "nlp_objective": 27.8719,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:50.364040+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 6,
+        "equations": 4,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -3707,22 +4604,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:20.746017+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.942,
+        "parse_date": "2026-01-15T16:57:51.083891+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.7026,
         "variables_count": 6,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:49.837453+00:00",
+        "translate_date": "2026-01-15T16:57:52.636533+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.9735,
+        "translate_time_seconds": 1.5502,
         "output_file": "data/gamslib/mcp/mhw4dx_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:10.399281+00:00",
+        "solve_date": "2026-01-15T16:57:52.829855+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3730,7 +4627,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4192,
+        "solve_time_seconds": 0.1863,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -3739,22 +4636,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:10.399367+00:00",
-        "nlp_objective": 27.8719,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:52.829923+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 6,
+        "equations": 4,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -3802,13 +4692,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:20.940831+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.194,
+        "parse_date": "2026-01-15T16:57:52.900322+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0702,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 39, column 26: Unexpected character: '('\n  li(k)    'lead for i'  / (se,sw)   1 /\n                           ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:52.902404+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:52.902404+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:52.902404+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3835,21 +4738,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:21.645500+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.704,
+        "parse_date": "2026-01-15T16:57:53.151109+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2485,
         "variables_count": 4,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:51.748680+00:00",
+        "translate_date": "2026-01-15T16:57:54.231485+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.9105,
+        "translate_time_seconds": 1.0778,
         "error": {
           "category": "diff_unsupported_func",
           "message": "Error: Invalid model - Differentiation not yet implemented for function 'loggamma'. Supported functions: power, exp, log, sqrt, sin, cos, tan, abs, sqr. Note: abs() requires --smooth-abs flag (non-differentiable at x=0).\n"
         }
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 2,
+        "parameters": 0,
+        "sets": 0
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:54.234787+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:54.234787+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -3921,13 +4839,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:22.372358+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.726,
+        "parse_date": "2026-01-15T16:57:54.530923+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2959,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 74, column 19: Unexpected character: 'm'\n  solve m using nlp maximimizing like;\n                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:54.533462+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:54.533462+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:54.533462+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3954,13 +4885,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:22.890724+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.518,
+        "parse_date": "2026-01-15T16:57:54.697256+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1637,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 60, column 19: Unexpected character: 'm'\n  solve m using nlp maximimizing like;\n                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:54.699501+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:54.699501+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:54.699501+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -3987,13 +4931,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:24.595693+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.705,
+        "parse_date": "2026-01-15T16:57:55.368457+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.6688,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 97, column 1: Unexpected character: 'T'\n  Tm0, RT0, FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:55.370821+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:55.370821+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:55.370821+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4041,13 +4998,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:25.012619+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.417,
+        "parse_date": "2026-01-15T16:57:55.463878+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0928,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 23, column 37: Unexpected character: '''\n  f       'farm types' / 'fam-farm'   'family farms  10-30 ha',\n                                      ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:55.467012+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:55.467012+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:55.467012+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4074,13 +5044,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:25.493572+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.481,
+        "parse_date": "2026-01-15T16:57:55.626411+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1592,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 60, column 1: Parse error at line 60, column 1: Unexpected character: 'S'\n  Set\n  ^\n  Set\n  ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 59. Add ';' after: * original data"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:55.629715+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:55.629715+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:55.629715+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4128,13 +5111,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:26.600958+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.107,
+        "parse_date": "2026-01-15T16:57:56.073025+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4431,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 150, column 42: Unexpected character: '0'\n  cost(col)   'alpha coeff.' / 'col-1'     0.23947,   'col-2'  0.75835   /\n                                           ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:57:56.074870+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:57:56.074870+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:57:56.074870+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4161,21 +5157,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:31.504129+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 4.903,
+        "parse_date": "2026-01-15T16:57:57.788316+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.7132,
         "variables_count": 25,
         "equations_count": 19
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:12:56.654061+00:00",
+        "translate_date": "2026-01-15T16:58:00.435108+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 4.9037,
+        "translate_time_seconds": 2.6449,
         "error": {
           "category": "diff_unsupported_func",
           "message": "Error: Invalid model - Differentiation not yet implemented for function 'gamma'. Supported functions: power, exp, log, sqrt, sin, cos, tan, abs, sqr. Note: abs() requires --smooth-abs flag (non-differentiable at x=0).\n"
         }
+      },
+      "model_statistics": {
+        "variables": 25,
+        "equations": 19,
+        "parameters": 0,
+        "sets": 8
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:00.438415+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:00.438415+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -4202,13 +5213,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:33.188450+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.654,
+        "parse_date": "2026-01-15T16:58:01.004482+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5458,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 97, column 1: Unexpected character: 'p'\n  pdef(tt).. pd(tt) =e= sum(n, alpha(n)*p(tt-(ord(n) - 1)));\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:01.006255+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:01.006255+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:01.006255+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4235,13 +5259,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:33.985441+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.797,
+        "parse_date": "2026-01-15T16:58:01.264573+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2582,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 48, column 47: Unexpected character: '3'\n  k(j)    'capital output ratio' / 'non-traded' 3.0, traded 4.5 /\n                                                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:01.267462+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:01.267462+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:01.267462+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4268,13 +5305,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:35.005106+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.019,
+        "parse_date": "2026-01-15T16:58:01.616033+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3484,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 96, column 5: Unexpected character: '('\n  tdn.(kharif,rabi)         1550          1050       750\n      ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:01.618549+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:01.618549+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:01.618549+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4301,13 +5351,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:35.215968+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.211,
+        "parse_date": "2026-01-15T16:58:01.693877+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0752,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 39, column 1: Unexpected character: 'c'\n  chips )        40      55;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:01.695800+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:01.695800+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:01.695800+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4334,13 +5397,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:35.772349+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.556,
+        "parse_date": "2026-01-15T16:58:01.864734+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1688,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:01.867253+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:01.867253+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:01.867253+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4367,13 +5443,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:36.477646+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.705,
+        "parse_date": "2026-01-15T16:58:02.110183+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2428,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 71, column 30: Unexpected character: '('\n  revfac(m) 'revenue factor' / (january,february) 1,  (march,april) 1.1 /;\n                               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:02.112561+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:02.112561+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:02.112561+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4421,13 +5510,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:37.272149+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.794,
+        "parse_date": "2026-01-15T16:58:02.385057+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2723,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 71, column 1: Unexpected character: 'd'\n  display td.l, s.l, cs.l, d.l, r.l;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:02.386729+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:02.386729+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:02.386729+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4475,13 +5577,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:39.186403+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.914,
+        "parse_date": "2026-01-15T16:58:03.045397+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.6585,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 72, column 43: Unexpected character: '('\n  Parameter tau(i) / cod .153e6, so2 .12e6, (land, water) .25e6 /;\n                                            ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:03.047241+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:03.047241+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:03.047241+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4508,13 +5623,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:39.943771+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.757,
+        "parse_date": "2026-01-15T16:58:03.269685+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2223,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:03.271497+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:03.271497+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:03.271497+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4583,22 +5711,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:40.961447+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.017,
+        "parse_date": "2026-01-15T16:58:03.576457+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3048,
         "variables_count": 3,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:12:58.593954+00:00",
+        "translate_date": "2026-01-15T16:58:04.553481+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.9379,
+        "translate_time_seconds": 0.974,
         "output_file": "data/gamslib/mcp/port_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:10.849727+00:00",
+        "solve_date": "2026-01-15T16:58:04.724560+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -4606,7 +5734,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4091,
+        "solve_time_seconds": 0.1645,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -4615,22 +5743,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:10.849974+00:00",
-        "nlp_objective": 0.2984,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 1,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:04.724638+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 2
       }
     },
     {
@@ -4657,22 +5778,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:42.515915+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.527,
+        "parse_date": "2026-01-15T16:58:05.183689+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4428,
         "variables_count": 15,
         "equations_count": 12
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:01.155269+00:00",
+        "translate_date": "2026-01-15T16:58:06.534750+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.5352,
+        "translate_time_seconds": 1.3479,
         "output_file": "data/gamslib/mcp/process_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:11.302862+00:00",
+        "solve_date": "2026-01-15T16:58:06.717470+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -4680,7 +5801,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.443,
+        "solve_time_seconds": 0.1755,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -4689,22 +5810,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:11.302955+00:00",
-        "nlp_objective": 2410.8283,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:06.717535+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 15,
+        "equations": 12,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -4731,13 +5845,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:42.849074+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.333,
+        "parse_date": "2026-01-15T16:58:06.858341+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1406,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 46, column 7: Unexpected character: '{'\n  -  k1*{(delta + a)*betareg(y,alpha,beta)\n        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:06.860531+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:06.860531+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:06.860531+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4764,22 +5891,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:43.362503+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.513,
+        "parse_date": "2026-01-15T16:58:07.013578+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1529,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:02.899110+00:00",
+        "translate_date": "2026-01-15T16:58:07.975021+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.7424,
+        "translate_time_seconds": 0.9585,
         "output_file": "data/gamslib/mcp/prodmix_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-01-14T17:59:12.070894+00:00",
+        "solve_date": "2026-01-15T16:58:08.286781+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4787,13 +5914,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.0,
-        "solve_time_seconds": 0.7523,
+        "solve_time_seconds": 0.3022,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-01-14T17:59:12.070997+00:00",
+        "comparison_date": "2026-01-15T16:58:08.286941+00:00",
         "nlp_objective": 18666.6667,
         "mcp_objective": 0.0,
         "absolute_difference": 18666.6667,
@@ -4808,6 +5935,12 @@
         "status_match": true,
         "comparison_result": "compare_objective_mismatch",
         "notes": "Mismatch: diff=1.87e+04 > tolerance=1.87e-02"
+      },
+      "model_statistics": {
+        "variables": 2,
+        "equations": 2,
+        "parameters": 0,
+        "sets": 2
       }
     },
     {
@@ -4855,13 +5988,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:43.505716+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.143,
+        "parse_date": "2026-01-15T16:58:08.335454+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0481,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 32, column 31: Unexpected character: '1'\n  c(i)     'profit' / 'class-1' 12, 'class-2' 20, 'class-3' 18, 'class-4' 40 /\n                                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.338048+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.338048+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.338048+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4888,13 +6034,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:43.911876+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.406,
+        "parse_date": "2026-01-15T16:58:08.477562+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1394,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 55, column 63: Unexpected character: '1'\n  p0(i) 'initial prices'           / food  .5942, 'h-industry'  1.6167, 'l-industry'  1.31077 /\n                                                                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.479986+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.479986+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.479986+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4921,13 +6080,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:44.113469+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.201,
+        "parse_date": "2026-01-15T16:58:08.583069+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1029,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 29, column 18: Parse error at line 29, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 28. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.585075+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.585075+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.585075+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4954,13 +6126,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:44.703480+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.589,
+        "parse_date": "2026-01-15T16:58:08.768172+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.183,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 46, column 18: Parse error at line 46, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 45. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.770006+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.770006+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.770006+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -4987,13 +6172,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:44.838672+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.135,
+        "parse_date": "2026-01-15T16:58:08.817273+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0472,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.819152+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.819152+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.819152+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5020,13 +6218,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:44.942373+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.103,
+        "parse_date": "2026-01-15T16:58:08.851464+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0322,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 20, column 18: Parse error at line 20, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 19. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:08.853356+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:08.853356+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:08.853356+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5053,22 +6264,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:45.466299+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.523,
+        "parse_date": "2026-01-15T16:58:09.029675+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1762,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:04.731951+00:00",
+        "translate_date": "2026-01-15T16:58:10.042214+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.8309,
+        "translate_time_seconds": 1.0096,
         "output_file": "data/gamslib/mcp/ps2_f_inf_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:12.511542+00:00",
+        "solve_date": "2026-01-15T16:58:10.231970+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -5076,7 +6287,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4302,
+        "solve_time_seconds": 0.1825,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -5085,22 +6296,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:12.511661+00:00",
-        "nlp_objective": 0.8333,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.232035+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 1
       }
     },
     {
@@ -5127,13 +6331,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:45.644365+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.147,
+        "parse_date": "2026-01-15T16:58:10.322570+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0729,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.325352+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.325352+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.325352+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5160,13 +6377,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:45.787365+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.143,
+        "parse_date": "2026-01-15T16:58:10.373117+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0476,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.375434+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.375434+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.375434+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5193,13 +6423,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:46.036412+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.249,
+        "parse_date": "2026-01-15T16:58:10.422888+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0472,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.424682+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.424682+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.424682+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5226,13 +6469,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:46.210017+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.173,
+        "parse_date": "2026-01-15T16:58:10.466356+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0416,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.468125+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.468125+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.468125+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5259,13 +6515,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:46.368999+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.159,
+        "parse_date": "2026-01-15T16:58:10.510800+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0426,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.512636+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.512636+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.512636+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5292,13 +6561,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:46.574374+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.205,
+        "parse_date": "2026-01-15T16:58:10.567094+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0543,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.569557+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.569557+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.569557+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5325,13 +6607,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:46.825096+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.25,
+        "parse_date": "2026-01-15T16:58:10.611400+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0417,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 26, column 18: Parse error at line 26, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 25. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.613011+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.613011+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.613011+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5358,13 +6653,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:47.494364+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.669,
+        "parse_date": "2026-01-15T16:58:10.849764+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2366,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 46, column 18: Parse error at line 46, column 18: Unexpected character: ','\n  Positive Variable,\n                   ^\n  Positive Variable,\n                   ^\n\nSuggestion: This character is not valid in this context\n\nMissing semicolon at end of line 45. Add ';' after: * Definition of Primal/Dual Variables,"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:10.851805+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:10.851805+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:10.851805+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5391,13 +6699,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:48.083786+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.589,
+        "parse_date": "2026-01-15T16:58:11.005804+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1539,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 59, column 47: Unexpected character: '1'\n  uinit(m)    'initial controls' / 'gov-expend' 110.5, money   147.1 /\n                                                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:11.007565+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:11.007565+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:11.007565+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5469,13 +6790,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:51.189303+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 3.105,
+        "parse_date": "2026-01-15T16:58:12.163398+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 1.1557,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 191, column 1: Unexpected character: 'a'\n  acost,   dem,      proc,   amisc\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:12.165367+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:12.165367+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:12.165367+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5670,13 +7004,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:51.653886+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.432,
+        "parse_date": "2026-01-15T16:58:12.254323+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0726,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 32, column 41: Unexpected character: '('\n  tb(i)   'original totals'    / lab 220, (h1,h2) na, p1 190, p2 105 /\n                                          ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:12.256087+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:12.256087+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:12.256087+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5703,13 +7050,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:53.233533+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.579,
+        "parse_date": "2026-01-15T16:58:12.823648+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5674,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 86, column 1: Unexpected character: 'F'\n  FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:12.825668+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:12.825668+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:12.825668+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5736,21 +7096,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:54.311001+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.077,
+        "parse_date": "2026-01-15T16:58:13.287903+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.4621,
         "variables_count": 4,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:13:07.109086+00:00",
+        "translate_date": "2026-01-15T16:58:14.519721+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.3755,
+        "translate_time_seconds": 1.23,
         "error": {
           "category": "unsup_index_offset",
           "message": "Error: Unexpected error - IndexOffset not yet supported in this context: IndexOffset(base='t', offset=SymbolRef(+), circular=False)\n"
         }
+      },
+      "model_statistics": {
+        "variables": 4,
+        "equations": 4,
+        "parameters": 0,
+        "sets": 3
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:14.522365+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:14.522365+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -5777,22 +7152,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:54.733284+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.422,
+        "parse_date": "2026-01-15T16:58:14.603752+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0812,
         "variables_count": 3,
         "equations_count": 1
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:08.733862+00:00",
+        "translate_date": "2026-01-15T16:58:15.501911+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.623,
+        "translate_time_seconds": 0.8959,
         "output_file": "data/gamslib/mcp/rbrock_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:12.945983+00:00",
+        "solve_date": "2026-01-15T16:58:15.687496+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -5800,7 +7175,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4204,
+        "solve_time_seconds": 0.1785,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -5809,22 +7184,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:12.946073+00:00",
-        "nlp_objective": 0.0,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:15.687570+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 1,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -5851,21 +7219,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:55.519677+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.786,
+        "parse_date": "2026-01-15T16:58:15.910707+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2229,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:13:10.641983+00:00",
+        "translate_date": "2026-01-15T16:58:17.047646+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.883,
+        "translate_time_seconds": 1.1339,
         "error": {
           "category": "model_domain_mismatch",
           "message": "Error: Invalid model - Incompatible domains for summation: variable domain ('p', 'tt'), multiplier domain ('r', 'tt'). Multiplier domain must be either a subset of variable domain or completely disjoint.\n"
         }
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 3,
+        "parameters": 0,
+        "sets": 4
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:17.051527+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:17.051527+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -5892,13 +7275,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:55.766735+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.246,
+        "parse_date": "2026-01-15T16:58:17.124863+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0731,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:17.127058+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:17.127058+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:17.127058+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5925,13 +7321,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:56.351954+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.585,
+        "parse_date": "2026-01-15T16:58:17.330833+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2036,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 71, column 19: Unexpected character: ','\n  Equation lpcons(i), defdual(j);\n                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:17.334633+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:17.334633+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:17.334633+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5958,13 +7367,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:58.019900+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.667,
+        "parse_date": "2026-01-15T16:58:17.889123+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5543,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:17.890794+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:17.890794+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:17.890794+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -5991,13 +7413,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:58.339712+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.319,
+        "parse_date": "2026-01-15T16:58:17.962696+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0718,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 30, column 40: Unexpected character: '('\n  tb(i)   'original totals'   / lab 220, (h1,h2) na, p1 190, p2 105 /\n                                         ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:17.964523+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:17.964523+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:17.964523+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6024,22 +7459,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:54:59.267258+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.927,
+        "parse_date": "2026-01-15T16:58:18.307271+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3426,
         "variables_count": 3,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:12.673790+00:00",
+        "translate_date": "2026-01-15T16:58:19.576997+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 2.0297,
+        "translate_time_seconds": 1.2672,
         "output_file": "data/gamslib/mcp/sample_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-01-14T17:59:13.404486+00:00",
+        "solve_date": "2026-01-15T16:58:19.778614+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -6047,7 +7482,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4147,
+        "solve_time_seconds": 0.1936,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -6056,22 +7491,15 @@
         }
       },
       "solution_comparison": {
-        "comparison_status": "skipped",
-        "comparison_date": "2026-01-14T17:59:13.404583+00:00",
-        "nlp_objective": 726.6794,
-        "mcp_objective": null,
-        "absolute_difference": null,
-        "relative_difference": null,
-        "objective_match": null,
-        "tolerance_absolute": 1e-08,
-        "tolerance_relative": 1e-06,
-        "nlp_solver_status": 1,
-        "nlp_model_status": 2,
-        "mcp_solver_status": null,
-        "mcp_model_status": null,
-        "status_match": null,
-        "comparison_result": "compare_mcp_failed",
-        "notes": "MCP solve status: failure"
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:19.778695+00:00",
+        "notes": "Skipped due to solve failure"
+      },
+      "model_statistics": {
+        "variables": 3,
+        "equations": 4,
+        "parameters": 0,
+        "sets": 2
       }
     },
     {
@@ -6098,13 +7526,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:59.631715+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.334,
+        "parse_date": "2026-01-15T16:58:19.979495+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1823,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 111, column 1: Unexpected character: '/'\n  /\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:19.981594+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:19.981594+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:19.981594+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6131,13 +7572,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:54:59.813674+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.181,
+        "parse_date": "2026-01-15T16:58:20.033730+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0519,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 33, column 16: Unexpected character: '''\n  'beet-lift'    'ing',\n                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.035700+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.035700+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.035700+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6206,13 +7660,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:00.094372+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.28,
+        "parse_date": "2026-01-15T16:58:20.080998+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0452,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 30, column 16: Unexpected character: '3'\n  / 'new-york'   325,\n                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.083387+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.083387+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.083387+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6239,13 +7706,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:00.205906+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.111,
+        "parse_date": "2026-01-15T16:58:20.119426+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0359,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 25, column 15: Unexpected character: '''\n  'shale-25'    'shale in place assaying 25 gallons per ton - gpt (mil tons)',\n                ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.121534+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.121534+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.121534+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6272,13 +7752,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:00.329901+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.124,
+        "parse_date": "2026-01-15T16:58:20.156095+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0344,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 23, column 50: Unexpected character: 'n'\n  ca       'corrosion allowance            (cm)' / na    /\n                                                   ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.157943+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.157943+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.157943+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6326,13 +7819,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:00.505764+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.175,
+        "parse_date": "2026-01-15T16:58:20.202813+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0448,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 38, column 23: Unexpected character: ','\n  Equation defobj, e1(i), e2(i), e3(i);\n                        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.204596+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.204596+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.204596+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6359,13 +7865,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:00.855409+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.349,
+        "parse_date": "2026-01-15T16:58:20.316021+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1113,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 39, column 39: Unexpected character: '5'\n  clen(l) 'cost of service'   / 'len-1' 50, 'len-2' 85, 'len-3' 115, 'len-4' 143 /;\n                                        ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.318819+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.318819+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.318819+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6392,13 +7911,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:02.466448+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.611,
+        "parse_date": "2026-01-15T16:58:20.924500+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.6055,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 155, column 35: Unexpected character: '.'\n  P2R3_MCP        / DEM, SUP, IN_OUT.P, DOM_TRAD.X /;\n                                    ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:20.926701+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:20.926701+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:20.926701+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6488,13 +8020,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:03.151340+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.685,
+        "parse_date": "2026-01-15T16:58:21.136827+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.21,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 52, column 34: Unexpected character: '*'\n  b(j)      = Z0(j)/prod(h, F0(h,j)**beta(h,j));\n                                   ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:21.138819+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:21.138819+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:21.138819+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6521,13 +8066,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:03.288417+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.136,
+        "parse_date": "2026-01-15T16:58:21.186260+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0473,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 31, column 43: Unexpected character: '['\n  L0    \"rest length of each spring\"     /  [2*sqrt(sqr(a_x-b_x) + sqr(a_y-b_y))/10]/\n                                            ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:21.188187+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:21.188187+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:21.188187+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6578,13 +8136,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:03.888684+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.561,
+        "parse_date": "2026-01-15T16:58:21.441892+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2353,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 56, column 41: Unexpected character: '.'\n  tn(t,n)   'time node mapping' / 'time-1'.('n-1'*'n-3'), 'time-2'.('n-4'*'n-12')      /\n                                          ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:21.443698+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:21.443698+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:21.443698+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6611,13 +8182,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:03.958408+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.069,
+        "parse_date": "2026-01-15T16:58:21.459926+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0161,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 15, column 69: Unexpected character: ','\n  i      'cities' / boston, chicago, dallas, 'kansas-cty', losangeles,,\n                                                                      ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:21.461940+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:21.461940+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:21.461940+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6644,13 +8228,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:04.160613+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.202,
+        "parse_date": "2026-01-15T16:58:21.518794+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0567,
         "error": {
-          "category": "syntax_error",
+          "category": "internal_error",
           "message": "Error: Model has no objective function defined\n\nSuggestion: Add an objective definition to your GAMS model:\n  Variables z;\n  Equations obj_def;\n  obj_def.. z =e= <expression>;\n  Model mymodel / all /;\n  Solve mymodel using NLP minimizing z;"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:21.520516+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:21.520516+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:21.520516+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6677,13 +8274,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:05.857609+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.697,
+        "parse_date": "2026-01-15T16:58:22.037731+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5171,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 84, column 1: Unexpected character: 'F'\n  FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:22.039798+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:22.039798+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:22.039798+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6731,13 +8341,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:07.131378+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.273,
+        "parse_date": "2026-01-15T16:58:22.551585+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.5116,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 64, column 54: Unexpected character: '('\n  yv(a)    'yield of planted timber     (m3 per ha)' / (a08,a16,a24) 120 /\n                                                       ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:22.553603+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:22.553603+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:22.553603+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6764,13 +8387,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:07.620500+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.489,
+        "parse_date": "2026-01-15T16:58:22.702336+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1486,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 37, column 30: Unexpected character: '2'\n  ('a-10','a-20','a-30')      .2      .2\n                               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:22.704224+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:22.704224+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:22.704224+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6797,13 +8433,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:08.520974+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.9,
+        "parse_date": "2026-01-15T16:58:23.056839+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3525,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 70, column 48: Unexpected character: '('\n  pc(p)   'process cost     (us$ per m3 input)' /('pulp-pl','pulp-sl','pulp-rs') 5.96, sawing 6 /\n                                                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:23.058770+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:23.058770+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:23.058770+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6872,13 +8521,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:08.966543+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.445,
+        "parse_date": "2026-01-15T16:58:23.199848+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1409,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 73, column 36: Unexpected character: ','\n  x.up(n,k)         = myScale*smax((i,kp),fx(i,kp));\n                                     ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:23.201876+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:23.201876+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:23.201876+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -6905,22 +8567,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:55:09.362828+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.396,
+        "parse_date": "2026-01-15T16:58:23.323445+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1214,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-01-14T03:13:14.293816+00:00",
+        "translate_date": "2026-01-15T16:58:24.346189+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.618,
+        "translate_time_seconds": 1.02,
         "output_file": "data/gamslib/mcp/trig_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-01-14T17:59:14.291870+00:00",
+        "solve_date": "2026-01-15T16:58:24.736359+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6928,13 +8590,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -2.479,
-        "solve_time_seconds": 0.8704,
+        "solve_time_seconds": 0.3815,
         "iterations": 88,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-01-14T17:59:14.291990+00:00",
+        "comparison_date": "2026-01-15T16:58:24.736458+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": -2.479,
         "absolute_difference": 2.479,
@@ -6949,6 +8611,12 @@
         "status_match": true,
         "comparison_result": "compare_objective_mismatch",
         "notes": "Mismatch: diff=2.48e+00 > tolerance=2.49e-06"
+      },
+      "model_statistics": {
+        "variables": 2,
+        "equations": 2,
+        "parameters": 0,
+        "sets": 0
       }
     },
     {
@@ -7020,16 +8688,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:09.546483+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.182,
+        "parse_date": "2026-01-15T16:58:24.790128+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0534,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 31, column 16: Unexpected character: '3'\n  / 'new-york'   325,\n                 ^\n\nSuggestion: This character is not valid in this context"
         }
       },
       "mcp_solve": {
-        "status": "not_tested"
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:24.792452+00:00"
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:24.792452+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:24.792452+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7056,13 +8734,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:10.002225+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.39,
+        "parse_date": "2026-01-15T16:58:24.922460+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1102,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 76, column 16: Unexpected character: '3'\n  / 'new-york'   325,\n                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:24.925632+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:24.925632+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:24.925632+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7110,21 +8801,36 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-01-02T16:55:11.291729+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.289,
+        "parse_date": "2026-01-15T16:58:25.245687+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3198,
         "variables_count": 5,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-01-14T03:13:16.267152+00:00",
+        "translate_date": "2026-01-15T16:58:26.505400+00:00",
         "nlp2mcp_version": "0.1.0",
-        "translate_time_seconds": 1.9726,
+        "translate_time_seconds": 1.2578,
         "error": {
           "category": "model_no_objective_def",
           "message": "Error: Invalid model - Objective variable 'tau' is not defined by any equation. ObjectiveIR.expr is None and no defining equation found. Available equations: ['volumeeq', 'deftk', 'reseq', 'trusscomp', 'stiffness']\n"
         }
+      },
+      "model_statistics": {
+        "variables": 5,
+        "equations": 5,
+        "parameters": 0,
+        "sets": 3
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:26.508304+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:26.508304+00:00",
+        "notes": "Skipped due to translate failure"
       }
     },
     {
@@ -7151,13 +8857,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:11.995319+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.703,
+        "parse_date": "2026-01-15T16:58:26.794045+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.2855,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 55, column 14: Unexpected character: '''\n  / 'irr-good' 'irrigated good land', 'irr-poor' 'irrigated poor land',\n               ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:26.796704+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:26.796704+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:26.796704+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7184,13 +8903,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:12.512773+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.517,
+        "parse_date": "2026-01-15T16:58:26.908739+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.1119,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 35, column 13: Unexpected character: '''\n  'e-fact'    'energy factor for hydro plants',\n              ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:26.911031+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:26.911031+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:26.911031+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7217,13 +8949,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:14.464684+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 1.952,
+        "parse_date": "2026-01-15T16:58:27.573896+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.6626,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 117, column 1: Unexpected character: 'F'\n  FF, Sf, tauz, taum;\n  ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:27.575989+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:27.575989+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:27.575989+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7250,13 +8995,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:15.370570+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.906,
+        "parse_date": "2026-01-15T16:58:27.925776+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.3496,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 77, column 27: Unexpected character: '('\n  s(k) 'storage cost'     / (nuts,bolts,washers) 1  /\n                            ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:27.928346+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:27.928346+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:27.928346+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7283,13 +9041,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:15.450910+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.08,
+        "parse_date": "2026-01-15T16:58:27.950926+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0222,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 19, column 13: Parse error at line 19, column 13: Unexpected character: 'V'\n  Nonnegative Variables so4, baoh, oh, hso4, h;\n              ^\n  Nonnegative Variables so4, baoh, oh, hso4, h;\n              ^\n\nSuggestion: This character is not valid in this context\n\nDid you mean 'Negative'?"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:27.952839+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:27.952839+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:27.952839+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7316,13 +9087,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:15.512432+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.061,
+        "parse_date": "2026-01-15T16:58:27.972436+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0195,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 18, column 13: Unexpected character: '''\n  'MRBM-1'    'Medium-Range Ballistic Missiles from first area',\n              ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:27.974570+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:27.974570+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:27.974570+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7349,13 +9133,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:15.602647+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.09,
+        "parse_date": "2026-01-15T16:58:28.004355+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0296,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 18, column 48: Unexpected character: '1'\n  price(t)  'selling price ($ per unit)' / 'q-1' 10, 'q-2' 12, 'q-3' 8, 'q-4' 9 /\n                                                 ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:28.006443+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:28.006443+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:28.006443+00:00",
+        "notes": "Skipped due to parse failure"
       }
     },
     {
@@ -7382,13 +9179,26 @@
       },
       "nlp2mcp_parse": {
         "status": "failure",
-        "parse_date": "2026-01-02T16:55:15.880090+00:00",
-        "nlp2mcp_version": "0.7.0",
-        "parse_time_seconds": 0.277,
+        "parse_date": "2026-01-15T16:58:28.103732+00:00",
+        "nlp2mcp_version": "0.1.0",
+        "parse_time_seconds": 0.0972,
         "error": {
-          "category": "syntax_error",
+          "category": "lexer_invalid_char",
           "message": "Error: Parse error at line 41, column 10: Unexpected character: 'f'\n  Acronym  future, call, puto;\n           ^\n\nSuggestion: This character is not valid in this context"
         }
+      },
+      "nlp2mcp_translate": {
+        "status": "not_tested",
+        "translate_date": "2026-01-15T16:58:28.105766+00:00"
+      },
+      "mcp_solve": {
+        "status": "not_tested",
+        "solve_date": "2026-01-15T16:58:28.105766+00:00"
+      },
+      "solution_comparison": {
+        "comparison_status": "not_tested",
+        "comparison_date": "2026-01-15T16:58:28.105766+00:00",
+        "notes": "Skipped due to parse failure"
       }
     }
   ],

--- a/data/gamslib/mcp/port_mcp.gms
+++ b/data/gamslib/mcp/port_mcp.gms
@@ -21,7 +21,7 @@ Sets
 ;
 
 Parameters
-    ydat(b,*) /'municip-a'.maturity 2.0, 'municip-a'.yield 9.0, 'municip-b'.maturity 5.0, 'municip-b'.yield 2.0, corporate.maturity 2.0, corporate.yield 15.0, 'us-ser-e'.maturity 1.0, 'us-ser-e'.yield 4.0, 'us-ser-f'.maturity 1.0, 'us-ser-f'.yield 3.0, corporate.rating 0.0, 'municip-b'.rating 0.0, 'municip-a'.rating 0.0, 'us-ser-f'.rating 0.0, 'us-ser-e'.rating 0.0/
+    ydat(b,*) /'municip-a'.maturity 2.0, 'municip-a'.yield 9.0, 'municip-b'.maturity 5.0, 'municip-b'.yield 2.0, corporate.maturity 2.0, corporate.yield 15.0, 'us-ser-e'.maturity 1.0, 'us-ser-e'.yield 4.0, 'us-ser-f'.maturity 1.0, 'us-ser-f'.yield 3.0, 'municip-a'.rating 0.0, 'us-ser-f'.rating 0.0, corporate.rating 0.0, 'municip-b'.rating 0.0, 'us-ser-e'.rating 0.0/
 ;
 
 * ============================================

--- a/docs/planning/EPIC_3/SPRINT_15/PLAN.md
+++ b/docs/planning/EPIC_3/SPRINT_15/PLAN.md
@@ -313,15 +313,15 @@ Sprint 15 builds on the JSON database infrastructure from Sprint 14 (219 models,
 - Summary statistics
 
 **Acceptance Criteria:**
-- [ ] Full pipeline runs on all 160 verified/likely_convex models
-- [ ] Summary shows parse/translate/solve/compare stats
-- [ ] --dry-run previews filter results
-- [ ] --verbose shows detailed progress
-- [ ] --json outputs machine-readable results
+- [x] Full pipeline runs on all 160 verified/likely_convex models
+- [x] Summary shows parse/translate/solve/compare stats
+- [x] --dry-run previews filter results
+- [x] --verbose shows detailed progress
+- [x] --json outputs machine-readable results
 
 **Time Estimate:** 6 hours
 
-**Checkpoint 4 (End of Day 9):** Full pipeline operational with filtering
+**Checkpoint 4 (End of Day 9):** ✅ COMPLETE - Full pipeline operational with filtering
 
 ---
 

--- a/docs/planning/EPIC_3/SPRINT_15/SPRINT_LOG.md
+++ b/docs/planning/EPIC_3/SPRINT_15/SPRINT_LOG.md
@@ -26,8 +26,8 @@
 |------------|-----|--------|------|
 | CP1: Schema migrated | 2 | ✅ Complete | 2026-01-13 |
 | CP2: Enhanced testing | 4 | ✅ Complete | 2026-01-13 |
-| CP3: Solve testing | 7 | Pending | - |
-| CP4: Pipeline complete | 9 | Pending | - |
+| CP3: Solve testing | 7 | ✅ Complete | 2026-01-14 |
+| CP4: Pipeline complete | 9 | ✅ Complete | 2026-01-15 |
 | CP5: Baseline recorded | 10 | Pending | - |
 
 ---
@@ -768,5 +768,99 @@ Average time per model: 2.21s
 - [x] Cascade failures mark downstream stages correctly
 
 **Next Steps:** Day 9 - Pipeline Integration and Summary
+
+---
+
+### Day 9: Pipeline Integration and Summary [Checkpoint 4]
+
+**Date:** January 15, 2026
+
+**Objective:** Complete pipeline runner with summary statistics and run full pipeline on all models
+
+**Tasks Completed:**
+
+1. **Added summary generation with timing statistics** (1.5h)
+   - Created `compute_timing_stats()` function with mean, median, stddev, min, max, p90, p99
+   - Created `generate_summary()` function returning structured dictionary
+   - Enhanced statistics collection: parse_times, translate_times, solve_times
+   - Enhanced error tracking: parse_errors, translate_errors, solve_errors
+
+2. **Added JSON output format** (1h)
+   - Added `--json` CLI flag for machine-readable output
+   - Created `print_json_summary()` function
+   - JSON includes full timing stats, error breakdowns, success rates
+   - JSON mode implies quiet mode (no progress logging)
+
+3. **Enhanced --dry-run mode** (0.5h)
+   - Shows count of models by type (NLP, LP, QCP)
+   - Shows pipeline stages that would run
+   - Lists models when verbose or <=20 models
+   - Supports JSON output for dry-run
+
+4. **Ran full pipeline on all 160 models** (2h)
+   - Command: `python scripts/gamslib/run_full_test.py --verbose`
+   - Processed all 160 verified_convex + likely_convex models
+   - Results stored in database
+
+**Quality Checks:**
+- `make typecheck`: PASSED
+- `make lint`: PASSED
+- `make format`: Applied
+- `make test`: 2853 passed, 10 skipped, 1 xfailed
+
+**Full Pipeline Results (160 models):**
+
+| Stage | Attempted | Success | Failure | Rate |
+|-------|-----------|---------|---------|------|
+| Parse | 160 | 34 | 126 | 21.3% |
+| Translate | 34 | 17 | 17 | 50.0% |
+| Solve | 17 | 3 | 14 | 17.6% |
+| Compare | 3 | 1 match | 2 mismatch | 33.3% |
+
+**Full Pipeline Success:** 1/160 (0.6%) - hs62
+
+**Timing Statistics:**
+
+| Stage | Mean | Median | P90 | Max |
+|-------|------|--------|-----|-----|
+| Parse | 0.30s | 0.17s | 0.66s | 2.32s |
+| Translate | 1.35s | 1.14s | 2.09s | 4.10s |
+| Solve | 0.21s | 0.18s | 0.32s | 0.38s |
+
+**Error Breakdown:**
+
+Parse Errors (126):
+- lexer_invalid_char: 109
+- internal_error: 17
+
+Translate Errors (17):
+- model_no_objective_def: 5
+- diff_unsupported_func: 5
+- unsup_index_offset: 3
+- model_domain_mismatch: 2
+- unsup_dollar_cond: 1
+- codegen_numerical_error: 1
+
+Solve Errors (14):
+- path_syntax_error: 14
+
+**Deliverables:**
+- [x] Summary generation with per-stage timing stats
+- [x] JSON output format (`--json` flag)
+- [x] Enhanced dry-run mode with type breakdown
+- [x] Full pipeline run on 160 models
+- [x] Baseline metrics recorded
+
+**Checkpoint 4 Status:** ✅ COMPLETE
+
+- [x] Full pipeline runs on all 160 models
+- [x] Summary shows parse/translate/solve/compare stats
+- [x] `--dry-run` previews filter results
+- [x] `--verbose` shows detailed progress
+- [x] `--json` outputs machine-readable results
+- [x] Filters work with AND logic
+- [x] Cascade handling correct
+
+**Next Steps:** Day 10 - Baseline Recording and Documentation
 
 ---


### PR DESCRIPTION
## Summary

Completes `run_full_test.py` with comprehensive summary generation, JSON output format, and enhanced dry-run mode. Ran full pipeline on all 160 models to establish baseline metrics.

## Changes

### Summary Generation
- `compute_timing_stats()` - Calculates mean, median, stddev, min, max, p90, p99
- `generate_summary()` - Produces structured dictionary for reporting
- Per-stage timing and error tracking
- Error category breakdown per stage

### Output Formats
- `--json` flag for machine-readable JSON output
- JSON includes full timing stats, error breakdowns, success rates
- JSON mode implies quiet mode (no progress logging)

### Enhanced Dry-Run
- Shows models by type (NLP: 94, LP: 57, QCP: 9)
- Shows pipeline stages that would run
- Lists models when verbose or <=20 models

## Full Pipeline Results (160 models)

| Stage | Attempted | Success | Failure | Rate |
|-------|-----------|---------|---------|------|
| Parse | 160 | 34 | 126 | 21.3% |
| Translate | 34 | 17 | 17 | 50.0% |
| Solve | 17 | 3 | 14 | 17.6% |
| Compare | 3 | 1 match | 2 mismatch | 33.3% |

**Full Pipeline Success:** 1/160 (0.6%) - hs62

## Timing Statistics

| Stage | Mean | Median | P90 | Max |
|-------|------|--------|-----|-----|
| Parse | 0.30s | 0.17s | 0.66s | 2.32s |
| Translate | 1.35s | 1.14s | 2.09s | 4.10s |
| Solve | 0.21s | 0.18s | 0.32s | 0.38s |

## Checkpoint 4 Criteria

- [x] Full pipeline runs on all 160 verified/likely_convex models
- [x] Summary shows parse/translate/solve/compare stats
- [x] `--dry-run` previews filter results
- [x] `--verbose` shows detailed progress
- [x] `--json` outputs machine-readable results
- [x] Filters work with AND logic
- [x] Cascade handling correct

## Quality Checks

- `make typecheck`: PASSED
- `make lint`: PASSED
- `make format`: Applied
- `make test`: 2853 passed, 10 skipped, 1 xfailed