### PR TITLE
docs: Move issue #623 to completed (already fixed by PR #628)

### DIFF
--- a/docs/issues/completed/emit-missing-mcp-pairing-cpack.md
+++ b/docs/issues/completed/emit-missing-mcp-pairing-cpack.md
@@ -1,6 +1,6 @@
 # Emit: Missing stat_r.r Pairing in MCP Model Declaration (cpack.gms)
 
-**Status:** Open  
+**Status:** Completed  
 **Priority:** High  
 **Affects:** cpack.gms (circle packing from GAMSLIB)  
 **GitHub Issue:** [#623](https://github.com/jeffreyhorn/nlp2mcp/issues/623)


### PR DESCRIPTION
## Summary

Closes #623. Moves the issue doc to the completed folder.

This issue (missing `stat_r.r` pairing in cpack.gms) shared the same root cause as Issue #624 (circle.gms) and was already fixed by the code change in PR #628. This PR just moves the issue documentation to completed.

No code changes — doc-only.