### PR TITLE
Update ISSUE_1049: pak MCP root cause analysis

### DIFF
--- a/docs/issues/ISSUE_1049_pak-mcp-locally-infeasible-incomplete-stationarity.md
+++ b/docs/issues/ISSUE_1049_pak-mcp-locally-infeasible-incomplete-stationarity.md
@@ -1,6 +1,6 @@
 # pak: MCP Locally Infeasible — Incomplete Stationarity
 
-**GitHub Issue:** #1049 (https://github.com/jeffreyhorn/nlp2mcp/issues/1049)
+**GitHub Issue:** [#1049](https://github.com/jeffreyhorn/nlp2mcp/issues/1049)
 **Status:** Open — Root cause identified but requires architectural changes
 **Severity:** Medium — Model translates without structural errors, but PATH reports locally infeasible
 **Date:** 2026-03-11
@@ -70,7 +70,7 @@ stat_c(te).. (-1) * delt(te)$(t(te)) + (-1) * nu_incd(te)$(t(te)) + ... =E= 0;
 
 In `wdef.. w =E= sum(t, delt(t)*c(t)) - gama*fb + d*dis*gnp("1985")`, the expression `gnp("1985")` stores the index as `'"1985"'` (with quotes), while the variable instance `gnp(('1985',))` uses unquoted `'1985'`. The differentiation system fails to match these, so `∂wdef/∂gnp(1985) = 0` instead of the correct value `-d*dis`.
 
-**Fix required:** Either strip quotes from string literal indices during parsing, or normalize them during differentiation to ensure `gnp("1985")` matches `gnp(1985)`.
+**Fix required:** Add canonical index normalization in the differentiation system (`src/ad/derivative_rules.py`) so that quoted string literal indices like `'"1985"'` are matched against unquoted variable instance keys like `'1985'`. This should be done at differentiation time (not parse time) to preserve the original source representation in the IR while ensuring correct matching during Jacobian computation.
 
 ---
 
@@ -124,7 +124,7 @@ cd data/gamslib/mcp && gams pak_mcp.gms
 
 2. **Bug 2 (Non-uniform Gradient):** Refactor `_build_indexed_gradient_term()` to handle cases where the first instance has zero gradient but others don't. One approach: scan all instances to find one with a non-zero gradient and use that as the template.
 
-3. **Bug 3 (Quoted Indices):** Normalize string literal indices during parsing or differentiation to strip quotes, ensuring `gnp("1985")` matches `gnp(1985)`.
+3. **Bug 3 (Quoted Indices):** Add canonical index normalization in `src/ad/derivative_rules.py` so that quoted string literal indices (`'"1985"'`) match unquoted variable instance keys (`'1985'`) during differentiation.
 
 4. After fixing all three bugs, regenerate pak_mcp.gms and verify with GAMS PATH solver.
 


### PR DESCRIPTION
## Summary
- Updated issue doc for #1049 (pak MCP Locally Infeasible) with detailed root cause analysis
- Identified 3 architectural bugs causing incorrect stationarity equations:
  1. **Subset/superset domain mismatch**: `_add_indexed_jacobian_terms()` treats `t` and `te` as disjoint sets when `t ⊂ te`, producing `Sum(('t',), ...)` instead of matching te to t with a `$(t(te))` guard
  2. **First-instance gradient template**: `_build_indexed_gradient_term()` uses `c("1962")` (gradient=0) as template, dropping the `-delt(te)` term from stat_c
  3. **Quoted string literal mismatch**: `gnp("1985")` stores index with quotes but variable instances use unquoted, so differentiation returns 0
- Added GitHub issue comment with findings
- Issue remains open — these require architectural refactoring of the stationarity builder

## Test plan
- [ ] No code changes to source files, only issue doc update
- [ ] Verify issue doc accurately captures the root cause analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)