### PR TITLE
Sprint 23 Prep Task 7: Catalog translate failures

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_23/CATALOG_TRANSLATE_FAILURES.md
+++ b/docs/planning/EPIC_4/SPRINT_23/CATALOG_TRANSLATE_FAILURES.md
@@ -25,7 +25,7 @@ Sprint 23 target: ≥ 145/156 (≥ 93%). This requires fixing **2 of 13** failur
 | **C: Missing IR feature** (LhsConditionalAssign) | 4 | agreste, ampl, cesam, korcge | Fixable — add emitter support for LhsConditionalAssign |
 | **D: Internal error** | 2 | mexls, mine | Fixable — specific code fixes needed |
 
-**Key finding:** The 4 LhsConditionalAssign models share a single root cause (missing `expr_to_gams()` handler). Fixing this one handler would recover all 4, exceeding the ≥ 145 target by 4 models (→ 147/156 = 94.2%). The 2 internal errors are also individually fixable. The 7 timeouts are architecturally intractable in Sprint 23.
+**Key finding:** The 4 LhsConditionalAssign models share a single root cause (missing statement-level emission support, currently falling through to `expr_to_gams()` and raising). Fixing this emission path would recover all 4, exceeding the ≥ 145 target by 2 models (→ 147/156 = 94.2%). The 2 internal errors are also individually fixable. The 7 timeouts are architecturally intractable in Sprint 23.
 
 ---
 
@@ -90,10 +90,12 @@ The node was introduced in Issue #1015 (shale model fix) and is correctly constr
 
 Handle `LhsConditionalAssign` at the **statement/assignment emission layer**, not in `expr_to_gams()`. The LHS-conditional semantics (`lhs$(cond) = rhs`, where false leaves the record unchanged) must be preserved — simply emitting `rhs$cond` would produce RHS-dollar semantics (assigns 0 where false), which is semantically wrong.
 
-The fix should intercept `LhsConditionalAssign` nodes in the assignment emitter (e.g., `original_symbols.py` or `emit_assignments.py`) and emit the condition on the LHS:
+The fix should intercept `LhsConditionalAssign` nodes in the assignment emitter (e.g., `original_symbols.py` or `emit_assignments.py`) and emit the condition on the LHS, using the assignment's existing target/indices for the LHS and the `LhsConditionalAssign` node's `condition` and `rhs` fields:
 ```python
+# `target`/`indices` come from the surrounding assignment context;
+# `node` is a LhsConditionalAssign providing only `condition` and `rhs`.
 # Emit as: lhs$(condition) = rhs;
-lhs_str = emit_lhs(node.target, node.indices)
+lhs_str = emit_lhs(target, indices)
 cond_str = expr_to_gams(node.condition, ...)
 rhs_str = expr_to_gams(node.rhs, ...)
 emit(f"{lhs_str}$({cond_str}) = {rhs_str};")

--- a/docs/planning/EPIC_4/SPRINT_23/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_23/KNOWN_UNKNOWNS.md
@@ -546,7 +546,7 @@ This document catalogs assumptions and unknowns for Sprint 23 (Solve Rate Push &
 
 **Estimated Research Time:** 1h (part of Task 7 catalog)
 **Owner:** Task 7 (translate failures catalog)
-**Verification Results:** ✅ VERIFIED — Of 13 remaining translate failures (not 15 — ferts, turkpow, clearlak recovered), the 6 non-timeout models (4 LhsConditionalAssign + 2 internal errors) are higher leverage than the 7 timeouts. The 4 LhsConditionalAssign models share a single root cause (missing `expr_to_gams()` handler, 2-3h fix) and would recover all 4 models. The 7 timeouts require architectural Jacobian changes. No compilation errors in the traditional sense — failures are either missing feature (C) or internal error (D), both fixable.
+**Verification Results:** ✅ VERIFIED — Of 13 remaining translate failures (not 15 — ferts, turkpow, clearlak recovered), the 6 non-timeout models (4 LhsConditionalAssign + 2 internal errors) are higher leverage than the 7 timeouts. The 4 LhsConditionalAssign models share a single root cause (missing statement-level emission support; currently falls through to `expr_to_gams()` and raises) and would recover all 4 models with a 2-3h fix. The 7 timeouts require architectural Jacobian changes. No compilation errors in the traditional sense — failures are either missing feature (C) or internal error (D), both fixable.
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_23/PREP_PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_23/PREP_PLAN.md
@@ -600,8 +600,8 @@ Sprint 23 targets reducing translate failures from 13 to ≤ 11 (≥ 145/156). W
 - Mix of timeouts (7), missing IR features (4), and internal errors (2) — no traditional compilation errors
 - Sprint 23 acceptance criterion: ≥ 93% of parsed models (≥ 145/156 assuming 156 parsed)
 - Pipeline retest script: `.venv/bin/python scripts/gamslib/run_full_test.py`
-- Related issues: #940 (mexls universal set), #1062 (tricp), #830 (gastrans Jacobian timeout), #885 (sarf timeout)
-- ~~#952 (lmp2), #953 (paperco)~~ — refuted by KU-25: these are NOT translate failures (both translate successfully; fail at solve)
+- Related issues: #940 (mexls universal set), #830 (gastrans Jacobian timeout), #885 (sarf timeout)
+- ~~#952 (lmp2), #953 (paperco), #1062 (tricp)~~ — not translate failures (lmp2/paperco refuted by KU-25; tricp is path_syntax_error Priority 4)
 
 ### What Needs to Be Done
 


### PR DESCRIPTION
## Summary
- Catalog all 13 translate failures with classification and error details (revised from 15 — ferts, turkpow, clearlak recovered)
- Classification: 7 timeout (B), 4 missing IR feature (C: LhsConditionalAssign), 2 internal error (D)
- Key finding: single LhsConditionalAssign handler fix (2-3h) recovers 4 models → 147/156 (94.2%), exceeding ≥145 target
- Verify 4 Known Unknowns: KU-22 (VERIFIED), KU-23 (VERIFIED), KU-24 (REFUTED), KU-25 (REFUTED)

## Deliverables
- `docs/planning/EPIC_4/SPRINT_23/CATALOG_TRANSLATE_FAILURES.md`
- Updated `KNOWN_UNKNOWNS.md` with KU-22–KU-25 verification results
- Updated `PREP_PLAN.md` Task 7 marked COMPLETE

## Test plan
- [x] All 13 translate failures identified by name
- [x] Each classified with error details (timeout/missing feature/internal error)
- [x] Top fix identified: LhsConditionalAssign handler recovers 4 models in 2-3h
- [x] KU verification results complete in KNOWN_UNKNOWNS.md Appendix C
- [x] PREP_PLAN.md Task 7 acceptance criteria all checked