### PR TITLE
Investigation findings for issues #826, #827, #828

### DIFF
--- a/docs/issues/ISSUE_826_decomp-empty-stationarity-equation.md
+++ b/docs/issues/ISSUE_826_decomp-empty-stationarity-equation.md
@@ -127,9 +127,9 @@ builder.
 3. **Result**: After simplification, the stationarity expression becomes `Const(0.0)`,
    producing empty equations `stat_lam(1).. 0 =E= 0` and `stat_lam(2).. 0 =E= 0`.
 
-4. **No empty-equation filtering**: `emit_model.py` (lines 128-151) does not check whether
-   stationarity equations are empty before including them in MCP pairing. GAMS requires that
-   MCP-paired empty equations correspond to fixed variables.
+4. **No empty-equation filtering**: `src/emit/model.py` (function `emit_model_mcp`, lines
+   128-151) does not check whether stationarity equations are empty before including them in
+   MCP pairing. GAMS requires that MCP-paired empty equations correspond to fixed variables.
 
 ### Why This Cannot Be Simply Fixed
 

--- a/docs/issues/ISSUE_827_gtm-domain-violation-zero-fill.md
+++ b/docs/issues/ISSUE_827_gtm-domain-violation-zero-fill.md
@@ -19,9 +19,10 @@ The gtm model (`data/gamslib/raw/gtm.gms`) generates an MCP file, but GAMS repor
 **** 141  Symbol declared but no values have been assigned.
 ```
 
-The errors occur because the emitter zero-fills parameter data for all combinations of domain
-indices, including `(i,j)` pairs where the first index is not in set `i` (e.g., `central`
-which is only in set `j`).
+The errors occur because the parser zero-fills parameter table data for all combinations of
+domain indices, including `(i,j)` pairs where the first index is not in set `i` (e.g.,
+`central` which is only in set `j`), and the emitter emits these entries without domain
+validation.
 
 Previously this model failed with `codegen_numerical_error` due to `+Inf` parameter value
 in the `sdat` table. The Inf handling fix (Sprint 20 Day 10) resolved that blocker, revealing
@@ -74,10 +75,11 @@ gams /tmp/gtm_mcp.gms lo=2
 
 ### Domain Violations (Error 170)
 
-The emitter's zero-fill logic in `emit_original_parameters()` generates entries for all
-combinations of the Cartesian product of domain sets. For `utc(i,j)`, this produces entries
-for `central.west-can`, `n-central.mexico`, etc. where the first index (`central`) is not in
-set `i`. GAMS enforces domain checking and rejects these entries.
+The parser's zero-fill logic in `_handle_table_block()` generates entries for all
+combinations of the Cartesian product of row and column headers. For `utc(i,j)`, this
+produces entries for `central.west-can`, `n-central.mexico`, etc. where the first index
+(`central`) is not in set `i`. The emitter then emits these entries without domain
+validation, and GAMS enforces domain checking and rejects them.
 
 The zero-fill should only generate entries for valid domain combinations, respecting the actual
 domain sets of each parameter dimension.

--- a/docs/issues/ISSUE_828_ibm1-locally-infeasible-stationarity.md
+++ b/docs/issues/ISSUE_828_ibm1-locally-infeasible-stationarity.md
@@ -120,9 +120,9 @@ handles several scenarios:
 - **Positive Variables**: `lo = 0.0` → creates uniform `piL_x` with variable's domain
 - **Infinite bound filtering**: `+Inf`/`-Inf` bounds are skipped at partition time
   (`partition.py`, lines 120-157), preventing meaningless multiplier generation
-- **Uniform bounds**: Single indexed multiplier `piL_x(i)` added to `stat_x(i)` via
+- **Uniform bounds**: Single indexed multiplier `piL_x(s)` added to `stat_x(s)` via
   `Binary("-", expr, MultiplierRef(piL_name, domain))` (stationarity.py lines 757-767)
-- **Non-uniform bounds**: Per-instance scalar multipliers `piL_x_i1` added to per-instance
+- **Non-uniform bounds**: Per-instance scalar multipliers `piL_x_s1` added to per-instance
   stationarity equations (stationarity.py lines 559-579, 1577-1623)
 
 **How bounds from parameter assignments are handled:**


### PR DESCRIPTION
## Summary

- Updated issue documents for #826, #827, #828 with detailed root cause analysis and investigation findings
- All three issues are deep infrastructure problems that cannot be simply fixed — documented what must be done before attempting each fix
- Added comments to each GitHub issue with findings summary

### Issue #826 (decomp: empty stationarity equation)
Domain/subset index mismatch in stationarity builder. Variable `lam(ss)` accessed only over dynamic subset `s(ss)` via `sum(s, ...)` in scalar equations. The index replacement logic cannot map concrete indices across different domain sets, resulting in empty stationarity expressions.

### Issue #827 (gtm: domain violations from zero-fill)
Two sub-problems:
1. Table parser zero-fills with blind Cartesian product without domain validation (Error 170)
2. Parameter assignments emitted in declaration order, not dependency order (Error 141) — topological sort exists but only applied to calibration parameters

### Issue #828 (ibm1: locally infeasible stationarity)
Bound multiplier terms missing from stationarity equations. Parameter-assigned bounds (`x.up(s) = sup(s,"inventory")`) may not resolve to numeric values, or the uniform/non-uniform detection may mismatch how multipliers were created.

## Test plan
- [x] No code changes — documentation only
- [x] GitHub issue comments posted on #826, #827, #828