### PR TITLE
ISSUE_1164 investigation: chenery/shale subset domain violation

### DIFF
--- a/docs/issues/ISSUE_1164_chenery-subset-domain-violation.md
+++ b/docs/issues/ISSUE_1164_chenery-subset-domain-violation.md
@@ -59,17 +59,17 @@ eq(t).. x(t) + alp(t) =e= 0;          # OK (equation domain matches)
 
 ---
 
-## Fix Approach
+## Fix Approach (Initial Hypothesis — Superseded)
 
-The stationarity builder needs to preserve subset domain indices for parameters and variables declared over subsets:
+> **Note:** The approach below was an initial hypothesis that was disproven during investigation. Simply rewriting `alp(i)` to `alp(t)` inside `stat_e(i)` leads to GAMS $149 (uncontrolled set). See the Investigation section below for the actual findings and the correct path forward.
 
-1. **In `_replace_matching_indices`:** When a parameter's declared domain position uses a subset (e.g., `t`) and the element-to-set mapping returns the superset (e.g., `i`), use the subset name instead.
+~~The stationarity builder needs to preserve subset domain indices for parameters and variables declared over subsets:~~
 
-2. **Alternative:** In `_replace_indices_in_expr`, for ParamRef/VarRef, check if the declared domain at each position is a subset of the equation domain. If so, use the subset name (parameter's declared domain variable) instead of the superset (equation's domain variable).
+~~1. In `_replace_matching_indices`: use subset name instead of superset.~~
+~~2. Alternative: check declared domain and use subset name.~~
+~~3. Key check: `model_ir.sets[t].domain == ('i',)`~~
 
-3. **Key check:** `model_ir.sets[t].domain == ('i',)` → `t` is a subset of `i`. When replacing indices for a ParamRef declared over `(t,)`, use `t` instead of `i`.
-
-**Effort estimate:** 2-3 hours
+**Effort estimate:** 3-5 hours (revised upward — requires domain restructuring, not just index rewriting)
 
 ---
 
@@ -94,7 +94,7 @@ The stationarity builder needs to preserve subset domain indices for parameters 
 **What must be done:**
 1. Detect parameters and variables in the stationarity expression that are declared over strict subsets of the equation domain (e.g., `alp(t)` where the equation is over `i` with `Set t(i)`)
 2. For such cases, generate stationarity equations whose domain matches the subset (e.g., `stat_e(t).. alp(t) * ... =E= 0;`) or otherwise restructure the generated model so that each indexed symbol is only ever used with indices consistent with its declared domain
-3. Preserve MCP pairing for the original variable domain (e.g., `e(i)`) by introducing the necessary mappings or fixings, rather than by relying on head conditions to mask domain violations
+3. Preserve MCP pairing for the original variable domain (e.g., `e(i)`) by introducing the necessary mappings or fixings while keeping all symbols indexed by their declared domains — **do not** attempt to fix the issue by merely rewriting `alp(i)` to `alp(t)` inside `stat_e(i)`, which leads to GAMS $149 (uncontrolled set)
 
 ---
 


### PR DESCRIPTION
## Summary
Investigated ISSUE #1164 (chenery/shale $171 domain violation). Found a catch-22:
- `alp(i)` → GAMS $171 (domain violation: parameter declared over subset `t`)
- `alp(t)` → GAMS $149 (uncontrolled set: `t` not in equation domain)

The only valid GAMS form requires the stationarity condition on the equation HEAD, but that re-introduces MCP pairing mismatches from #1147.

Fix requires selectively routing equations with subset-domain parameters through the head-condition path while keeping body-condition for other equations.

## Test plan
- [x] `make test` — 4331 passed, 0 failed (no code changes, doc update only)