### PR TITLE
Fix prolog: multiplier dimension mismatch (#1227)

### DIFF
--- a/docs/issues/ISSUE_1247_prolog-objective-mismatch.md
+++ b/docs/issues/ISSUE_1247_prolog-objective-mismatch.md
@@ -1,0 +1,82 @@
+# prolog: Objective Mismatch (MCP=-73.5 vs NLP=-0.0)
+
+**GitHub Issue:** [#1247](https://github.com/jeffreyhorn/nlp2mcp/issues/1247)
+**Status:** OPEN
+**Severity:** Medium — Model solves optimally but objective differs from NLP
+**Date:** 2026-04-09
+**Last Updated:** 2026-04-09
+**Affected Models:** prolog
+
+---
+
+## Problem Summary
+
+After fixing the multiplier dimension mismatch (#1227), prolog solves to
+MODEL STATUS 1 Optimal but with MCP obj=-73.528 vs NLP obj=-0.0 (or near
+zero). The KKT system produces a valid but different optimum.
+
+---
+
+## Current Status
+
+- **Translation**: Success
+- **GAMS compilation**: Success
+- **PATH solve**: MODEL STATUS 1 Optimal, SOLVER STATUS 1 Normal Completion
+- **Objective**: MCP=-73.528, NLP=-0.0
+- **Pipeline category**: model_optimal (mismatch)
+- **Previous fixes**: #1227 (multiplier dimension mismatch, FIXED)
+
+---
+
+## Root Cause (Investigation Needed)
+
+The prolog model is a general equilibrium model (Shoven-Whalley prototype)
+with CES production functions, multiple solve variants (nortone, nortonl,
+nortonn), and complex alias structures (Alias(i,j), Alias(g,gp)).
+
+The objective is `zdef.. z =e= sum(h, y(h))` — sum of household demands.
+The NLP objective of -0.0 suggests the NLP solver found a boundary solution,
+while the MCP finds a different equilibrium point.
+
+Possible causes:
+1. **Multi-model structure**: prolog has 3 model variants (nortone, nortonl,
+   nortonn). nlp2mcp reformulates the LAST solve which may not be the
+   primary one the NLP comparison uses.
+2. **Alias-related Jacobian terms**: The model uses `Alias(i,j)` and
+   `Alias(g,gp)` extensively. Some Jacobian terms may be incorrect.
+3. **CES function derivatives**: Nested power expressions with `epsi(g,h)`
+   and `eta(g,gp,h)` parameters may have derivative errors.
+4. **Inequality complementarity**: `mp(i,t)` is `=l=` (inequality). The
+   complementarity formulation may not match the NLP's active constraint
+   handling.
+
+---
+
+## Reproduction
+
+**Prerequisite:** GAMSlib raw sources in `data/gamslib/raw/`.
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/prolog.gms -o /tmp/prolog_mcp.gms --quiet
+gams /tmp/prolog_mcp.gms lo=0
+
+# Output:
+# **** SOLVER STATUS     1 Normal Completion
+# **** MODEL STATUS      1 Optimal
+# nlp2mcp_obj_val = -73.528 (NLP: -0.0)
+```
+
+---
+
+## Files Involved
+
+- `src/kkt/stationarity.py` — Stationarity equation builder
+- `src/ad/constraint_jacobian.py` — Jacobian computation
+- `data/gamslib/raw/prolog.gms` — Original model (~160 lines)
+
+---
+
+## Related Issues
+
+- #1227 (FIXED) — Multiplier dimension mismatch
+- #1070 — Originally described as CES singular Jacobian (superseded by #1227)

--- a/docs/issues/completed/ISSUE_1227_prolog-multiplier-dimension-mismatch.md
+++ b/docs/issues/completed/ISSUE_1227_prolog-multiplier-dimension-mismatch.md
@@ -1,0 +1,116 @@
+# prolog: Multiplier Dimension Mismatch — lam_mp Missing Index t
+
+**GitHub Issue:** [#1227](https://github.com/jeffreyhorn/nlp2mcp/issues/1227)
+**Status:** OPEN
+**Severity:** High — GAMS Error 148 (compilation failure)
+**Date:** 2026-04-06
+**Affected Models:** prolog
+**Supersedes:** #1070 (originally described as CES singular Jacobian)
+
+---
+
+## Problem Summary
+
+The prolog model (GAMS/MPSGE Prototype: Shoven-Whalley, GAMSlib) fails with
+GAMS Error 148 during MCP compilation. The root cause is a multiplier dimension
+mismatch in the stationarity equation for variable `p(i)`.
+
+Equation `mp(i,t)` references variable `p(i)`. When generating the stationarity
+equation `stat_p(i)`, the multiplier `lam_mp` appears in two inconsistent forms:
+
+- `lam_mp(i,t)` — correct, inside `sum(t, ...)` context
+- `lam_mp(i)` — incorrect, missing the `t` dimension
+
+This dimension mismatch causes GAMS Error 148 (symbol dimension mismatch).
+
+---
+
+## Root Cause
+
+The equation `mp(i,t)` is 2-dimensional, so its Lagrange multiplier must be
+`lam_mp(i,t)`. When building `stat_p(i)`, the stationarity builder must sum
+over the extra dimension `t`:
+
+```gams
+stat_p(i).. sum(t, lam_mp(i,t) * d_mp_dp(i,t)) + ... =E= 0;
+```
+
+However, the current code emits `lam_mp(i)` in some terms (outside the sum or
+with incorrect index propagation), creating a dimension conflict:
+
+```gams
+* INCORRECT — mixes lam_mp(i,t) and lam_mp(i)
+stat_p(i).. sum(t, lam_mp(i,t) * ...) + lam_mp(i) * ... =E= 0;
+```
+
+The issue likely occurs in `stationarity.py` when the equation domain `(i,t)`
+is partially matched against the variable domain `(i)` — the `t` index from
+the equation is not consistently carried through to all multiplier references.
+
+---
+
+## Reproduction
+
+```bash
+python -m src.cli data/gamslib/raw/prolog.gms -o /tmp/prolog_mcp.gms
+gams /tmp/prolog_mcp.gms lo=2
+# GAMS Error 148: symbol dimension mismatch on lam_mp
+```
+
+---
+
+## GAMS Errors
+
+```
+*** Error 148: symbol 'lam_mp' has dimension 2 but is used with dimension 1
+```
+
+The error occurs in the stationarity equation `stat_p` where `lam_mp(i)` appears
+but `lam_mp` was declared as `lam_mp(i,t)`.
+
+---
+
+## Model Structure
+
+- **File**: `data/gamslib/raw/prolog.gms` (~160 lines)
+- **Aliases**: `Alias(i,j)`, `Alias(g,gp)`
+- **Key equation**: `mp(i,t)` — references variable `p(i)`
+- **Key variable**: `p(i)` — prices (1-dimensional)
+- **Multiplier**: `lam_mp(i,t)` — must be 2-dimensional to match equation `mp(i,t)`
+- **Stationarity**: `stat_p(i)` — must sum over `t` when referencing `lam_mp`
+
+---
+
+## Potential Fix Approaches
+
+1. **Consistent index propagation**: When building stationarity equations, ensure
+   that ALL references to `lam_mp` carry the full equation domain `(i,t)`, even
+   when the derivative terms have been simplified
+2. **Sum wrapping for extra dimensions**: When equation domain has dimensions not
+   in the variable domain, wrap ALL multiplier terms in `sum(extra_dims, ...)`
+3. **Dimension validation pass**: Add a post-generation check that all multiplier
+   references match their declared dimension
+
+---
+
+## FIXED (Sprint 24)
+
+**Fix:** Added `_fix_multiplier_dimensions` post-processing step in
+`build_stationarity_equations`. After building each stationarity expression,
+the function walks the additive term tree and checks all MultiplierRef nodes
+for dimension mismatches. When a MultiplierRef has fewer indices than declared
+(e.g., `lam_mp(i)` should be `lam_mp(i,t)`), the term is wrapped in a
+`Sum` over the missing dimensions.
+
+**Result:** prolog compiles and solves to MODEL STATUS 1 Optimal (was Error 148).
+MCP obj=-73.528. All 4387 tests pass.
+
+## Files Modified
+
+- `src/kkt/stationarity.py` — `_fix_multiplier_dimensions`,
+  `_fix_mult_dims_recursive`, `_find_bad_multiplier`, `_replace_mult_indices`
+
+## Related Files
+
+- `data/gamslib/raw/prolog.gms` — Source model (~160 lines)
+- `docs/issues/ISSUE_1070_prolog-mcp-infeasible-ces-singular-jacobian.md` — Superseded issue

--- a/docs/issues/completed/ISSUE_1227_prolog-multiplier-dimension-mismatch.md
+++ b/docs/issues/completed/ISSUE_1227_prolog-multiplier-dimension-mismatch.md
@@ -1,8 +1,8 @@
 # prolog: Multiplier Dimension Mismatch — lam_mp Missing Index t
 
 **GitHub Issue:** [#1227](https://github.com/jeffreyhorn/nlp2mcp/issues/1227)
-**Status:** OPEN
-**Severity:** High — GAMS Error 148 (compilation failure)
+**Status:** FIXED
+**Severity:** High — was GAMS Error 148 (now resolved)
 **Date:** 2026-04-06
 **Affected Models:** prolog
 **Supersedes:** #1070 (originally described as CES singular Jacobian)

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -3506,8 +3506,14 @@ def _find_bad_multiplier(
     return None
 
 
-def _replace_mult_indices(expr: Expr, mult_name: str, new_indices: tuple[str, ...]) -> Expr:
-    """Replace a MultiplierRef's indices with the declared domain."""
+def _replace_mult_indices(
+    expr: Expr, mult_name: str, new_indices: tuple[str | IndexOffset, ...]
+) -> Expr:
+    """Replace a MultiplierRef's indices with the given tuple.
+
+    The new_indices may contain both plain strings and IndexOffset objects
+    (existing offsets are preserved from the original indices).
+    """
     if isinstance(expr, MultiplierRef) and expr.name == mult_name:
         return MultiplierRef(expr.name, new_indices)
     if isinstance(expr, Binary):

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -995,6 +995,13 @@ def build_stationarity_equations(
                 # Note: wrapping after simplification means 0$cond won't be
                 # folded here, but downstream emission handles this gracefully.
                 stat_expr = DollarConditional(stat_expr, access_cond)
+            # Issue #1227: Fix MultiplierRef dimension mismatches.
+            # When a constraint has more indices than the variable (e.g.,
+            # mp(i,t) → stat_p(i)), some MultiplierRef nodes may have fewer
+            # indices than declared. Wrap these in a Sum over the missing
+            # dimensions to produce valid GAMS.
+            stat_expr = _fix_multiplier_dimensions(stat_expr, kkt)
+
             stationarity[stat_name] = EquationDef(
                 name=stat_name,
                 domain=var_def.domain,  # Use same domain as variable
@@ -3415,6 +3422,100 @@ def _compute_index_offset_key(
             offsets.append(0)
 
     return tuple(offsets)
+
+
+def _fix_multiplier_dimensions(expr: Expr, kkt: KKTSystem) -> Expr:
+    """Fix MultiplierRef nodes whose indices don't match declared dimensions.
+
+    Issue #1227: When a constraint has more dimensions than the variable
+    (e.g., mp(i,t) → stat_p(i)), some code paths produce MultiplierRef
+    with fewer indices than declared. This post-processing step finds such
+    mismatches and wraps the offending term in a Sum over the missing
+    dimensions.
+
+    Only fixes top-level additive terms (Binary(+/-) tree) to avoid
+    breaking expression structure inside sums that already handle
+    the extra dimensions correctly.
+    """
+    # Collect declared multiplier dimensions
+    mult_dims: dict[str, tuple[str, ...]] = {}
+    for mult_def in list(kkt.multipliers_eq.values()) + list(kkt.multipliers_ineq.values()):
+        mult_dims[mult_def.name] = mult_def.domain
+
+    return _fix_mult_dims_recursive(expr, mult_dims, inside_sum=False)
+
+
+def _fix_mult_dims_recursive(
+    expr: Expr, mult_dims: dict[str, tuple[str, ...]], *, inside_sum: bool
+) -> Expr:
+    """Recursively fix MultiplierRef dimension mismatches in additive terms."""
+    if isinstance(expr, Binary) and expr.op in ("+", "-"):
+        new_left = _fix_mult_dims_recursive(expr.left, mult_dims, inside_sum=inside_sum)
+        new_right = _fix_mult_dims_recursive(expr.right, mult_dims, inside_sum=inside_sum)
+        if new_left is not expr.left or new_right is not expr.right:
+            return Binary(expr.op, new_left, new_right)
+        return expr
+    elif isinstance(expr, Sum):
+        # Don't fix inside sums — they already handle extra dimensions
+        return expr
+    elif isinstance(expr, DollarConditional):
+        new_val = _fix_mult_dims_recursive(expr.value_expr, mult_dims, inside_sum=inside_sum)
+        if new_val is not expr.value_expr:
+            return DollarConditional(new_val, expr.condition)
+        return expr
+
+    # Check if this term contains a MultiplierRef with wrong dimensions
+    bad_mult = _find_bad_multiplier(expr, mult_dims)
+    if bad_mult:
+        mult_name, actual_indices, declared_domain = bad_mult
+        # Find missing dimensions
+        actual_set = set(actual_indices) if actual_indices else set()
+        missing = tuple(d for d in declared_domain if d not in actual_set)
+        if missing:
+            # Fix the MultiplierRef inside the expression
+            fixed_expr = _replace_mult_indices(expr, mult_name, declared_domain)
+            return Sum(missing, fixed_expr)
+    return expr
+
+
+def _find_bad_multiplier(
+    expr: Expr, mult_dims: dict[str, tuple[str, ...]]
+) -> tuple[str, tuple, tuple[str, ...]] | None:
+    """Find a MultiplierRef with fewer indices than declared."""
+    if isinstance(expr, MultiplierRef):
+        declared = mult_dims.get(expr.name)
+        if declared and len(expr.indices) < len(declared):
+            return (expr.name, expr.indices, declared)
+    if isinstance(expr, Binary):
+        result = _find_bad_multiplier(expr.left, mult_dims)
+        if result:
+            return result
+        return _find_bad_multiplier(expr.right, mult_dims)
+    if isinstance(expr, Unary):
+        return _find_bad_multiplier(expr.child, mult_dims)
+    if isinstance(expr, DollarConditional):
+        return _find_bad_multiplier(expr.value_expr, mult_dims)
+    return None
+
+
+def _replace_mult_indices(expr: Expr, mult_name: str, new_indices: tuple[str, ...]) -> Expr:
+    """Replace a MultiplierRef's indices with the declared domain."""
+    if isinstance(expr, MultiplierRef) and expr.name == mult_name:
+        return MultiplierRef(expr.name, new_indices)
+    if isinstance(expr, Binary):
+        new_left = _replace_mult_indices(expr.left, mult_name, new_indices)
+        new_right = _replace_mult_indices(expr.right, mult_name, new_indices)
+        if new_left is not expr.left or new_right is not expr.right:
+            return Binary(expr.op, new_left, new_right)
+    if isinstance(expr, Unary):
+        new_child = _replace_mult_indices(expr.child, mult_name, new_indices)
+        if new_child is not expr.child:
+            return Unary(expr.op, new_child)
+    if isinstance(expr, DollarConditional):
+        new_val = _replace_mult_indices(expr.value_expr, mult_name, new_indices)
+        if new_val is not expr.value_expr:
+            return DollarConditional(new_val, expr.condition)
+    return expr
 
 
 def _build_offset_guard(

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -3442,16 +3442,14 @@ def _fix_multiplier_dimensions(expr: Expr, kkt: KKTSystem) -> Expr:
     for mult_def in list(kkt.multipliers_eq.values()) + list(kkt.multipliers_ineq.values()):
         mult_dims[mult_def.name] = mult_def.domain
 
-    return _fix_mult_dims_recursive(expr, mult_dims, inside_sum=False)
+    return _fix_mult_dims_recursive(expr, mult_dims)
 
 
-def _fix_mult_dims_recursive(
-    expr: Expr, mult_dims: dict[str, tuple[str, ...]], *, inside_sum: bool
-) -> Expr:
+def _fix_mult_dims_recursive(expr: Expr, mult_dims: dict[str, tuple[str, ...]]) -> Expr:
     """Recursively fix MultiplierRef dimension mismatches in additive terms."""
     if isinstance(expr, Binary) and expr.op in ("+", "-"):
-        new_left = _fix_mult_dims_recursive(expr.left, mult_dims, inside_sum=inside_sum)
-        new_right = _fix_mult_dims_recursive(expr.right, mult_dims, inside_sum=inside_sum)
+        new_left = _fix_mult_dims_recursive(expr.left, mult_dims)
+        new_right = _fix_mult_dims_recursive(expr.right, mult_dims)
         if new_left is not expr.left or new_right is not expr.right:
             return Binary(expr.op, new_left, new_right)
         return expr
@@ -3459,7 +3457,7 @@ def _fix_mult_dims_recursive(
         # Don't fix inside sums — they already handle extra dimensions
         return expr
     elif isinstance(expr, DollarConditional):
-        new_val = _fix_mult_dims_recursive(expr.value_expr, mult_dims, inside_sum=inside_sum)
+        new_val = _fix_mult_dims_recursive(expr.value_expr, mult_dims)
         if new_val is not expr.value_expr:
             return DollarConditional(new_val, expr.condition)
         return expr
@@ -3468,12 +3466,19 @@ def _fix_mult_dims_recursive(
     bad_mult = _find_bad_multiplier(expr, mult_dims)
     if bad_mult:
         mult_name, actual_indices, declared_domain = bad_mult
-        # Find missing dimensions
-        actual_set = set(actual_indices) if actual_indices else set()
-        missing = tuple(d for d in declared_domain if d not in actual_set)
+        # Extract base names from IndexOffset for comparison
+        actual_bases: set[str] = set()
+        for idx in actual_indices:
+            if isinstance(idx, str):
+                actual_bases.add(idx)
+            elif isinstance(idx, IndexOffset):
+                actual_bases.add(idx.base)
+        missing = tuple(d for d in declared_domain if d not in actual_bases)
         if missing:
-            # Fix the MultiplierRef inside the expression
-            fixed_expr = _replace_mult_indices(expr, mult_name, declared_domain)
+            # Extend the MultiplierRef indices with missing dimensions
+            # (preserving existing indices including IndexOffsets)
+            new_indices = tuple(actual_indices) + missing
+            fixed_expr = _replace_mult_indices(expr, mult_name, new_indices)
             return Sum(missing, fixed_expr)
     return expr
 

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -3437,10 +3437,13 @@ def _fix_multiplier_dimensions(expr: Expr, kkt: KKTSystem) -> Expr:
     breaking expression structure inside sums that already handle
     the extra dimensions correctly.
     """
-    # Collect declared multiplier dimensions
-    mult_dims: dict[str, tuple[str, ...]] = {}
-    for mult_def in list(kkt.multipliers_eq.values()) + list(kkt.multipliers_ineq.values()):
-        mult_dims[mult_def.name] = mult_def.domain
+    # Use cached mult_dims if available, otherwise build it
+    mult_dims: dict[str, tuple[str, ...]] | None = getattr(kkt, "_mult_dims_cache", None)
+    if mult_dims is None:
+        mult_dims = {}
+        for mult_def in list(kkt.multipliers_eq.values()) + list(kkt.multipliers_ineq.values()):
+            mult_dims[mult_def.name] = mult_def.domain
+        object.__setattr__(kkt, "_mult_dims_cache", mult_dims)
 
     return _fix_mult_dims_recursive(expr, mult_dims)
 

--- a/tests/unit/kkt/test_fix_multiplier_dimensions.py
+++ b/tests/unit/kkt/test_fix_multiplier_dimensions.py
@@ -1,0 +1,70 @@
+"""Test MultiplierRef dimension mismatch fixing.
+
+Issue #1227: When a constraint has more dimensions than the variable
+(e.g., mp(i,t) → stat_p(i)), MultiplierRef nodes may have fewer indices
+than declared. _fix_multiplier_dimensions wraps these in Sum over the
+missing dimensions.
+"""
+
+import pytest
+
+from src.ir.ast import Binary, Const, MultiplierRef, Sum
+from src.kkt.stationarity import _fix_multiplier_dimensions
+
+
+class _FakeMultDef:
+    def __init__(self, name: str, domain: tuple[str, ...]):
+        self.name = name
+        self.domain = domain
+
+
+class _FakeKKT:
+    def __init__(self, mult_defs: list[_FakeMultDef]):
+        self.multipliers_eq = {d.name: d for d in mult_defs if d.name.startswith("nu_")}
+        self.multipliers_ineq = {d.name: d for d in mult_defs if d.name.startswith("lam_")}
+
+
+@pytest.mark.unit
+class TestFixMultiplierDimensions:
+    def test_wraps_missing_dimension_in_sum(self):
+        """lam_mp(i) with declared domain (i,t) → sum(t, lam_mp(i,t))."""
+        kkt = _FakeKKT([_FakeMultDef("lam_mp", ("i", "t"))])
+        # expr: lam_mp(i) — missing dimension t
+        expr = MultiplierRef("lam_mp", ("i",))
+        result = _fix_multiplier_dimensions(expr, kkt)
+
+        assert isinstance(result, Sum)
+        assert result.index_sets == ("t",)
+        inner = result.body
+        assert isinstance(inner, MultiplierRef)
+        assert inner.name == "lam_mp"
+        assert inner.indices == ("i", "t")
+
+    def test_correct_dimensions_unchanged(self):
+        """lam_mp(i,t) with declared domain (i,t) → unchanged."""
+        kkt = _FakeKKT([_FakeMultDef("lam_mp", ("i", "t"))])
+        expr = MultiplierRef("lam_mp", ("i", "t"))
+        result = _fix_multiplier_dimensions(expr, kkt)
+
+        assert isinstance(result, MultiplierRef)
+        assert result.indices == ("i", "t")
+
+    def test_additive_terms_fixed_independently(self):
+        """a + lam_mp(i) → a + sum(t, lam_mp(i,t))."""
+        kkt = _FakeKKT([_FakeMultDef("lam_mp", ("i", "t"))])
+        expr = Binary("+", Const(1.0), MultiplierRef("lam_mp", ("i",)))
+        result = _fix_multiplier_dimensions(expr, kkt)
+
+        assert isinstance(result, Binary)
+        assert isinstance(result.left, Const)
+        assert isinstance(result.right, Sum)
+        assert result.right.index_sets == ("t",)
+
+    def test_inside_sum_not_modified(self):
+        """sum(t, lam_mp(i,t)) — already correct, not modified."""
+        kkt = _FakeKKT([_FakeMultDef("lam_mp", ("i", "t"))])
+        inner = MultiplierRef("lam_mp", ("i", "t"))
+        expr = Sum(("t",), inner)
+        result = _fix_multiplier_dimensions(expr, kkt)
+
+        assert result is expr  # Unchanged


### PR DESCRIPTION
## Summary

- Added `_fix_multiplier_dimensions` post-processing step that detects MultiplierRef nodes with fewer indices than declared and wraps them in Sum over missing dimensions
- Fixes `lam_mp(i)` → `sum(t, lam_mp(i,t))` in `stat_p(i)`
- prolog: Error 148 → MODEL STATUS 1 Optimal

## Test plan

- [x] `make test` — 4387 passed, 10 skipped, 1 xfailed
- [x] `make typecheck && make lint && make format` — all clean
- [x] prolog: compiles and solves optimally
- [x] Dispatch canary: no regressions