### PR TITLE
Close #884: ParamRef in IndexOffset already fixed

### DIFF
--- a/docs/issues/completed/ISSUE_884_imsl-paramref-in-indexoffset-to-gams-string.md
+++ b/docs/issues/completed/ISSUE_884_imsl-paramref-in-indexoffset-to-gams-string.md
@@ -1,7 +1,7 @@
 # imsl: ParamRef Not Handled in IndexOffset._offset_expr_to_string()
 
 **GitHub Issue:** [#884](https://github.com/jeffreyhorn/nlp2mcp/issues/884)
-**Status:** OPEN
+**Status:** RESOLVED
 **Severity:** Medium — Model parses but translation fails
 **Date:** 2026-02-25
 **Affected Models:** imsl
@@ -120,6 +120,10 @@ w(m+1,n)$w(m,n) = 1 - w(m,n);
 ```
 
 ---
+
+## Resolution
+
+This issue was already fixed in commit b94ab2ba (PR #883 review comments), which added `ParamRef` and `VarRef` handlers to `IndexOffset._offset_expr_to_string()`. The imsl model now parses and translates successfully (`python -m src.cli data/gamslib/raw/imsl.gms` produces MCP output without errors).
 
 ## Related Issues
 


### PR DESCRIPTION
## Summary
- Issue #884 (ParamRef not handled in `IndexOffset._offset_expr_to_string()`) was already resolved in commit b94ab2ba (PR #883 review comments)
- That commit added `ParamRef` and `VarRef` handlers to the method
- Verified: `imsl.gms` parses and translates successfully
- Moved issue doc to `docs/issues/completed/`, closed GitHub issue

## Test plan
- [x] Verified `python -m src.cli data/gamslib/raw/imsl.gms` produces MCP output without errors
- [x] No code changes — doc-only update