### PR TITLE
Fix #1054: detect Call-based parameter references in MCP emitter

### DIFF
--- a/data/gamslib/mcp/stdcge_mcp.gms
+++ b/data/gamslib/mcp/stdcge_mcp.gms
@@ -130,9 +130,11 @@ taud = Td0 / sum(h, FF(h));
 lambda(i) = Xv0(i) / (Sp0 + Sg0 + Sf);
 Z0(j) = Y0(j) + sum(i, X0(i,j));
 b(j) = Y0(j) / prod(h, F0(h,j) ** beta(h,j));
+UU0 = prod(i, Xp0(i) ** alpha(i));
 tauz(j) = Tz0(j) / Z0(j);
 ax(i,j) = X0(i,j) / Z0(j);
 ay(j) = Y0(j) / Z0(j);
+ep0 = UU0 / prod(i, (alpha(i) / 1) ** alpha(i));
 D0(i) = (1 + tauz(i)) * Z0(i) - E0(i);
 deltam(i) = (1 + taum(i)) * M0(i) ** (1 - eta(i)) / ((1 + taum(i)) * M0(i) ** (1 - eta(i)) + D0(i) ** (1 - eta(i)));
 deltad(i) = D0(i) ** (1 - eta(i)) / ((1 + taum(i)) * M0(i) ** (1 - eta(i)) + D0(i) ** (1 - eta(i)));
@@ -182,11 +184,11 @@ Variables
     nu_eqF(h,j)
     nu_eqX(i,j)
     nu_eqY(j)
-    nu_eqpzs(i)
+    nu_eqpzs(j)
     nu_eqTd
     nu_eqTz(j)
     nu_eqTm(i)
-    nu_eqXg(j)
+    nu_eqXg(i)
     nu_eqXv(i)
     nu_eqSp
     nu_eqSg
@@ -197,9 +199,9 @@ Variables
     nu_eqpqs(i)
     nu_eqM(i)
     nu_eqD(i)
-    nu_eqpzd(j)
-    nu_eqE(j)
-    nu_eqDs(j)
+    nu_eqpzd(i)
+    nu_eqE(i)
+    nu_eqDs(i)
     nu_eqpqd(i)
     nu_eqpf(h)
     nu_pf_fx_LAB
@@ -233,12 +235,6 @@ Positive Variables
 ;
 
 * ============================================
-* Variable Bounds
-* ============================================
-
-pf.fx('LAB') = 1;
-
-* ============================================
 * Variable Initialization
 * ============================================
 
@@ -247,56 +243,56 @@ pf.fx('LAB') = 1;
 * non-zero initial values.
 
 Y.l(j) = Y0(j);
-Y.l('BRD') = max(Y.l('BRD'), 1e-05);
-Y.l('MLK') = max(Y.l('MLK'), 1e-05);
+Y.l("BRD") = max(Y.l("BRD"), 1e-05);
+Y.l("MLK") = max(Y.l("MLK"), 1e-05);
 F.l(h,j) = F0(h,j);
-F.l('CAP','BRD') = max(F.l('CAP','BRD'), 1e-05);
-F.l('CAP','MLK') = max(F.l('CAP','MLK'), 1e-05);
-F.l('LAB','BRD') = max(F.l('LAB','BRD'), 1e-05);
-F.l('LAB','MLK') = max(F.l('LAB','MLK'), 1e-05);
+F.l("CAP","BRD") = max(F.l("CAP","BRD"), 1e-05);
+F.l("CAP","MLK") = max(F.l("CAP","MLK"), 1e-05);
+F.l("LAB","BRD") = max(F.l("LAB","BRD"), 1e-05);
+F.l("LAB","MLK") = max(F.l("LAB","MLK"), 1e-05);
 X.l(i,j) = X0(i,j);
-X.l('BRD','BRD') = max(X.l('BRD','BRD'), 1e-05);
-X.l('BRD','MLK') = max(X.l('BRD','MLK'), 1e-05);
-X.l('MLK','BRD') = max(X.l('MLK','BRD'), 1e-05);
-X.l('MLK','MLK') = max(X.l('MLK','MLK'), 1e-05);
+X.l("BRD","BRD") = max(X.l("BRD","BRD"), 1e-05);
+X.l("BRD","MLK") = max(X.l("BRD","MLK"), 1e-05);
+X.l("MLK","BRD") = max(X.l("MLK","BRD"), 1e-05);
+X.l("MLK","MLK") = max(X.l("MLK","MLK"), 1e-05);
 Z.l(j) = Z0(j);
-Z.l('BRD') = max(Z.l('BRD'), 1e-05);
-Z.l('MLK') = max(Z.l('MLK'), 1e-05);
+Z.l("BRD") = max(Z.l("BRD"), 1e-05);
+Z.l("MLK") = max(Z.l("MLK"), 1e-05);
 Xp.l(i) = Xp0(i);
-Xp.l('BRD') = max(Xp.l('BRD'), 1e-05);
-Xp.l('MLK') = max(Xp.l('MLK'), 1e-05);
+Xp.l("BRD") = max(Xp.l("BRD"), 1e-05);
+Xp.l("MLK") = max(Xp.l("MLK"), 1e-05);
 Xg.l(i) = Xg0(i);
-Xg.l('BRD') = max(Xg.l('BRD'), 1e-05);
-Xg.l('MLK') = max(Xg.l('MLK'), 1e-05);
+Xg.l("BRD") = max(Xg.l("BRD"), 1e-05);
+Xg.l("MLK") = max(Xg.l("MLK"), 1e-05);
 Xv.l(i) = Xv0(i);
-Xv.l('BRD') = max(Xv.l('BRD'), 1e-05);
-Xv.l('MLK') = max(Xv.l('MLK'), 1e-05);
+Xv.l("BRD") = max(Xv.l("BRD"), 1e-05);
+Xv.l("MLK") = max(Xv.l("MLK"), 1e-05);
 E.l(i) = E0(i);
-E.l('BRD') = max(E.l('BRD'), 1e-05);
-E.l('MLK') = max(E.l('MLK'), 1e-05);
+E.l("BRD") = max(E.l("BRD"), 1e-05);
+E.l("MLK") = max(E.l("MLK"), 1e-05);
 M.l(i) = M0(i);
-M.l('BRD') = max(M.l('BRD'), 1e-05);
-M.l('MLK') = max(M.l('MLK'), 1e-05);
+M.l("BRD") = max(M.l("BRD"), 1e-05);
+M.l("MLK") = max(M.l("MLK"), 1e-05);
 Q.l(i) = Q0(i);
-Q.l('BRD') = max(Q.l('BRD'), 1e-05);
-Q.l('MLK') = max(Q.l('MLK'), 1e-05);
+Q.l("BRD") = max(Q.l("BRD"), 1e-05);
+Q.l("MLK") = max(Q.l("MLK"), 1e-05);
 D.l(i) = D0(i);
-D.l('BRD') = max(D.l('BRD'), 1e-05);
-D.l('MLK') = max(D.l('MLK'), 1e-05);
-pf.l('CAP') = 1.0;
-pf.l('LAB') = 1.0;
-py.l('BRD') = 1.0;
-py.l('MLK') = 1.0;
-pz.l('BRD') = 1.0;
-pz.l('MLK') = 1.0;
-pq.l('BRD') = 1.0;
-pq.l('MLK') = 1.0;
-pe.l('BRD') = 1.0;
-pe.l('MLK') = 1.0;
-pm.l('BRD') = 1.0;
-pm.l('MLK') = 1.0;
-pd.l('BRD') = 1.0;
-pd.l('MLK') = 1.0;
+D.l("BRD") = max(D.l("BRD"), 1e-05);
+D.l("MLK") = max(D.l("MLK"), 1e-05);
+pf.l("CAP") = 1.0;
+pf.l("LAB") = 1.0;
+py.l("BRD") = 1.0;
+py.l("MLK") = 1.0;
+pz.l("BRD") = 1.0;
+pz.l("MLK") = 1.0;
+pq.l("BRD") = 1.0;
+pq.l("MLK") = 1.0;
+pe.l("BRD") = 1.0;
+pe.l("MLK") = 1.0;
+pm.l("BRD") = 1.0;
+pm.l("MLK") = 1.0;
+pd.l("BRD") = 1.0;
+pd.l("MLK") = 1.0;
 epsilon.l = 1.0;
 Sp.l = Sp0;
 Sp.l = max(Sp.l, 1e-05);
@@ -410,24 +406,24 @@ stat_f(h,j).. ((-1) * (b(j) * prod(h__, f(h__,j) ** beta(h__,j)) * sum(h__, f(h_
 stat_m(i).. ((-1) * (taum(i) * pm(i))) * nu_eqTm(i) + ((-1) * pWm(i)) * nu_eqepsilon + ((-1) * (gamma(i) * (deltam(i) * m(i) ** eta(i) + deltad(i) * d(i) ** eta(i)) ** (1 / eta(i)) * 1 / eta(i) / (deltam(i) * m(i) ** eta(i) + deltad(i) * d(i) ** eta(i)) * deltam(i) * m(i) ** eta(i) * eta(i) / m(i))) * nu_eqpqs(i) + nu_eqM(i) - piL_m(i) =E= 0;
 stat_pd(i).. ((-1) * (q(i) * (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) * ((-1) * (gamma(i) ** eta(i) * deltad(i) * pq(i))) / sqr(pd(i)))) * nu_eqD(i) + ((-1) * (z(i) * (theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i) / pd(i)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i) / pd(i)) * ((-1) * (theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i))) / sqr(pd(i)))) * nu_eqDs(i) - piL_pd(i) =E= 0;
 stat_pe(i).. nu_eqpe(i) + ((-1) * (z(i) * (theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i) / pe(i)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i) / pe(i)) * ((-1) * (theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i))) / sqr(pe(i)))) * nu_eqE(i) - piL_pe(i) =E= 0;
-stat_pf(h).. sum(j, ((-1) * (((-1) * (beta(h,j) * py(j) * y(j))) / sqr(pf(h)))) * nu_eqF(h,j)) + ((-1) * (taud * FF(h))) * nu_eqTd + ((-1) * (ssp * FF(h))) * nu_eqSp + sum(i, ((-1) * (pq(i) * alpha(i) * FF(h) / sqr(pq(i)))) * nu_eqXp(i)) + nu_pf_fx_LAB$(sameas(h, 'LAB')) - piL_pf(h) =E= 0;
+stat_pf(h).. sum(j, ((-1) * (((-1) * (beta(h,j) * py(j) * y(j))) / sqr(pf(h)))) * nu_eqF(h,j)) + ((-1) * (taud * FF(h))) * nu_eqTd + ((-1) * (ssp * FF(h))) * nu_eqSp + sum(i, ((-1) * (pq(i) * alpha(i) * FF(h) / sqr(pq(i)))) * nu_eqXp(i)) + nu_pf_fx_LAB$sameas(h, 'LAB') - piL_pf(h) =E= 0;
 stat_pm(i).. ((-1) * (m(i) * taum(i))) * nu_eqTm(i) + nu_eqpm(i) + ((-1) * (q(i) * (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) * ((-1) * (gamma(i) ** eta(i) * deltam(i) * pq(i) * (1 + taum(i)))) / sqr((1 + taum(i)) * pm(i)))) * nu_eqM(i) - piL_pm(i) =E= 0;
-stat_pq(i).. ((-1) * ax(i,i)) * nu_eqpzs(i) + (((-1) * ax(i,i)) * nu_eqpzs(i+1))$(ord(i) <= card(i) - 1) + (((-1) * ax(i,i)) * nu_eqpzs(i-1))$(ord(i) > 1) + ((-1) * (((-1) * (mu(i) * (td + sum(j, tz(j)) + sum(j, tm(j)) - sg))) / sqr(pq(i)))) * nu_eqXg(i) + ((-1) * (((-1) * (lambda(i) * (sp + sg + epsilon * Sf))) / sqr(pq(i)))) * nu_eqXv(i) + ((-1) * (((-1) * (alpha(i) * (sum(h, pf(h) * FF(h)) - sp - td))) / sqr(pq(i)))) * nu_eqXp(i) + ((-1) * (q(i) * (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) * (1 + taum(i)) * pm(i) * gamma(i) ** eta(i) * deltam(i) / sqr((1 + taum(i)) * pm(i)))) * nu_eqM(i) + ((-1) * (q(i) * (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) * pd(i) * gamma(i) ** eta(i) * deltad(i) / sqr(pd(i)))) * nu_eqD(i) - piL_pq(i) =E= 0;
+stat_pq(i).. sum(j, ((-1) * ax(i,j)) * nu_eqpzs(j)) + ((-1) * (((-1) * (mu(i) * (td + sum(j, tz(j)) + sum(j, tm(j)) - sg))) / sqr(pq(i)))) * nu_eqXg(i) + ((-1) * (((-1) * (lambda(i) * (sp + sg + epsilon * Sf))) / sqr(pq(i)))) * nu_eqXv(i) + ((-1) * (((-1) * (alpha(i) * (sum(h, pf(h) * FF(h)) - sp - td))) / sqr(pq(i)))) * nu_eqXp(i) + ((-1) * (q(i) * (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) * (1 + taum(i)) * pm(i) * gamma(i) ** eta(i) * deltam(i) / sqr((1 + taum(i)) * pm(i)))) * nu_eqM(i) + ((-1) * (q(i) * (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) * pd(i) * gamma(i) ** eta(i) * deltad(i) / sqr(pd(i)))) * nu_eqD(i) - piL_pq(i) =E= 0;
 stat_py(j).. sum(h, ((-1) * (pf(h) * y(j) * beta(h,j) / sqr(pf(h)))) * nu_eqF(h,j)) + ((-1) * ay(j)) * nu_eqpzs(j) - piL_py(j) =E= 0;
-stat_pz(j).. nu_eqpzs(j) + sum(i, ((-1) * (z(j) * tauz(i))) * nu_eqTz(j)) + ((-1) * (z(j) * (theta(j) ** phi(j) * xie(j) * (1 + tauz(j)) * pz(j) / pe(j)) ** (1 / (1 - phi(j))) * 1 / (1 - phi(j)) / (theta(j) ** phi(j) * xie(j) * (1 + tauz(j)) * pz(j) / pe(j)) * pe(j) * theta(j) ** phi(j) * xie(j) * (1 + tauz(j)) / sqr(pe(j)))) * nu_eqE(j) + ((-1) * (z(j) * (theta(j) ** phi(j) * xid(j) * (1 + tauz(j)) * pz(j) / pd(j)) ** (1 / (1 - phi(j))) * 1 / (1 - phi(j)) / (theta(j) ** phi(j) * xid(j) * (1 + tauz(j)) * pz(j) / pd(j)) * pd(j) * theta(j) ** phi(j) * xid(j) * (1 + tauz(j)) / sqr(pd(j)))) * nu_eqDs(j) - piL_pz(j) =E= 0;
+stat_pz(j).. nu_eqpzs(j) + sum(i, ((-1) * (z(j) * tauz(i))) * nu_eqTz(j)) + sum(i, ((-1) * (z(i) * (theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i) / pe(i)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i) / pe(i)) * pe(i) * theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) / sqr(pe(i)))) * nu_eqE(i)) + sum(i, ((-1) * (z(i) * (theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i) / pd(i)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i) / pd(i)) * pd(i) * theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) / sqr(pd(i)))) * nu_eqDs(i)) - piL_pz(j) =E= 0;
 stat_q(i).. nu_eqpqs(i) + ((-1) * ((gamma(i) ** eta(i) * deltam(i) * pq(i) / ((1 + taum(i)) * pm(i))) ** (1 / (1 - eta(i))))) * nu_eqM(i) + ((-1) * ((gamma(i) ** eta(i) * deltad(i) * pq(i) / pd(i)) ** (1 / (1 - eta(i))))) * nu_eqD(i) + nu_eqpqd(i) - piL_q(i) =E= 0;
 stat_sg.. sum(i, ((-1) * (pq(i) * mu(i) * (-1) / sqr(pq(i)))) * nu_eqXg(i)) + sum(i, ((-1) * (pq(i) * lambda(i) / sqr(pq(i)))) * nu_eqXv(i)) + nu_eqSg - piL_sg =E= 0;
 stat_sp.. sum(i, ((-1) * (pq(i) * lambda(i) / sqr(pq(i)))) * nu_eqXv(i)) + nu_eqSp + sum(i, ((-1) * (pq(i) * alpha(i) * (-1) / sqr(pq(i)))) * nu_eqXp(i)) - piL_sp =E= 0;
 stat_td.. nu_eqTd + sum(i, ((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i)) + ((-1) * ssg) * nu_eqSg + sum(i, ((-1) * (pq(i) * alpha(i) * (-1) / sqr(pq(i)))) * nu_eqXp(i)) - piL_td =E= 0;
-stat_tm(i).. nu_eqTm(i) + ((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i) + (((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i+1))$(ord(i) <= card(i) - 1) + (((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i-1))$(ord(i) > 1) + ((-1) * ssg) * nu_eqSg - piL_tm(i) =E= 0;
-stat_tz(j).. nu_eqTz(j) + ((-1) * (pq(j) * mu(j) / sqr(pq(j)))) * nu_eqXg(j) + (((-1) * (pq(j) * mu(j) / sqr(pq(j)))) * nu_eqXg(j+1))$(ord(j) <= card(j) - 1) + (((-1) * (pq(j) * mu(j) / sqr(pq(j)))) * nu_eqXg(j-1))$(ord(j) > 1) + ((-1) * ssg) * nu_eqSg - piL_tz(j) =E= 0;
+stat_tm(i).. nu_eqTm(i) + ((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i) + ((-1) * ssg) * nu_eqSg - piL_tm(i) =E= 0;
+stat_tz(j).. nu_eqTz(j) + sum(i, ((-1) * (pq(i) * mu(i) / sqr(pq(i)))) * nu_eqXg(i)) + ((-1) * ssg) * nu_eqSg - piL_tz(j) =E= 0;
 stat_uu.. 0 =E= 0;
 stat_x(i,j).. nu_eqX(i,j) - piL_x(i,j) =E= 0;
 stat_xg(i).. nu_eqXg(i) - nu_eqpqd(i) - piL_xg(i) =E= 0;
 stat_xp(i).. ((-1) * (prod(i__, xp(i__) ** alpha(i__)) * sum(i__, xp(i__) ** alpha(i__) * alpha(i__) / xp(i__) / xp(i__) ** alpha(i__)))) + nu_eqXp(i) - nu_eqpqd(i) - piL_xp(i) =E= 0;
 stat_xv(i).. nu_eqXv(i) - nu_eqpqd(i) - piL_xv(i) =E= 0;
 stat_y(j).. nu_eqpy(j) + sum(h, ((-1) * (pf(h) * beta(h,j) * py(j) / sqr(pf(h)))) * nu_eqF(h,j)) + nu_eqY(j) - piL_y(j) =E= 0;
-stat_z(j).. sum(i, ((-1) * ax(i,j)) * nu_eqX(i,j)) + ((-1) * ay(j)) * nu_eqY(j) + sum(i, ((-1) * (tauz(i) * pz(j))) * nu_eqTz(j)) + nu_eqpzd(j) + ((-1) * ((theta(j) ** phi(j) * xie(j) * (1 + tauz(j)) * pz(j) / pe(j)) ** (1 / (1 - phi(j))))) * nu_eqE(j) + ((-1) * ((theta(j) ** phi(j) * xid(j) * (1 + tauz(j)) * pz(j) / pd(j)) ** (1 / (1 - phi(j))))) * nu_eqDs(j) - piL_z(j) =E= 0;
+stat_z(j).. sum(i, ((-1) * ax(i,j)) * nu_eqX(i,j)) + ((-1) * ay(j)) * nu_eqY(j) + sum(i, ((-1) * (tauz(i) * pz(j))) * nu_eqTz(j)) + sum(i, nu_eqpzd(i)) + sum(i, ((-1) * ((theta(i) ** phi(i) * xie(i) * (1 + tauz(i)) * pz(i) / pe(i)) ** (1 / (1 - phi(i))))) * nu_eqE(i)) + sum(i, ((-1) * ((theta(i) ** phi(i) * xid(i) * (1 + tauz(i)) * pz(i) / pd(i)) ** (1 / (1 - phi(i))))) * nu_eqDs(i)) - piL_z(j) =E= 0;
 
 * Lower bound complementarity equations
 comp_lo_d(i).. d(i) - 1e-05 =G= 0;

--- a/data/gamslib/mcp/twocge_mcp.gms
+++ b/data/gamslib/mcp/twocge_mcp.gms
@@ -180,11 +180,11 @@ Variables
     nu_eqX(i,j,r)
     nu_eqY(j,r)
     nu_eqF(h,j,r)
-    nu_eqpzs(i,r)
+    nu_eqpzs(j,r)
     nu_eqTd(r)
-    nu_eqTz(j,r)
+    nu_eqTz(i,r)
     nu_eqTm(i,r)
-    nu_eqXg(j,r)
+    nu_eqXg(i,r)
     nu_eqXv(i,r)
     nu_eqSp(r)
     nu_eqSg(r)
@@ -195,9 +195,9 @@ Variables
     nu_eqpqs(i,r)
     nu_eqM(i,r)
     nu_eqD(i,r)
-    nu_eqpzd(j,r)
-    nu_eqE(j,r)
-    nu_eqDs(j,r)
+    nu_eqpzd(i,r)
+    nu_eqE(i,r)
+    nu_eqDs(i,r)
     nu_eqpqd(i,r)
     nu_eqpf(h,r)
     nu_eqUU(r)
@@ -236,14 +236,6 @@ Positive Variables
 ;
 
 * ============================================
-* Variable Bounds
-* ============================================
-
-pf.fx('LAB','JPN') = 1;
-pf.fx('LAB','USA') = 1;
-epsilon.fx('USA') = 1;
-
-* ============================================
 * Variable Initialization
 * ============================================
 
@@ -252,115 +244,115 @@ epsilon.fx('USA') = 1;
 * non-zero initial values.
 
 Y.l(j,r) = Y0(j,r);
-Y.l('BRD','JPN') = max(Y.l('BRD','JPN'), 1e-05);
-Y.l('BRD','USA') = max(Y.l('BRD','USA'), 1e-05);
-Y.l('MLK','JPN') = max(Y.l('MLK','JPN'), 1e-05);
-Y.l('MLK','USA') = max(Y.l('MLK','USA'), 1e-05);
+Y.l("BRD","JPN") = max(Y.l("BRD","JPN"), 1e-05);
+Y.l("BRD","USA") = max(Y.l("BRD","USA"), 1e-05);
+Y.l("MLK","JPN") = max(Y.l("MLK","JPN"), 1e-05);
+Y.l("MLK","USA") = max(Y.l("MLK","USA"), 1e-05);
 F.l(h,j,r) = F0(h,j,r);
-F.l('CAP','BRD','JPN') = max(F.l('CAP','BRD','JPN'), 1e-05);
-F.l('CAP','BRD','USA') = max(F.l('CAP','BRD','USA'), 1e-05);
-F.l('CAP','MLK','JPN') = max(F.l('CAP','MLK','JPN'), 1e-05);
-F.l('CAP','MLK','USA') = max(F.l('CAP','MLK','USA'), 1e-05);
-F.l('LAB','BRD','JPN') = max(F.l('LAB','BRD','JPN'), 1e-05);
-F.l('LAB','BRD','USA') = max(F.l('LAB','BRD','USA'), 1e-05);
-F.l('LAB','MLK','JPN') = max(F.l('LAB','MLK','JPN'), 1e-05);
-F.l('LAB','MLK','USA') = max(F.l('LAB','MLK','USA'), 1e-05);
+F.l("CAP","BRD","JPN") = max(F.l("CAP","BRD","JPN"), 1e-05);
+F.l("CAP","BRD","USA") = max(F.l("CAP","BRD","USA"), 1e-05);
+F.l("CAP","MLK","JPN") = max(F.l("CAP","MLK","JPN"), 1e-05);
+F.l("CAP","MLK","USA") = max(F.l("CAP","MLK","USA"), 1e-05);
+F.l("LAB","BRD","JPN") = max(F.l("LAB","BRD","JPN"), 1e-05);
+F.l("LAB","BRD","USA") = max(F.l("LAB","BRD","USA"), 1e-05);
+F.l("LAB","MLK","JPN") = max(F.l("LAB","MLK","JPN"), 1e-05);
+F.l("LAB","MLK","USA") = max(F.l("LAB","MLK","USA"), 1e-05);
 X.l(i,j,r) = X0(i,j,r);
-X.l('BRD','BRD','JPN') = max(X.l('BRD','BRD','JPN'), 1e-05);
-X.l('BRD','BRD','USA') = max(X.l('BRD','BRD','USA'), 1e-05);
-X.l('BRD','MLK','JPN') = max(X.l('BRD','MLK','JPN'), 1e-05);
-X.l('BRD','MLK','USA') = max(X.l('BRD','MLK','USA'), 1e-05);
-X.l('MLK','BRD','JPN') = max(X.l('MLK','BRD','JPN'), 1e-05);
-X.l('MLK','BRD','USA') = max(X.l('MLK','BRD','USA'), 1e-05);
-X.l('MLK','MLK','JPN') = max(X.l('MLK','MLK','JPN'), 1e-05);
-X.l('MLK','MLK','USA') = max(X.l('MLK','MLK','USA'), 1e-05);
+X.l("BRD","BRD","JPN") = max(X.l("BRD","BRD","JPN"), 1e-05);
+X.l("BRD","BRD","USA") = max(X.l("BRD","BRD","USA"), 1e-05);
+X.l("BRD","MLK","JPN") = max(X.l("BRD","MLK","JPN"), 1e-05);
+X.l("BRD","MLK","USA") = max(X.l("BRD","MLK","USA"), 1e-05);
+X.l("MLK","BRD","JPN") = max(X.l("MLK","BRD","JPN"), 1e-05);
+X.l("MLK","BRD","USA") = max(X.l("MLK","BRD","USA"), 1e-05);
+X.l("MLK","MLK","JPN") = max(X.l("MLK","MLK","JPN"), 1e-05);
+X.l("MLK","MLK","USA") = max(X.l("MLK","MLK","USA"), 1e-05);
 Z.l(j,r) = Z0(j,r);
-Z.l('BRD','JPN') = max(Z.l('BRD','JPN'), 1e-05);
-Z.l('BRD','USA') = max(Z.l('BRD','USA'), 1e-05);
-Z.l('MLK','JPN') = max(Z.l('MLK','JPN'), 1e-05);
-Z.l('MLK','USA') = max(Z.l('MLK','USA'), 1e-05);
+Z.l("BRD","JPN") = max(Z.l("BRD","JPN"), 1e-05);
+Z.l("BRD","USA") = max(Z.l("BRD","USA"), 1e-05);
+Z.l("MLK","JPN") = max(Z.l("MLK","JPN"), 1e-05);
+Z.l("MLK","USA") = max(Z.l("MLK","USA"), 1e-05);
 Xp.l(i,r) = Xp0(i,r);
-Xp.l('BRD','JPN') = max(Xp.l('BRD','JPN'), 1e-05);
-Xp.l('BRD','USA') = max(Xp.l('BRD','USA'), 1e-05);
-Xp.l('MLK','JPN') = max(Xp.l('MLK','JPN'), 1e-05);
-Xp.l('MLK','USA') = max(Xp.l('MLK','USA'), 1e-05);
+Xp.l("BRD","JPN") = max(Xp.l("BRD","JPN"), 1e-05);
+Xp.l("BRD","USA") = max(Xp.l("BRD","USA"), 1e-05);
+Xp.l("MLK","JPN") = max(Xp.l("MLK","JPN"), 1e-05);
+Xp.l("MLK","USA") = max(Xp.l("MLK","USA"), 1e-05);
 Xg.l(i,r) = Xg0(i,r);
-Xg.l('BRD','JPN') = max(Xg.l('BRD','JPN'), 1e-05);
-Xg.l('BRD','USA') = max(Xg.l('BRD','USA'), 1e-05);
-Xg.l('MLK','JPN') = max(Xg.l('MLK','JPN'), 1e-05);
-Xg.l('MLK','USA') = max(Xg.l('MLK','USA'), 1e-05);
+Xg.l("BRD","JPN") = max(Xg.l("BRD","JPN"), 1e-05);
+Xg.l("BRD","USA") = max(Xg.l("BRD","USA"), 1e-05);
+Xg.l("MLK","JPN") = max(Xg.l("MLK","JPN"), 1e-05);
+Xg.l("MLK","USA") = max(Xg.l("MLK","USA"), 1e-05);
 Xv.l(i,r) = Xv0(i,r);
-Xv.l('BRD','JPN') = max(Xv.l('BRD','JPN'), 1e-05);
-Xv.l('BRD','USA') = max(Xv.l('BRD','USA'), 1e-05);
-Xv.l('MLK','JPN') = max(Xv.l('MLK','JPN'), 1e-05);
-Xv.l('MLK','USA') = max(Xv.l('MLK','USA'), 1e-05);
+Xv.l("BRD","JPN") = max(Xv.l("BRD","JPN"), 1e-05);
+Xv.l("BRD","USA") = max(Xv.l("BRD","USA"), 1e-05);
+Xv.l("MLK","JPN") = max(Xv.l("MLK","JPN"), 1e-05);
+Xv.l("MLK","USA") = max(Xv.l("MLK","USA"), 1e-05);
 E.l(i,r) = E0(i,r);
-E.l('BRD','JPN') = max(E.l('BRD','JPN'), 1e-05);
-E.l('BRD','USA') = max(E.l('BRD','USA'), 1e-05);
-E.l('MLK','JPN') = max(E.l('MLK','JPN'), 1e-05);
-E.l('MLK','USA') = max(E.l('MLK','USA'), 1e-05);
+E.l("BRD","JPN") = max(E.l("BRD","JPN"), 1e-05);
+E.l("BRD","USA") = max(E.l("BRD","USA"), 1e-05);
+E.l("MLK","JPN") = max(E.l("MLK","JPN"), 1e-05);
+E.l("MLK","USA") = max(E.l("MLK","USA"), 1e-05);
 M.l(i,r) = M0(i,r);
-M.l('BRD','JPN') = max(M.l('BRD','JPN'), 1e-05);
-M.l('BRD','USA') = max(M.l('BRD','USA'), 1e-05);
-M.l('MLK','JPN') = max(M.l('MLK','JPN'), 1e-05);
-M.l('MLK','USA') = max(M.l('MLK','USA'), 1e-05);
+M.l("BRD","JPN") = max(M.l("BRD","JPN"), 1e-05);
+M.l("BRD","USA") = max(M.l("BRD","USA"), 1e-05);
+M.l("MLK","JPN") = max(M.l("MLK","JPN"), 1e-05);
+M.l("MLK","USA") = max(M.l("MLK","USA"), 1e-05);
 Q.l(i,r) = Q0(i,r);
-Q.l('BRD','JPN') = max(Q.l('BRD','JPN'), 1e-05);
-Q.l('BRD','USA') = max(Q.l('BRD','USA'), 1e-05);
-Q.l('MLK','JPN') = max(Q.l('MLK','JPN'), 1e-05);
-Q.l('MLK','USA') = max(Q.l('MLK','USA'), 1e-05);
+Q.l("BRD","JPN") = max(Q.l("BRD","JPN"), 1e-05);
+Q.l("BRD","USA") = max(Q.l("BRD","USA"), 1e-05);
+Q.l("MLK","JPN") = max(Q.l("MLK","JPN"), 1e-05);
+Q.l("MLK","USA") = max(Q.l("MLK","USA"), 1e-05);
 D.l(i,r) = D0(i,r);
-D.l('BRD','JPN') = max(D.l('BRD','JPN'), 1e-05);
-D.l('BRD','USA') = max(D.l('BRD','USA'), 1e-05);
-D.l('MLK','JPN') = max(D.l('MLK','JPN'), 1e-05);
-D.l('MLK','USA') = max(D.l('MLK','USA'), 1e-05);
-pf.l('CAP','JPN') = 1.0;
-pf.l('CAP','USA') = 1.0;
-pf.l('LAB','JPN') = 1.0;
-pf.l('LAB','USA') = 1.0;
-py.l('BRD','JPN') = 1.0;
-py.l('BRD','USA') = 1.0;
-py.l('MLK','JPN') = 1.0;
-py.l('MLK','USA') = 1.0;
-pz.l('BRD','JPN') = 1.0;
-pz.l('BRD','USA') = 1.0;
-pz.l('MLK','JPN') = 1.0;
-pz.l('MLK','USA') = 1.0;
-pq.l('BRD','JPN') = 1.0;
-pq.l('BRD','USA') = 1.0;
-pq.l('MLK','JPN') = 1.0;
-pq.l('MLK','USA') = 1.0;
-pe.l('BRD','JPN') = 1.0;
-pe.l('BRD','USA') = 1.0;
-pe.l('MLK','JPN') = 1.0;
-pe.l('MLK','USA') = 1.0;
-pm.l('BRD','JPN') = 1.0;
-pm.l('BRD','USA') = 1.0;
-pm.l('MLK','JPN') = 1.0;
-pm.l('MLK','USA') = 1.0;
-pd.l('BRD','JPN') = 1.0;
-pd.l('BRD','USA') = 1.0;
-pd.l('MLK','JPN') = 1.0;
-pd.l('MLK','USA') = 1.0;
-epsilon.l('JPN') = 1.0;
-epsilon.l('USA') = 1.0;
-pWe.l('BRD','JPN') = 1.0;
-pWe.l('BRD','USA') = 1.0;
-pWe.l('MLK','JPN') = 1.0;
-pWe.l('MLK','USA') = 1.0;
-pWm.l('BRD','JPN') = 1.0;
-pWm.l('BRD','USA') = 1.0;
-pWm.l('MLK','JPN') = 1.0;
-pWm.l('MLK','USA') = 1.0;
+D.l("BRD","JPN") = max(D.l("BRD","JPN"), 1e-05);
+D.l("BRD","USA") = max(D.l("BRD","USA"), 1e-05);
+D.l("MLK","JPN") = max(D.l("MLK","JPN"), 1e-05);
+D.l("MLK","USA") = max(D.l("MLK","USA"), 1e-05);
+pf.l("CAP","JPN") = 1.0;
+pf.l("CAP","USA") = 1.0;
+pf.l("LAB","JPN") = 1.0;
+pf.l("LAB","USA") = 1.0;
+py.l("BRD","JPN") = 1.0;
+py.l("BRD","USA") = 1.0;
+py.l("MLK","JPN") = 1.0;
+py.l("MLK","USA") = 1.0;
+pz.l("BRD","JPN") = 1.0;
+pz.l("BRD","USA") = 1.0;
+pz.l("MLK","JPN") = 1.0;
+pz.l("MLK","USA") = 1.0;
+pq.l("BRD","JPN") = 1.0;
+pq.l("BRD","USA") = 1.0;
+pq.l("MLK","JPN") = 1.0;
+pq.l("MLK","USA") = 1.0;
+pe.l("BRD","JPN") = 1.0;
+pe.l("BRD","USA") = 1.0;
+pe.l("MLK","JPN") = 1.0;
+pe.l("MLK","USA") = 1.0;
+pm.l("BRD","JPN") = 1.0;
+pm.l("BRD","USA") = 1.0;
+pm.l("MLK","JPN") = 1.0;
+pm.l("MLK","USA") = 1.0;
+pd.l("BRD","JPN") = 1.0;
+pd.l("BRD","USA") = 1.0;
+pd.l("MLK","JPN") = 1.0;
+pd.l("MLK","USA") = 1.0;
+epsilon.l("JPN") = 1.0;
+epsilon.l("USA") = 1.0;
+pWe.l("BRD","JPN") = 1.0;
+pWe.l("BRD","USA") = 1.0;
+pWe.l("MLK","JPN") = 1.0;
+pWe.l("MLK","USA") = 1.0;
+pWm.l("BRD","JPN") = 1.0;
+pWm.l("BRD","USA") = 1.0;
+pWm.l("MLK","JPN") = 1.0;
+pWm.l("MLK","USA") = 1.0;
 Sp.l(r) = Sp0(r);
-Sp.l('JPN') = max(Sp.l('JPN'), 1e-05);
-Sp.l('USA') = max(Sp.l('USA'), 1e-05);
+Sp.l("JPN") = max(Sp.l("JPN"), 1e-05);
+Sp.l("USA") = max(Sp.l("USA"), 1e-05);
 Sg.l(r) = Sg0(r);
-Sg.l('JPN') = max(Sg.l('JPN'), 1e-05);
-Sg.l('USA') = max(Sg.l('USA'), 1e-05);
+Sg.l("JPN") = max(Sg.l("JPN"), 1e-05);
+Sg.l("USA") = max(Sg.l("USA"), 1e-05);
 Td.l(r) = Td0(r);
-Td.l('JPN') = max(Td.l('JPN'), 1e-05);
-Td.l('USA') = max(Td.l('USA'), 1e-05);
+Td.l("JPN") = max(Td.l("JPN"), 1e-05);
+Td.l("USA") = max(Td.l("USA"), 1e-05);
 Tz.l(i,r) = Tz0(i,r);
 Tm.l(i,r) = Tm0(i,r);
 
@@ -470,32 +462,32 @@ Alias(i, i__);
 * Stationarity equations
 stat_d(i,r).. ((-1) * (gamma(i, r) * (deltam(i,r) * m(i,r) ** eta(i) + deltad(i,r) * d(i,r) ** eta(i)) ** (1 / eta(i)) * 1 / eta(i) / (deltam(i,r) * m(i,r) ** eta(i) + deltad(i,r) * d(i,r) ** eta(i)) * deltad(i,r) * d(i,r) ** eta(i) * eta(i) / d(i,r))) * nu_eqpqs(i,r) + nu_eqD(i,r) + ((-1) * (theta(i,r) * (xie(i,r) * e(i,r) ** phi(i) + xid(i,r) * d(i,r) ** phi(i)) ** (1 / phi(i)) * 1 / phi(i) / (xie(i,r) * e(i,r) ** phi(i) + xid(i,r) * d(i,r) ** phi(i)) * xid(i,r) * d(i,r) ** phi(i) * phi(i) / d(i,r))) * nu_eqpzd(i,r) + nu_eqDs(i,r) - piL_d(i,r) =E= 0;
 stat_e(i,r).. pwe(i,r) * nu_eqepsilon(r) + ((-1) * (theta(i,r) * (xie(i,r) * e(i,r) ** phi(i) + xid(i,r) * d(i,r) ** phi(i)) ** (1 / phi(i)) * 1 / phi(i) / (xie(i,r) * e(i,r) ** phi(i) + xid(i,r) * d(i,r) ** phi(i)) * xie(i,r) * e(i,r) ** phi(i) * phi(i) / e(i,r))) * nu_eqpzd(i,r) + nu_eqE(i,r) - piL_e(i,r) =E= 0;
-stat_epsilon(r).. sum(i, ((-1) * (pq(i,r) * lambda(i,r) * Sf(r) / sqr(pq(i,r)))) * nu_eqXv(i,r)) + sum(i, ((-1) * pwe(i,r)) * nu_eqpe(i,r)) + sum(i, ((-1) * pwm(i,r)) * nu_eqpm(i,r)) + nu_epsilon_fx_USA$(sameas(r, 'USA')) - piL_epsilon(r) =E= 0;
+stat_epsilon(r).. sum(i, ((-1) * (pq(i,r) * lambda(i,r) * Sf(r) / sqr(pq(i,r)))) * nu_eqXv(i,r)) + sum(i, ((-1) * pwe(i,r)) * nu_eqpe(i,r)) + sum(i, ((-1) * pwm(i,r)) * nu_eqpm(i,r)) + nu_epsilon_fx_USA$sameas(r, 'USA') - piL_epsilon(r) =E= 0;
 stat_f(h,j,r).. ((-1) * (b(j,r) * prod(h__, f(h__,j,r) ** beta(h__,j,r)) * sum(h__, f(h__,j,r) ** beta(h__,j,r) * beta(h__,j,r) / f(h__,j,r) / f(h__,j,r) ** beta(h__,j,r)))) * nu_eqpy(j,r) + nu_eqF(h,j,r) - nu_eqpf(h,r) - piL_f(h,j,r) =E= 0;
 stat_m(i,r).. ((-1) * (taum(i,r) * pm(i,r))) * nu_eqTm(i,r) + ((-1) * pwm(i,r)) * nu_eqepsilon(r) + ((-1) * (gamma(i, r) * (deltam(i,r) * m(i,r) ** eta(i) + deltad(i,r) * d(i,r) ** eta(i)) ** (1 / eta(i)) * 1 / eta(i) / (deltam(i,r) * m(i,r) ** eta(i) + deltad(i,r) * d(i,r) ** eta(i)) * deltam(i,r) * m(i,r) ** eta(i) * eta(i) / m(i,r))) * nu_eqpqs(i,r) + nu_eqM(i,r) - piL_m(i,r) =E= 0;
 stat_pd(i,r).. ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) * ((-1) * (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r))) / sqr(pd(i,r)))) * nu_eqD(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) * ((-1) * (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r))) / sqr(pd(i,r)))) * nu_eqDs(i,r) - piL_pd(i,r) =E= 0;
 stat_pe(i,r).. nu_eqpe(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) * ((-1) * (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r))) / sqr(pe(i,r)))) * nu_eqE(i,r) - piL_pe(i,r) =E= 0;
 stat_pf(h,r).. sum(j, ((-1) * (((-1) * (beta(h,j,r) * py(j,r) * y(j,r))) / sqr(pf(h,r)))) * nu_eqF(h,j,r)) + ((-1) * (taud(r) * FF(h,r))) * nu_eqTd(r) + ((-1) * (ssp(r) * FF(h,r))) * nu_eqSp(r) + sum(i, ((-1) * (pq(i,r) * alpha(i,r) * FF(h,r) / sqr(pq(i,r)))) * nu_eqXp(i,r)) + nu_pf_fx_LAB_JPN$(sameas(h, 'LAB') and sameas(r, 'JPN')) + nu_pf_fx_LAB_USA$(sameas(h, 'LAB') and sameas(r, 'USA')) - piL_pf(h,r) =E= 0;
 stat_pm(i,r).. ((-1) * (m(i,r) * taum(i,r))) * nu_eqTm(i,r) + nu_eqpm(i,r) + ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) * ((-1) * (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) * (1 + taum(i,r)))) / sqr((1 + taum(i,r)) * pm(i,r)))) * nu_eqM(i,r) - piL_pm(i,r) =E= 0;
-stat_pq(i,r).. ((-1) * ax(i,i,r)) * nu_eqpzs(i,r) + (((-1) * ax(i,i,r)) * nu_eqpzs(i+1,r))$(ord(i) <= card(i) - 1) + (((-1) * ax(i,i,r)) * nu_eqpzs(i-1,r))$(ord(i) > 1) + ((-1) * (((-1) * (mu(i,r) * (td(r) + sum(j, tz(j,r)) + sum(j, tm(j,r)) - sg(r)))) / sqr(pq(i,r)))) * nu_eqXg(i,r) + ((-1) * (((-1) * (lambda(i,r) * (sp(r) + sg(r) + epsilon(r) * Sf(r)))) / sqr(pq(i,r)))) * nu_eqXv(i,r) + ((-1) * (((-1) * (alpha(i,r) * (sum(h, pf(h,r) * FF(h,r)) - sp(r) - td(r)))) / sqr(pq(i,r)))) * nu_eqXp(i,r) + ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) * (1 + taum(i,r)) * pm(i,r) * gamma(i, r) ** eta(i) * deltam(i,r) / sqr((1 + taum(i,r)) * pm(i,r)))) * nu_eqM(i,r) + ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) * pd(i,r) * gamma(i, r) ** eta(i) * deltad(i,r) / sqr(pd(i,r)))) * nu_eqD(i,r) - piL_pq(i,r) =E= 0;
+stat_pq(i,r).. sum(j, ((-1) * ax(i,j,r)) * nu_eqpzs(j,r)) + ((-1) * (((-1) * (mu(i,r) * (td(r) + sum(j, tz(j,r)) + sum(j, tm(j,r)) - sg(r)))) / sqr(pq(i,r)))) * nu_eqXg(i,r) + ((-1) * (((-1) * (lambda(i,r) * (sp(r) + sg(r) + epsilon(r) * Sf(r)))) / sqr(pq(i,r)))) * nu_eqXv(i,r) + ((-1) * (((-1) * (alpha(i,r) * (sum(h, pf(h,r) * FF(h,r)) - sp(r) - td(r)))) / sqr(pq(i,r)))) * nu_eqXp(i,r) + ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) * (1 + taum(i,r)) * pm(i,r) * gamma(i, r) ** eta(i) * deltam(i,r) / sqr((1 + taum(i,r)) * pm(i,r)))) * nu_eqM(i,r) + ((-1) * (q(i,r) * (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) ** (1 / (1 - eta(i))) * 1 / (1 - eta(i)) / (gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) * pd(i,r) * gamma(i, r) ** eta(i) * deltad(i,r) / sqr(pd(i,r)))) * nu_eqD(i,r) - piL_pq(i,r) =E= 0;
 stat_pwe(i,r).. ((-1) * epsilon(r)) * nu_eqpe(i,r) + e(i,r) * nu_eqepsilon(r) - piL_pwe(i,r) =E= 0;
 stat_pwm(i,r).. ((-1) * epsilon(r)) * nu_eqpm(i,r) + ((-1) * m(i,r)) * nu_eqepsilon(r) - piL_pwm(i,r) =E= 0;
 stat_py(j,r).. sum(h, ((-1) * (pf(h,r) * y(j,r) * beta(h,j,r) / sqr(pf(h,r)))) * nu_eqF(h,j,r)) + ((-1) * ay(j,r)) * nu_eqpzs(j,r) - piL_py(j,r) =E= 0;
-stat_pz(i,r).. nu_eqpzs(i,r) + ((-1) * (z(i,r) * tauz(i,r))) * nu_eqTz(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) * pe(i,r) * theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) / sqr(pe(i,r)))) * nu_eqE(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) * pd(i,r) * theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) / sqr(pd(i,r)))) * nu_eqDs(i,r) - piL_pz(i,r) =E= 0;
+stat_pz(i,r).. sum(j, nu_eqpzs(j,r)) + ((-1) * (z(i,r) * tauz(i,r))) * nu_eqTz(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) * pe(i,r) * theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) / sqr(pe(i,r)))) * nu_eqE(i,r) + ((-1) * (z(i,r) * (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) ** (1 / (1 - phi(i))) * 1 / (1 - phi(i)) / (theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) * pd(i,r) * theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) / sqr(pd(i,r)))) * nu_eqDs(i,r) - piL_pz(i,r) =E= 0;
 stat_q(i,r).. nu_eqpqs(i,r) + ((-1) * ((gamma(i, r) ** eta(i) * deltam(i,r) * pq(i,r) / ((1 + taum(i,r)) * pm(i,r))) ** (1 / (1 - eta(i))))) * nu_eqM(i,r) + ((-1) * ((gamma(i, r) ** eta(i) * deltad(i,r) * pq(i,r) / pd(i,r)) ** (1 / (1 - eta(i))))) * nu_eqD(i,r) + nu_eqpqd(i,r) - piL_q(i,r) =E= 0;
 stat_sg(r).. sum(i, ((-1) * (pq(i,r) * mu(i,r) * (-1) / sqr(pq(i,r)))) * nu_eqXg(i,r)) + sum(i, ((-1) * (pq(i,r) * lambda(i,r) / sqr(pq(i,r)))) * nu_eqXv(i,r)) + nu_eqSg(r) - piL_sg(r) =E= 0;
 stat_sp(r).. sum(i, ((-1) * (pq(i,r) * lambda(i,r) / sqr(pq(i,r)))) * nu_eqXv(i,r)) + nu_eqSp(r) + sum(i, ((-1) * (pq(i,r) * alpha(i,r) * (-1) / sqr(pq(i,r)))) * nu_eqXp(i,r)) - piL_sp(r) =E= 0;
 stat_sw.. 0 =E= 0;
 stat_td(r).. nu_eqTd(r) + sum(i, ((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i,r)) + ((-1) * ssg(r)) * nu_eqSg(r) + sum(i, ((-1) * (pq(i,r) * alpha(i,r) * (-1) / sqr(pq(i,r)))) * nu_eqXp(i,r)) - piL_td(r) =E= 0;
-stat_tm(i,r).. nu_eqTm(i,r) + ((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i,r) + (((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i+1,r))$(ord(i) <= card(i) - 1) + (((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i-1,r))$(ord(i) > 1) + ((-1) * ssg(r)) * nu_eqSg(r) - piL_tm(i,r) =E= 0;
-stat_tz(j,r).. nu_eqTz(j,r) + ((-1) * (pq(j,r) * mu(j,r) / sqr(pq(j,r)))) * nu_eqXg(j,r) + (((-1) * (pq(j,r) * mu(j,r) / sqr(pq(j,r)))) * nu_eqXg(j+1,r))$(ord(j) <= card(j) - 1) + (((-1) * (pq(j,r) * mu(j,r) / sqr(pq(j,r)))) * nu_eqXg(j-1,r))$(ord(j) > 1) + ((-1) * ssg(r)) * nu_eqSg(r) - piL_tz(j,r) =E= 0;
+stat_tm(i,r).. nu_eqTm(i,r) + ((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i,r) + ((-1) * ssg(r)) * nu_eqSg(r) - piL_tm(i,r) =E= 0;
+stat_tz(j,r).. sum(i, nu_eqTz(i,r)) + sum(i, ((-1) * (pq(i,r) * mu(i,r) / sqr(pq(i,r)))) * nu_eqXg(i,r)) + ((-1) * ssg(r)) * nu_eqSg(r) - piL_tz(j,r) =E= 0;
 stat_uu(r).. -1 + nu_eqUU(r) =E= 0;
 stat_x(i,j,r).. nu_eqX(i,j,r) - piL_x(i,j,r) =E= 0;
 stat_xg(i,r).. nu_eqXg(i,r) - nu_eqpqd(i,r) - piL_xg(i,r) =E= 0;
 stat_xp(i,r).. nu_eqXp(i,r) - nu_eqpqd(i,r) + ((-1) * (prod(i__, xp(i__,r) ** alpha(i__,r)) * sum(i__, xp(i__,r) ** alpha(i__,r) * alpha(i__,r) / xp(i__,r) / xp(i__,r) ** alpha(i__,r)))) * nu_eqUU(r) - piL_xp(i,r) =E= 0;
 stat_xv(i,r).. nu_eqXv(i,r) - nu_eqpqd(i,r) - piL_xv(i,r) =E= 0;
 stat_y(j,r).. nu_eqpy(j,r) + nu_eqY(j,r) + sum(h, ((-1) * (pf(h,r) * beta(h,j,r) * py(j,r) / sqr(pf(h,r)))) * nu_eqF(h,j,r)) - piL_y(j,r) =E= 0;
-stat_z(j,r).. sum(i, ((-1) * ax(i,j,r)) * nu_eqX(i,j,r)) + ((-1) * ay(j,r)) * nu_eqY(j,r) + ((-1) * (tauz(j,r) * pz(j,r))) * nu_eqTz(j,r) + nu_eqpzd(j,r) + ((-1) * ((theta(j,r) ** phi(j) * xie(j,r) * (1 + tauz(j,r)) * pz(j,r) / pe(j,r)) ** (1 / (1 - phi(j))))) * nu_eqE(j,r) + ((-1) * ((theta(j,r) ** phi(j) * xid(j,r) * (1 + tauz(j,r)) * pz(j,r) / pd(j,r)) ** (1 / (1 - phi(j))))) * nu_eqDs(j,r) - piL_z(j,r) =E= 0;
+stat_z(j,r).. sum(i, ((-1) * ax(i,j,r)) * nu_eqX(i,j,r)) + ((-1) * ay(j,r)) * nu_eqY(j,r) + sum(i, ((-1) * (tauz(i,r) * pz(i,r))) * nu_eqTz(i,r)) + sum(i, nu_eqpzd(i,r)) + sum(i, ((-1) * ((theta(i,r) ** phi(i) * xie(i,r) * (1 + tauz(i,r)) * pz(i,r) / pe(i,r)) ** (1 / (1 - phi(i))))) * nu_eqE(i,r)) + sum(i, ((-1) * ((theta(i,r) ** phi(i) * xid(i,r) * (1 + tauz(i,r)) * pz(i,r) / pd(i,r)) ** (1 / (1 - phi(i))))) * nu_eqDs(i,r)) - piL_z(j,r) =E= 0;
 
 * Lower bound complementarity equations
 comp_lo_d(i,r).. d(i,r) - 1e-05 =G= 0;

--- a/tests/integration/emit/test_fx_complementarity.py
+++ b/tests/integration/emit/test_fx_complementarity.py
@@ -153,7 +153,10 @@ class TestCallBasedParameterDetection:
         gamma_assignment_lines = [
             ln
             for ln in lines
-            if "gamma(i)" in ln and "=" in ln and "stat_" not in ln and ".." not in ln
+            if ln.lstrip().startswith("gamma(i)")
+            and "=" in ln
+            and "stat_" not in ln
+            and ".." not in ln
         ]
         assert (
             len(gamma_assignment_lines) > 0


### PR DESCRIPTION
## Summary

- Fix `_collect_model_relevant_params()` in `emit_gams.py` to detect parameters referenced via `Call` nodes (parser treats `gamma(i)` as `Call(func="gamma")` instead of `ParamRef`)
- stdcge now compiles and solves optimally (MODEL STATUS 1, obj=25.508)
- twocge compiles without $66 error (locally infeasible is a pre-existing issue #970)
- Regenerated MCP files for both models

## Test plan

- [x] Integration test: `TestCallBasedParameterDetection::test_stdcge_gamma_assignment_emitted` verifies gamma assignment appears in MCP output
- [x] Quality gate: 4141 tests pass, typecheck/lint/format clean
- [x] Manual verification: stdcge solves optimally, twocge compiles