### PR TITLE
Document investigation findings for issues #764 and #765

### DIFF
--- a/docs/issues/ISSUE_764_mexss-mcp-locally-infeasible-accounting-variables.md
+++ b/docs/issues/ISSUE_764_mexss-mcp-locally-infeasible-accounting-variables.md
@@ -1,7 +1,7 @@
 # Mexss MCP: Locally Infeasible Due to Inconsistent Stationarity Equations for Accounting Variables
 
 **GitHub Issue:** [#764](https://github.com/jeffreyhorn/nlp2mcp/issues/764)
-**Status:** OPEN — Not fixable in Sprint 19 (requires KKT architectural changes for accounting/auxiliary variables)
+**Status:** OPEN — Not fixable (root cause is incorrect `sameas` guard in indexed stationarity builder; see Investigation section below)
 **Severity:** High — MCP generates and compiles, but PATH solver reports locally infeasible
 **Date:** 2026-02-16
 **Affected Models:** mexss
@@ -153,5 +153,128 @@ variable/equation pairs from the MCP.
 ## Related Issues
 
 - **ISSUE_670**: Cross-indexed sums (Error 149) — resolved; this issue is the next blocker
+- **ISSUE_767**: `sameas` guard for per-instance `.fx` multipliers — the guard logic is the root cause
+- **ISSUE_765 (orani)**: Similar infeasibility but caused by linearized CGE model structure
 - Similar pattern may affect other models with auxiliary cost-accounting variables
   (e.g., CGE models with decomposed cost functions)
+
+---
+
+## Investigation Attempt (2026-02-22)
+
+### Initial Analysis: Stationarity Equations
+
+Generated the MCP for mexss and examined the stationarity equations:
+
+```gams
+stat_phieps.. -1 + nu_aeps =E= 0;
+stat_philam.. 1 + nu_alam =E= 0;
+stat_phipsi.. 1 + nu_apsi =E= 0;
+stat_phipi.. 1 + nu_api =E= 0;
+```
+
+These are individually satisfiable (nu_aeps=1, nu_alam=-1, nu_apsi=-1, nu_api=-1). The
+accounting variable stationarity equations are NOT the primary source of infeasibility.
+
+### Actual Root Cause: Incorrect `sameas` Guard in `_add_indexed_jacobian_terms`
+
+The real problem is in the stationarity equations for indexed primal variables like `e(c,i)`,
+`u(c,i)`, `v(c,j)`, and `x(c,i,j)`. These equations have incorrect dollar conditions that
+restrict multiplier terms to single instances.
+
+**Example — `stat_e(c,i)`:**
+
+```gams
+stat_e(c,i)$(cf(c))..
+    (((-1) * mue(i)) * nu_alam)$(sameas(c, 'steel') and sameas(i, 'ahmsa'))
+  + (((-1) * pe(c)) * nu_aeps)$(sameas(c, 'steel') and sameas(i, 'ahmsa'))
+  + sum(cf, lam_mbf(cf,i))
+  + sum(cf, lam_me(cf))
+  =E= 0;
+```
+
+The `$(sameas(c, 'steel') and sameas(i, 'ahmsa'))` condition restricts the `nu_alam` and
+`nu_aeps` multiplier terms to ONLY the instance `e('steel','ahmsa')`. But the scalar equation
+`alam` sums over `e(cf,i)` for ALL valid `(cf,i)` combinations — the Jacobian derivative
+∂alam/∂e(c,i) = `mue(i)` is nonzero for all 5 instances where `c ∈ cf` (steel × 5 plants),
+not just `('steel','ahmsa')`.
+
+**How the bug manifests:**
+
+1. The `alam` equation is scalar (no domain indices)
+2. Its Jacobian w.r.t. `e(c,i)` has 5 nonzero entries: `(steel, ahmsa)`, `(steel, fundidora)`,
+   `(steel, sicartsa)`, `(steel, hylsa)`, `(steel, hylsap)`
+3. Variable `e` has 40 total instances (8 commodities × 5 plants)
+4. The Issue #767 guard at `stationarity.py:1543` checks `len(entries) < len(instances)` →
+   `5 < 40` → True → applies `sameas` guard
+5. But the guard uses `entries[0]` (the FIRST entry only, typically `('steel','ahmsa')`) to
+   build the `sameas` condition, ignoring the other 4 valid instances
+
+**The guard is designed for a different case:** It was built for scalar `.fx` constraints like
+`b_fx_s1.. b('s1') = value;` where only ONE instance of an indexed variable has a nonzero
+Jacobian entry. For such constraints, `len(entries) == 1` and the guard correctly restricts
+the multiplier to that single instance.
+
+**But for scalar equations like `alam` that sum over multiple instances of an indexed variable,**
+`len(entries) > 1` and the guard incorrectly restricts to the first entry only.
+
+### Same Bug Affects Multiple Stationarity Equations
+
+| Stationarity Eq | Scalar Constraint | Variable | Valid Instances | Guard Restricts To |
+|-----------------|-------------------|----------|-----------------|-------------------|
+| `stat_e(c,i)` | `alam` | `e(c,i)` | 5 (steel × 5 plants) | `(steel, ahmsa)` only |
+| `stat_e(c,i)` | `aeps` | `e(c,i)` | 5 (steel × 5 plants) | `(steel, ahmsa)` only |
+| `stat_u(c,i)` | `apsi` | `u(c,i)` | 5 (coke × 5 plants) | `(coke, ahmsa)` only |
+| `stat_v(c,j)` | `alam` | `v(c,j)` | 3 (steel × 3 markets) | `(steel, guadalaja)` only |
+| `stat_v(c,j)` | `api` | `v(c,j)` | 3 (steel × 3 markets) | `(steel, guadalaja)` only |
+| `stat_x(c,i,j)` | `alam` | `x(c,i,j)` | 15 (steel × 5 × 3) | `(steel, ahmsa, guadalaja)` only |
+
+This produces stationarity equations that are too restrictive — the multiplier terms only
+contribute to one instance when they should contribute to all valid instances.
+
+### Why This Is Not a Simple Fix
+
+The fix requires changing how `_add_indexed_jacobian_terms()` handles the case where a scalar
+constraint has multiple nonzero Jacobian entries for different instances of an indexed variable.
+Instead of a single `sameas` guard on `entries[0]`, the code needs to:
+
+1. **Group entries by their element indices** and determine if ALL instances of the variable
+   within the constraint's summation domain are present
+2. **If all instances in a subset are present**, use a subset condition (e.g., `$(cf(c))`)
+   rather than `sameas`
+3. **If only some instances are present**, generate a disjunction of `sameas` conditions
+   (e.g., `$(sameas(i,'ahmsa') or sameas(i,'fundidora') or ...)`)
+
+This requires:
+- Understanding the constraint's summation structure (which sets are being summed over)
+- Matching Jacobian entry indices against set membership
+- Generating appropriate GAMS conditions (subset membership vs sameas disjunctions)
+
+The Issue #767 guard at `stationarity.py:1536-1563` needs to be refactored from a simple
+"first entry" guard to a proper "active domain" guard.
+
+### What Must Be Done Before Attempting Another Fix
+
+1. **Refactor the Issue #767 guard** in `_add_indexed_jacobian_terms()` (stationarity.py:1536-1563):
+   - When `len(entries) > 1`, do NOT use `entries[0]` alone
+   - Group entries by their variable indices
+   - Determine if the entries cover a known subset (e.g., all elements of set `cf`)
+   - Generate appropriate conditions: subset membership `$(cf(c))` if entries match a defined
+     subset, or an `or`-disjunction of `sameas` calls if entries are arbitrary
+
+2. **Add test cases** for scalar-constraint-to-indexed-variable Jacobian patterns:
+   - Scalar equation summing over a subset of an indexed variable
+   - Scalar equation summing over multiple subsets
+   - Scalar equation with partial instance coverage (not matching any named subset)
+
+3. **Verify mexss solves correctly** after the guard fix — the accounting variable stationarity
+   equations (`stat_phieps`, etc.) are individually satisfiable, so fixing the `sameas` guard
+   should make the full MCP system feasible.
+
+### Conclusion
+
+**This issue is NOT fixable** with a simple change. The root cause is the Issue #767 `sameas`
+guard in `_add_indexed_jacobian_terms()` which incorrectly restricts scalar-constraint multiplier
+terms to a single variable instance when the constraint actually references multiple instances.
+The fix requires a non-trivial refactor of the guard logic to handle multi-entry Jacobian
+patterns. This is an architectural improvement that should be planned as a dedicated workstream.

--- a/docs/issues/ISSUE_765_orani-mcp-locally-infeasible-fixed-variables-exogenous.md
+++ b/docs/issues/ISSUE_765_orani-mcp-locally-infeasible-fixed-variables-exogenous.md
@@ -1,7 +1,7 @@
 # Orani MCP: Locally Infeasible Due to Fixed Exogenous Variables in Percentage-Change Model
 
 **GitHub Issue:** [#765](https://github.com/jeffreyhorn/nlp2mcp/issues/765)
-**Status:** OPEN — Not fixable in Sprint 19 (requires architectural support for fixed/exogenous variables in linearized CGE models)
+**Status:** OPEN — Not fixable (structurally infeasible linearized CGE model; see Investigation section below)
 **Severity:** High — MCP generates and compiles, but PATH solver reports locally infeasible
 **Date:** 2026-02-16
 **Affected Models:** orani
@@ -161,5 +161,101 @@ equations infeasible, and allow detection/handling of inconsistent equations.
 ## Related Issues
 
 - **ISSUE_670**: Cross-indexed sums (Error 149) — resolved; this issue is the next blocker
-- **mexss issue**: Similar infeasibility pattern from accounting variable stationarity
+- **ISSUE_764 (mexss)**: Similar infeasibility pattern from accounting variable stationarity
 - Other linearized CGE models (e.g., dyncge, irscge, korcge, lrgcge) may have the same problem
+
+---
+
+## Investigation Attempt (2026-02-22)
+
+### Approach: Exclude Fixed Variables from MCP Stationarity (Option A)
+
+**What was tried:**
+
+1. Added a `fixed_variables: set[str]` field to `KKTSystem` in `src/kkt/kkt_system.py`
+2. Modified `build_stationarity_equations()` in `src/kkt/stationarity.py` to detect variables
+   where `.lo == .up` (fully fixed via `.fx`), skip stationarity equation generation for them,
+   and record them in `KKTSystem.fixed_variables`
+
+**Identified fixed variables in orani:**
+- `df(c)`, `e(cm)`, `kappa(i)`, `phi`, `pm(c)`, `t(c)`, `v(ca)`, `ws`, `ye` — 9 variables
+
+**Result: Fix did NOT work.**
+
+Two cascading failures prevented this approach:
+
+#### Failure 1: MCP Count Mismatch
+
+Removing stationarity equations for 9 fixed variables (which eliminates 9 equation–variable
+pairs from the MCP model statement) produces a count mismatch:
+
+```
+*** Error: Counts do not match in model mcp_model
+    Unmatched free variables = 13
+```
+
+The emitter still declares all variables (including fixed ones), but their paired stationarity
+equations are gone. The MCP requires a 1:1 equation–variable pairing. Fixing this would require
+also removing the fixed variables from the MCP model statement and adding `.fx` handling in the
+emitter — a much deeper change than just skipping stationarity generation.
+
+#### Failure 2: Non-Fixed Variable Stationarity Equations Are Also Infeasible
+
+Even after addressing the count mismatch, the **non-fixed variable** stationarity equations
+are themselves structurally infeasible. For example:
+
+```gams
+stat_b.. nu_baltrade =E= 0;
+stat_cn(c,s).. nu_con(c,s) =E= 0;
+stat_cr.. nu_realc =E= 0;
+```
+
+These force equality constraint multipliers to zero. But the remaining stationarity equations
+for other variables (e.g., `stat_p`, `stat_pk`, `stat_w`) require those same multipliers to
+be nonzero to satisfy their own conditions. This creates a cascading infeasibility that cannot
+be resolved by simply excluding fixed variables.
+
+**Example cascade:**
+- `stat_b.. nu_baltrade =E= 0;` forces `nu_baltrade = 0`
+- `stat_et.. nu_exports + ((-1) * C) * nu_baltrade =E= 0;` then forces `nu_exports = 0`
+- But other equations need `nu_exports ≠ 0` to satisfy their conditions
+
+### Root Cause Analysis
+
+The orani model is a **linearized percentage-change CGE model**, not a standard NLP. The
+equations represent first-order approximations around an equilibrium, and the model's solution
+structure is fundamentally different from what the NLP→MCP transformation assumes:
+
+1. All variables represent **percentage changes** from a base equilibrium (not level values)
+2. Many variables are fixed to represent exogenous policy shocks
+3. The system of equations is a square linear system (N equations, N endogenous variables)
+   that should be solved directly, not reformulated as KKT conditions
+4. The stationarity equations for this linearized system are trivially constant (since the
+   Lagrangian gradients w.r.t. percentage-change variables produce constant multiplier terms),
+   making the resulting MCP structurally infeasible
+
+### What Must Be Done Before Attempting Another Fix
+
+1. **Model classification**: Add a pre-transformation heuristic that detects linearized CGE
+   models (e.g., >30% of variables fixed, all equations are linear, all constraints are
+   equalities). Such models should produce a warning and suggest solving directly as a
+   square system rather than converting to MCP.
+
+2. **Fixed-variable MCP handling**: If excluding fixed variables from stationarity is pursued,
+   the full pipeline must be updated:
+   - `build_stationarity_equations()`: skip fixed variables ✓ (done in attempt)
+   - `emit_gams.py`: suppress fixed variable declarations in MCP model statement
+   - `emit/model.py`: exclude fixed variables from equation–variable pairing
+   - `complementarity.py`: exclude fixed-variable bound complementarity pairs
+
+3. **Fundamental limitation**: Even with perfect fixed-variable handling, the orani model's
+   non-fixed variable stationarity equations are structurally infeasible due to the linearized
+   CGE nature of the model. This model class is **not suitable for NLP→MCP conversion** and
+   should be explicitly excluded or warned about.
+
+### Conclusion
+
+**This issue is NOT fixable** within the current NLP→MCP architecture. The orani model is a
+linearized percentage-change CGE model that represents a fundamentally different problem class
+from the nonlinear optimization problems that KKT-based MCP conversion is designed for. The
+recommended approach is to detect and warn about this model class rather than attempt conversion.


### PR DESCRIPTION
## Summary
- Investigated issues #764 (mexss MCP infeasible) and #765 (orani MCP infeasible)
- Both found to be NOT fixable with simple changes — updated issue .md files with detailed investigation findings
- Added comments on both GitHub issues with findings

### Issue #764 (mexss)
**Root cause:** The Issue #767 `sameas` guard in `_add_indexed_jacobian_terms()` (stationarity.py:1536-1563) incorrectly restricts scalar-constraint multiplier terms to a single variable instance when the constraint references multiple instances. For example, `alam` sums over `e(cf,i)` for 5 valid instances, but the guard only applies the multiplier to `e('steel','ahmsa')`.

**Required fix:** Refactor the guard to handle multi-entry Jacobian patterns — generate subset conditions or `or`-disjunctions of `sameas` instead of using `entries[0]` alone.

### Issue #765 (orani)
**Attempted fix:** Exclude fixed variables from MCP stationarity equation generation.

**Result:** Failed due to (1) MCP count mismatch when stationarity equations are removed but variable declarations remain, and (2) non-fixed variable stationarity equations are also structurally infeasible — multipliers are forced to zero in a cascade. Orani is a linearized percentage-change CGE model fundamentally unsuitable for NLP→MCP conversion.

## Test plan
- [ ] No code changes — documentation only
- [ ] Verify issue .md files render correctly
- [ ] Confirm GitHub issue comments posted (#764, #765)