### PR TITLE
Sprint 23 Day 0: Baseline Confirm + Sprint Kickoff

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_23/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_23/SPRINT_LOG.md
@@ -84,12 +84,12 @@
 
 **Pipeline Results (147-scope, clean re-run):**
 
-| Stage | This Run | Baseline | Match |
+| Stage | This Run | Baseline (BASELINE_METRICS.md §4) | Status |
 |---|---|---|---|
-| Parse | 144/147 (98.0%) | 144/147 (98.0%) | ✅ |
-| Translate | 128/144 (88.9%) | 127-128/144 | ✅ |
-| Solve | 81/128 (63.3%) | 81 | ✅ |
-| Match | 47/147 (32.0%) | 47/147 (32.0%) | ✅ |
+| Parse | 144/147 (98.0%) | 144/147 (98.0%) | ✅ Exact match |
+| Translate | 128/144 (88.9%) | 127/144 (88.2%) | +1 borderline timeout variance |
+| Solve | 81/128 (63.3%) | 81/127 (63.8%) | ✅ Same solve count (denominator differs due to +1 translate) |
+| Match | 47/147 (32.0%) | 47/147 (32.0%) | ✅ Exact match |
 
 **Solve Error Categories (147-scope; matches BASELINE_METRICS.md §5 after removing feedtray which is excluded):**
 


### PR DESCRIPTION
## Summary

Completes Sprint 23 Day 0 — baseline confirmation and sprint kickoff.

- **make test**: 4,209 passed, 10 skipped, 1 xfailed (matches baseline)
- **Full pipeline**: Metrics match BASELINE_METRICS.md (parse 144/147, translate 128/144 vs baseline 127/144 (+1 borderline timeout variance), solve 81, match 47/147)
- **Solve errors confirmed**: path_syntax_error 18, model_infeasible 12, path_solve_terminated 10, path_solve_license 7
- **Issue mapping**: 24 open sprint-23 issues confirmed against PLAN.md workstream table
- **SPRINT_LOG.md**: Initialized with start date (2026-03-21), baseline commit (`main @ 2c33989e` for metrics, kickoff from `main @ 89ff673e` after prep merge), pipeline results, and Day 0 status

## Test plan

- [ ] SPRINT_LOG.md Day 0 status is COMPLETE with all tasks checked
- [ ] Pipeline results table references BASELINE_METRICS.md section 4 values
- [ ] Start date and baseline commit are correct
- [ ] No code changes (doc-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)