### PR TITLE
Fix solve extraction from doubly-nested loops (#810)

### DIFF
--- a/docs/issues/completed/ISSUE_810_lmp2-solve-doubly-nested-loop.md
+++ b/docs/issues/completed/ISSUE_810_lmp2-solve-doubly-nested-loop.md
@@ -83,3 +83,16 @@ Medium — affects 3 GAMSlib models (lmp1, lmp2, lmp3). The `model_no_objective_
 
 ## Sprint Context
 Discovered during Sprint 20 Day 5 while fixing the `$if set workSpace` inline guard preprocessor bug. The inline `$if` fix reduced `model_no_objective_def` from 14 to 4, but lmp1/lmp2/lmp3 require a different fix (nested loop extraction). Deferred to Sprint 21.
+
+## Resolution
+
+**Status:** FIXED
+
+**Approach:** Option 1 — Recursive extraction (as proposed).
+
+**Changes:**
+- `src/ir/parser.py`: Added `_find_solve_in_loop_body()` static method that recursively searches loop body statements for a `solve` node at any nesting depth. Recognizes all 6 loop statement variants (`loop_stmt`, `loop_stmt_paren`, `loop_stmt_filtered`, `loop_stmt_paren_filtered`, `loop_stmt_indexed`, `loop_stmt_indexed_filtered`) and recurses into their `loop_body` children.
+- `src/ir/parser.py`: Updated `_handle_loop_stmt` to call `_find_solve_in_loop_body()` instead of the previous flat scan of `body_stmts`.
+- `tests/unit/test_issue_810_nested_loop_solve.py`: 6 unit tests — doubly-nested, triply-nested, single-nested regression, top-level regression, parse check, and maximizing sense check.
+
+**Verified:** lmp1, lmp2, lmp3 all correctly extract objective from nested loops. `model_no_objective_def` reduced from 4 to 1 (only mhw4dxx remains, which has a different root cause — parse error).

--- a/tests/unit/test_issue_810_nested_loop_solve.py
+++ b/tests/unit/test_issue_810_nested_loop_solve.py
@@ -1,0 +1,122 @@
+"""Unit tests for Issue #810: solve inside doubly-nested loop."""
+
+import pytest
+
+from src.ir.parser import parse_model_text, parse_text
+
+pytestmark = pytest.mark.unit
+
+
+class TestNestedLoopSolveExtraction:
+    """Test solve extraction from doubly (and deeper) nested loops."""
+
+    def test_doubly_nested_loop_solve(self):
+        """solve inside loop(c, loop(i, solve ...)) should extract objective."""
+        source = """
+        Sets c / c1*c3 /, i / i1*i5 /;
+        Variables obj, x(i);
+        Equations defobj;
+        defobj.. obj =e= sum(i, x(i));
+        Model lmp2 / all /;
+
+        loop(c,
+           loop(i,
+              solve lmp2 minimizing obj using nlp;
+           );
+        );
+        """
+        ir = parse_model_text(source)
+        assert ir.objective is not None
+        assert ir.objective.objvar == "obj"
+        assert ir.model_name == "lmp2"
+
+    def test_triply_nested_loop_solve(self):
+        """solve inside three levels of nesting should extract objective."""
+        source = """
+        Sets a / a1 /, b / b1 /, c / c1 /;
+        Variables obj, x;
+        Equations defobj;
+        defobj.. obj =e= x;
+        Model m / all /;
+
+        loop(a,
+           loop(b,
+              loop(c,
+                 solve m minimizing obj using nlp;
+              );
+           );
+        );
+        """
+        ir = parse_model_text(source)
+        assert ir.objective is not None
+        assert ir.objective.objvar == "obj"
+
+    def test_single_nested_loop_solve_still_works(self):
+        """Regression: single-level loop solve must still work."""
+        source = """
+        Sets i / i1*i5 /;
+        Variables obj, x(i);
+        Equations defobj;
+        defobj.. obj =e= sum(i, x(i));
+        Model m / all /;
+
+        loop(i,
+           solve m minimizing obj using nlp;
+        );
+        """
+        ir = parse_model_text(source)
+        assert ir.objective is not None
+        assert ir.objective.objvar == "obj"
+
+    def test_top_level_solve_still_works(self):
+        """Regression: top-level solve (no loop) must still work."""
+        source = """
+        Variables obj, x;
+        Equations defobj;
+        defobj.. obj =e= x;
+        Model m / all /;
+        solve m minimizing obj using nlp;
+        """
+        ir = parse_model_text(source)
+        assert ir.objective is not None
+        assert ir.objective.objvar == "obj"
+
+    def test_nested_loop_parses(self):
+        """Doubly-nested loop with solve should parse successfully."""
+        source = """
+        Sets c / c1*c3 /, i / i1*i5 /;
+        Variables obj, x(i);
+        Equations defobj;
+        defobj.. obj =e= sum(i, x(i));
+        Model m / all /;
+
+        loop(c,
+           loop(i,
+              solve m maximizing obj using nlp;
+           );
+        );
+        """
+        result = parse_text(source)
+        assert result is not None
+
+    def test_nested_loop_solve_maximizing(self):
+        """solve ... maximizing inside nested loop should extract MAX sense."""
+        source = """
+        Sets c / c1 /, i / i1 /;
+        Variables obj, x;
+        Equations defobj;
+        defobj.. obj =e= x;
+        Model m / all /;
+
+        loop(c,
+           loop(i,
+              solve m maximizing obj using nlp;
+           );
+        );
+        """
+        ir = parse_model_text(source)
+        assert ir.objective is not None
+        assert ir.objective.objvar == "obj"
+        from src.ir.symbols import ObjSense
+
+        assert ir.objective.sense == ObjSense.MAX


### PR DESCRIPTION
## Summary
- Add `_find_solve_in_loop_body()` recursive helper to `_ModelBuilder` that searches for `solve` nodes at any loop nesting depth
- Previously, solve extraction only checked direct children of a loop body, so `loop(c, loop(i, solve ...))` patterns were missed
- Fixes objective extraction for lmp1, lmp2, lmp3 GAMSlib models
- Reduces `model_no_objective_def` from 4 to 1 (only mhw4dxx remains — different root cause)

## Changes
- `src/ir/parser.py` — Added `_find_solve_in_loop_body()` static method, updated `_handle_loop_stmt` to use it
- `tests/unit/test_issue_810_nested_loop_solve.py` — 6 unit tests (doubly-nested, triply-nested, single-nested regression, top-level regression, parse check, maximizing sense)
- `docs/issues/completed/ISSUE_810_lmp2-solve-doubly-nested-loop.md` — Updated with resolution details, moved from `docs/issues/`

## Test plan
- [x] 6 new unit tests pass
- [x] All 3,635 tests pass (typecheck, lint, format, test)
- [x] lmp1, lmp2, lmp3 all extract objective correctly from nested loops

Closes #810