### PR TITLE
Sprint 23 Day 2: Alias-aware differentiation (#1111)

### DIFF
--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -272,6 +272,7 @@ def _alias_match(
         return None
 
     guards: list[Expr] = []
+    bound_lower = {b.lower() for b in bound_indices}
     for expr_idx, wrt_idx in zip(expr_indices, wrt_indices, strict=True):
         # IndexOffset dimensions (lead/lag like t+1) require full structural
         # equality — alias matching by base name alone would incorrectly treat
@@ -295,7 +296,7 @@ def _alias_match(
 
         # Same root set, but different names — alias relationship
         # Check if the expr index is a bound iteration variable
-        if expr_str.lower() in {b.lower() for b in bound_indices}:
+        if expr_str.lower() in bound_lower:
             return None  # Bound variable: independent iteration, no match
 
         # Free alias variable: generate sameas() guard

--- a/tests/unit/ad/test_alias_differentiation.py
+++ b/tests/unit/ad/test_alias_differentiation.py
@@ -75,8 +75,14 @@ class TestSameRootSet:
         assert _same_root_set("n", "k", aliases) is False
 
     def test_case_insensitive(self):
-        aliases = {"NP": AliasDef("NP", "n")}
-        assert _same_root_set("n", "NP", aliases) is True
+        """Root set comparison is case-insensitive (resolve returns .lower()).
+
+        Note: case-insensitive dict *lookup* is provided by ModelIR.aliases
+        (CaseInsensitiveDict). Here we test that the resolved root names are
+        compared case-insensitively — "N" and "n" resolve to the same root.
+        """
+        aliases = {"np": AliasDef("np", "N")}  # target is uppercase "N"
+        assert _same_root_set("n", "np", aliases) is True
 
     def test_plain_string_aliases(self):
         """Some test setups use plain strings instead of AliasDef objects."""
@@ -190,6 +196,8 @@ class TestAliasDifferentiation:
         result = differentiate_expr(expr, "p", ("i",), config)
         # Result: sum(j, 0) — the sum is preserved with zero body derivative
         assert isinstance(result, Sum)
+        assert isinstance(result.body, Const)
+        assert result.body.value == 0.0
 
     def test_dispatch_pattern_no_spurious_match(self):
         """dispatch: Alias(i,j); sum((i,j), p(i)*b(i,j)*p(j)) w.r.t. p(i).


### PR DESCRIPTION
## Summary

- Add summation-context tracking (`bound_indices: frozenset[str]`) to the AD engine so alias indices are correctly matched (or rejected) during symbolic differentiation
- Thread `bound_indices` as a keyword-only parameter through `differentiate_expr()` and all 28 `_diff_*` functions (backward compatible — defaults to `frozenset()`)
- Sum/Prod augment `bound_indices` with their `index_sets` before recursing into body expressions
- `_diff_varref()` checks alias match when exact match fails: free alias → `sameas()` guard, bound alias → 0
- Add `_same_root_set()` (alias chain resolution) and `_alias_match()` (per-dimension comparison) helpers
- 19 new unit tests covering helpers, integration, and the critical dispatch regression pattern

## Test plan

- [x] `make typecheck` — passes
- [x] `make lint` — passes
- [x] `make format` — passes
- [x] `make test` — 4,249 passed, 10 skipped, 1 xfailed
- [x] Existing 4,230 tests unchanged (no regressions)
- [x] 19 new tests: `_same_root_set` (6), `_alias_match` (6), integration (7)
- [x] dispatch pattern: bound alias j → returns 0 (no spurious match)
- [x] qabel pattern: free alias np → produces sameas(np,n) guard