### PR TITLE
Update ISSUE_1223: worst root cause is dotted parameter key mismatch

### DIFF
--- a/docs/issues/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
+++ b/docs/issues/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
@@ -96,9 +96,34 @@ grep "stat_d1\|stat_d2" /tmp/worst_mcp.gms
 
 ---
 
+## Sprint 24 Investigation (NOT FIXED)
+
+**Root cause confirmed:** The `errorf` derivative IS implemented. The issue is
+that `callval`, `putval`, `dd1`, `dd2` equations ALL have 0 instances from
+condition evaluation — NOT because the conditions are unevaluable (no error),
+but because the condition evaluator produces False for all instances.
+
+The condition `pdata(i,t,j,"type") = call` involves a 4D parameter with dotted
+keys: `pdata.values` stores keys like `('9000011.jun.1', 'type')` — the first
+3 dimensions are dotted together. The condition evaluator constructs a lookup
+key from the individual indices `('9000011', 'jun', '1', 'type')` which doesn't
+match the dotted format.
+
+With 0 instances for all conditioned equations, no Jacobian entries are generated
+for `d1`/`d2`, producing zero stationarity.
+
+**Fix requires:** Improve the condition evaluator's parameter value lookup to
+handle dotted multi-dimensional keys. When `pdata(i,t,j,"type")` is evaluated
+at indices `('9000011', 'jun', '1')`, the evaluator should try both:
+- 4-tuple key: `('9000011', 'jun', '1', 'type')`
+- Dotted key: `('9000011.jun.1', 'type')`
+
+This is a ~2-4h fix in `src/ir/condition_eval.py`.
+
 ## Files Involved
 
-- `src/ad/derivative_rules.py` — Function differentiation (errorf support)
-- `src/kkt/stationarity.py` — Stationarity equation builder
+- `src/ir/condition_eval.py` — Parameter value lookup (dotted key handling)
+- `src/ad/index_mapping.py` — enumerate_equation_instances
+- `src/ad/derivative_rules.py` — errorf derivative (WORKS correctly)
 - `src/ad/constraint_jacobian.py` — Jacobian term generation
 - `data/gamslib/raw/worst.gms` — Original model (152 lines)

--- a/docs/issues/completed/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
+++ b/docs/issues/completed/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
@@ -1,0 +1,136 @@
+# worst: Conditioned Equation Variables Produce Zero Stationarity
+
+**GitHub Issue:** [#1223](https://github.com/jeffreyhorn/nlp2mcp/issues/1223)
+**Status:** OPEN — KKT formulation bug (conditioned equation gradient)
+**Severity:** Medium — Variables d1/d2 get trivial 0=0 stationarity equations
+**Date:** 2026-04-07
+**Last Updated:** 2026-04-07
+**Affected Models:** worst
+
+---
+
+## Problem Summary
+
+The worst model (GAMSlib SEQ=111, "Financial Optimization: Risk Management")
+has variables `d1(i,t,j)` and `d2(i,t,j)` that appear in equations `dd1` and
+`dd2`, which are conditioned with `$pdata(i,t,j,"strike")`. The stationarity
+builder produces `stat_d1(i,t,j).. 0 =E= 0;` and `stat_d2(i,t,j).. 0 =E= 0;`
+— the conditioned gradients evaluate to zero across all terms. GAMS then
+reports Error 483 ("Mapped variables have to appear in the model") because
+d1/d2 don't appear in their paired stationarity equations.
+
+---
+
+## Root Cause
+
+Variables `d1` and `d2` only appear in two types of equations:
+
+1. **Defining equations** `dd1`, `dd2` — conditioned with `$pdata(i,t,j,"strike")`:
+   ```gams
+   dd1(i,t,j)$pdata(i,t,j,"strike")..
+      d1(i,t,j) =e= (log(f(i,t)/pdata(i,t,j,"strike")) + 0.5*sqr(q(t))*tdata(t,"term"))
+                     / (q(t)*sqrt(tdata(t,"term")));
+   dd2(i,t,j)$pdata(i,t,j,"strike")..
+      d2(i,t,j) =e= d1(i,t,j) - q(t)*sqrt(tdata(t,"term"));
+   ```
+
+2. **Call/put equations** `c`, `p` — where d1/d2 appear inside `errorf()`:
+   ```gams
+   c(i,j,t) =e= exp(...) * (f(i,t)*errorf(d1(i,t,j)) - strike*errorf(d2(i,t,j)));
+   p(i,j,t) =e= exp(...) * (strike*errorf(-d2(i,t,j)) - f(i,t)*errorf(-d1(i,t,j)));
+   ```
+
+The stationarity builder should produce non-zero gradients from equations `c`
+and `p` (via `errorf'(d1) = dnorm(d1)`), but these contributions are missing
+from the stationarity output, resulting in `0 =E= 0`.
+
+The issue may be that:
+- The `errorf()` derivative is not implemented or returns 0
+- The conditioned equations `dd1`/`dd2` mask the gradient contributions
+- The dollar condition causes ALL stationarity terms to be wrapped and
+  evaluated to zero
+
+---
+
+## Reproduction
+
+```bash
+# Translate
+.venv/bin/python -m src.cli data/gamslib/raw/worst.gms -o /tmp/worst_mcp.gms --quiet
+
+# Compile — Error 483 (Mapped variables have to appear in the model)
+gams /tmp/worst_mcp.gms lo=0
+
+# Check stationarity equations:
+grep "stat_d1\|stat_d2" /tmp/worst_mcp.gms
+# Output:
+# stat_d1(i,t,j).. 0 =E= 0;
+# stat_d2(i,t,j).. 0 =E= 0;
+```
+
+---
+
+## GAMS Errors
+
+- **Error 483**: Mapped variables have to appear in the model — `d1` and `d2`
+  are paired with `stat_d1`/`stat_d2` in the MCP but don't appear in those
+  equations (which are trivially `0 =E= 0`)
+
+---
+
+## Potential Fix Approaches
+
+1. **Fix conditioned equation gradient propagation**: Ensure that when
+   equations `c` and `p` reference `d1`/`d2`, the Jacobian terms are
+   correctly included in `stat_d1`/`stat_d2`. The `errorf()` (normal CDF)
+   derivative should produce `dnorm(d1)` terms.
+
+2. **Handle `errorf` differentiation**: Verify that `errorf` (Gauss error
+   function / normal CDF) is in the AD engine's function table with the
+   correct derivative `errorf'(x) = (2/sqrt(pi)) * exp(-x^2)` or
+   `normcdf'(x) = normpdf(x)`.
+
+3. **Detect zero-stationarity and warn**: If all stationarity terms for a
+   variable evaluate to zero, emit a warning rather than silently producing
+   `0 =E= 0`.
+
+---
+
+## Sprint 24 Investigation (NOT FIXED)
+
+**Root cause confirmed:** The `errorf` derivative IS implemented. The issue is
+that `callval`, `putval`, `dd1`, `dd2` equations ALL have 0 instances from
+condition evaluation — NOT because the conditions are unevaluable (no error),
+but because the condition evaluator produces False for all instances.
+
+The condition `pdata(i,t,j,"type") = call` involves a 4D parameter with dotted
+keys: `pdata.values` stores keys like `('9000011.jun.1', 'type')` — the first
+3 dimensions are dotted together. The condition evaluator constructs a lookup
+key from the individual indices `('9000011', 'jun', '1', 'type')` which doesn't
+match the dotted format.
+
+With 0 instances for all conditioned equations, no Jacobian entries are generated
+for `d1`/`d2`, producing zero stationarity.
+
+## FIXED (Sprint 24)
+
+Added `_try_dotted_key_lookup` in `condition_eval.py` that progressively
+joins indices from the left with `.` to match the parser's Table format.
+For `pdata(i,t,j,"type")` at `('9000011','jun','1')`:
+- Direct lookup: `('9000011','jun','1','type')` — fails
+- Dotted fallback: `('9000011.jun.1','type')` — matches!
+
+**Result:** worst compiles and solves to MODEL STATUS 1 Optimal.
+MCP obj=20,800,200 vs NLP obj=20,941,622 (~0.7% mismatch).
+All conditioned equations now have correct instances:
+- callval: 5, putval: 3, dd1: 8, dd2: 8, futval: 5
+
+**Files modified:** `src/ir/condition_eval.py`, `tests/unit/ir/test_condition_eval_dotted.py`
+
+## Files Involved
+
+- `src/ir/condition_eval.py` — Parameter value lookup (dotted key handling)
+- `src/ad/index_mapping.py` — enumerate_equation_instances
+- `src/ad/derivative_rules.py` — errorf derivative (WORKS correctly)
+- `src/ad/constraint_jacobian.py` — Jacobian term generation
+- `data/gamslib/raw/worst.gms` — Original model (152 lines)

--- a/docs/issues/completed/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
+++ b/docs/issues/completed/ISSUE_1223_worst-conditioned-equation-zero-stationarity.md
@@ -1,10 +1,10 @@
 # worst: Conditioned Equation Variables Produce Zero Stationarity
 
 **GitHub Issue:** [#1223](https://github.com/jeffreyhorn/nlp2mcp/issues/1223)
-**Status:** OPEN — KKT formulation bug (conditioned equation gradient)
-**Severity:** Medium — Variables d1/d2 get trivial 0=0 stationarity equations
+**Status:** FIXED
+**Severity:** Medium — was 0=0 stationarity (now resolved)
 **Date:** 2026-04-07
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-04-10
 **Affected Models:** worst
 
 ---
@@ -96,23 +96,14 @@ grep "stat_d1\|stat_d2" /tmp/worst_mcp.gms
 
 ---
 
-## Sprint 24 Investigation (NOT FIXED)
-
-**Root cause confirmed:** The `errorf` derivative IS implemented. The issue is
-that `callval`, `putval`, `dd1`, `dd2` equations ALL have 0 instances from
-condition evaluation — NOT because the conditions are unevaluable (no error),
-but because the condition evaluator produces False for all instances.
-
-The condition `pdata(i,t,j,"type") = call` involves a 4D parameter with dotted
-keys: `pdata.values` stores keys like `('9000011.jun.1', 'type')` — the first
-3 dimensions are dotted together. The condition evaluator constructs a lookup
-key from the individual indices `('9000011', 'jun', '1', 'type')` which doesn't
-match the dotted format.
-
-With 0 instances for all conditioned equations, no Jacobian entries are generated
-for `d1`/`d2`, producing zero stationarity.
-
 ## FIXED (Sprint 24)
+
+**Root cause:** The `errorf` derivative IS implemented correctly. The issue was
+that `callval`, `putval`, `dd1`, `dd2` equations ALL had 0 instances from
+condition evaluation because the condition evaluator couldn't match dotted
+parameter keys. `pdata.values` stores keys like `('9000011.jun.1', 'type')`
+(dotted) but the evaluator constructed `('9000011', 'jun', '1', 'type')`
+(individual elements).
 
 Added `_try_dotted_key_lookup` in `condition_eval.py` that progressively
 joins indices from the left with `.` to match the parser's Table format.

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_1223.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_1223.md
@@ -1,0 +1,205 @@
+# Plan: Fix Dotted Parameter Key Lookup in Condition Evaluator (#1223)
+
+**Goal:** Fix condition evaluation for parameters with dotted multi-dimensional
+keys (e.g., `pdata(i,t,j,"type")` stored as `('9000011.jun.1', 'type')`), so
+conditioned equation instances are correctly enumerated and Jacobian entries
+are generated.
+
+**Estimated effort:** 2-3 hours
+**Models unblocked:** worst (and potentially any model with `Table` parameters
+using `*` wildcard domain that produces dotted keys)
+
+---
+
+## Problem Recap
+
+The `worst` model has 4 conditioned equations (`callval`, `putval`, `dd1`,
+`dd2`) that all return 0 instances from `enumerate_equation_instances`. This
+causes variables `d1`/`d2` to have zero stationarity (`0 =E= 0`), producing
+GAMS Error 483.
+
+The root cause is a key format mismatch in `condition_eval.py`:
+
+### What the condition evaluator constructs
+
+For `pdata(i,t,j,"type")` at indices `('9000011', 'jun', '1')`:
+
+```python
+concrete_indices = ('9000011', 'jun', '1', 'type')  # 4-tuple
+```
+
+### What `pdata.values` actually stores
+
+```python
+pdata.values = {
+    ('9000011.jun.1', 'type'): 'future',   # 2-tuple, first 3 dims dotted
+    ('9000011.jun.1', 'nom'): -35000.0,
+    ...
+}
+```
+
+The parser's Table handler for `Table pdata(i,t,j,*)` collapses the first
+3 dimensions into a single dotted string when building the values dict. This
+is because GAMS Table syntax treats multi-dimensional row headers as dotted
+labels:
+
+```
+Table pdata(i,t,j,*) 'portfolio data'
+                type     strike    nom       price
+9000011.jun.1   future            -35000     96.6
+9000011.oct.1   future             15000     96.6
+```
+
+The row header `9000011.jun.1` becomes a single string key for the first 3
+domain positions.
+
+### Why lookup fails
+
+`condition_eval.py` line 156:
+```python
+if concrete_indices in param.values:  # ('9000011','jun','1','type') NOT in values
+    return param.values[concrete_indices]
+```
+
+The 4-tuple `('9000011', 'jun', '1', 'type')` doesn't match the 2-tuple
+`('9000011.jun.1', 'type')`.
+
+---
+
+## Fix: Dotted Key Fallback in condition_eval.py
+
+### Step 1: Add dotted-key lookup fallback (~1h)
+
+**File:** `src/ir/condition_eval.py`, around line 156
+
+After the direct tuple lookup fails, try constructing a dotted-key variant:
+
+```python
+# Direct lookup
+if concrete_indices in param.values:
+    return param.values[concrete_indices]
+
+# Dotted-key fallback: for parameters with star (*) domains where the
+# parser collapses multi-dimensional row headers into dotted strings,
+# try joining the first N indices with '.' and keeping the rest separate.
+# Example: ('9000011', 'jun', '1', 'type') → ('9000011.jun.1', 'type')
+if param.domain and '*' in param.domain:
+    star_pos = param.domain.index('*')
+    if star_pos > 1 and len(concrete_indices) > star_pos:
+        dotted_prefix = '.'.join(concrete_indices[:star_pos])
+        remaining = concrete_indices[star_pos:]
+        dotted_key = (dotted_prefix,) + remaining
+        if dotted_key in param.values:
+            return param.values[dotted_key]
+```
+
+**Key insight:** The `*` in `param.domain` tells us where the star domain
+starts. All indices before `*` are collapsed into a single dotted string
+by the parser. So for `domain = ('i', 't', 'j', '*')` with `star_pos = 3`:
+- `concrete_indices[:3] = ('9000011', 'jun', '1')` → `'9000011.jun.1'`
+- `concrete_indices[3:] = ('type',)` → remaining
+- `dotted_key = ('9000011.jun.1', 'type')` → matches!
+
+### Step 2: Handle non-star dotted keys (~30min)
+
+Some models may have dotted keys without a `*` domain (e.g., `Table p(i,j)`
+with row headers `a.b`). For these, try progressively dotting from the left:
+
+```python
+# Progressive dotting fallback (for any parameter with dotted keys)
+if not found:
+    for split_pos in range(2, len(concrete_indices)):
+        dotted_prefix = '.'.join(concrete_indices[:split_pos])
+        remaining = concrete_indices[split_pos:]
+        candidate = (dotted_prefix,) + remaining
+        if candidate in param.values:
+            return param.values[candidate]
+```
+
+This is O(N) where N is the number of dimensions, which is typically 2-5.
+
+### Step 3: Also fix the comparison side (~30min)
+
+The condition `pdata(i,t,j,"type") = call` compares the result of the
+parameter lookup against the value of scalar parameter `call`. The `call`
+parameter has `values = {(): 0.0}` but the comparison expects a string
+match (`'future' = 'call'`). Need to verify that string-vs-number
+comparison works correctly.
+
+Actually: `call` is a scalar parameter with value `0.0`, not a string.
+But the GAMS model uses `call` as an **acronym** (not a number). Check
+if `call` is in `model_ir.acronyms`:
+
+```python
+# From the investigation:
+# call param: domain=(), values={(): 0.0}
+# But 'call' might be an acronym for string comparison
+```
+
+The fix: check `model_ir.acronyms` for `call` and use the acronym
+string value for comparison instead of the numeric 0.0.
+
+### Step 4: Unit tests (~30min)
+
+**File:** `tests/unit/ir/test_condition_eval_dotted.py` (new)
+
+Test cases:
+1. Parameter with `*` domain and dotted keys → correct lookup
+2. Condition `pdata(i,t,j,"type") = acronym` → correct string comparison
+3. Non-dotted parameter → unchanged behavior (regression)
+
+### Step 5: Integration test (~15min)
+
+- Verify worst equations get nonzero instances after fix
+- Verify `stat_d1`/`stat_d2` are no longer `0 =E= 0`
+
+---
+
+## Detailed Key Format Analysis
+
+### How the parser creates dotted keys
+
+In `src/ir/parser.py`, the Table handler reads multi-dimensional row headers
+as dotted strings. For `Table pdata(i,t,j,*)`:
+
+```
+Row header: "9000011.jun.1"
+Column headers: "type", "strike", "nom", "price"
+```
+
+The row header is stored as a single string `'9000011.jun.1'` and the
+column header becomes the second element: `('9000011.jun.1', 'type')`.
+
+The domain `('i', 't', 'j', '*')` indicates 4 dimensions, but the values
+dict only has 2-element tuples because the first 3 are collapsed.
+
+### Why this doesn't affect all models
+
+Most models use set-element-based table rows where each dimension is a
+separate column, producing N-tuple keys matching the domain. The dotted
+format only occurs when:
+1. The Table has a `*` (universal set) domain
+2. Row headers use dotted notation for multi-dimensional labels
+3. The condition evaluator needs to look up values at runtime
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/ir/condition_eval.py` | Add dotted-key fallback in parameter lookup |
+| `tests/unit/ir/test_condition_eval_dotted.py` | NEW — unit tests |
+
+---
+
+## Risk Assessment
+
+**Low risk:** The fix adds a fallback after the existing lookup fails.
+If the dotted key also doesn't match, the behavior is unchanged (returns
+default 0.0 or raises error). No existing behavior is modified.
+
+**Potential false positive:** If a parameter has both `('a.b', 'c')` and
+`('a', 'b', 'c')` entries, the dotted fallback could match the wrong one.
+This is extremely unlikely in practice (requires a parameter with duplicate
+entries in different key formats).

--- a/src/ir/condition_eval.py
+++ b/src/ir/condition_eval.py
@@ -44,7 +44,20 @@ def _try_dotted_key_lookup(param: object, concrete_indices: tuple[str, ...]) -> 
     if not values:
         return None
 
-    # Try joining first N indices with '.' for N from 2 to len-1
+    domain = getattr(param, "domain", None)
+
+    # Prefer the star-domain split position when available: the parser
+    # collapses all indices before '*' into one dotted label.
+    if domain and "*" in domain:
+        star_pos = list(domain).index("*")
+        if star_pos >= 2 and len(concrete_indices) > star_pos:
+            dotted_prefix = ".".join(concrete_indices[:star_pos])
+            remaining = concrete_indices[star_pos:]
+            candidate = (dotted_prefix,) + remaining
+            if candidate in values:
+                return values[candidate]
+
+    # Fallback: try joining first N indices with '.' for N from 2 to len-1
     for split_pos in range(2, len(concrete_indices)):
         dotted_prefix = ".".join(concrete_indices[:split_pos])
         remaining = concrete_indices[split_pos:]

--- a/src/ir/condition_eval.py
+++ b/src/ir/condition_eval.py
@@ -52,10 +52,10 @@ def _try_dotted_key_lookup(param: object, concrete_indices: tuple[str, ...]) -> 
         if candidate in values:
             return values[candidate]
 
-    # Also try joining ALL indices (single dotted string key)
+    # Also try joining ALL indices as a single-element tuple
     full_dotted = ".".join(concrete_indices)
-    if full_dotted in values:
-        return values[full_dotted]
+    if (full_dotted,) in values:
+        return values[(full_dotted,)]
 
     return None
 

--- a/src/ir/condition_eval.py
+++ b/src/ir/condition_eval.py
@@ -31,6 +31,35 @@ class ConditionEvaluationError(Exception):
     pass
 
 
+def _try_dotted_key_lookup(param: object, concrete_indices: tuple[str, ...]) -> float | str | None:
+    """Try looking up a parameter value using dotted key variants.
+
+    Issue #1223: Table parameters with * domain store row headers as dotted
+    strings (e.g., ('9000011.jun.1', 'type') for pdata(i,t,j,*)). This
+    function tries progressively joining indices from the left to match.
+
+    Returns the parameter value if found, or None if no match.
+    """
+    values = getattr(param, "values", None)
+    if not values:
+        return None
+
+    # Try joining first N indices with '.' for N from 2 to len-1
+    for split_pos in range(2, len(concrete_indices)):
+        dotted_prefix = ".".join(concrete_indices[:split_pos])
+        remaining = concrete_indices[split_pos:]
+        candidate = (dotted_prefix,) + remaining
+        if candidate in values:
+            return values[candidate]
+
+    # Also try joining ALL indices (single dotted string key)
+    full_dotted = ".".join(concrete_indices)
+    if full_dotted in values:
+        return values[full_dotted]
+
+    return None
+
+
 class ConditionCycleError(ConditionEvaluationError):
     """Raised when a cycle is detected in expression-based parameter resolution."""
 
@@ -155,6 +184,19 @@ def _eval_expr(
         # Look up parameter value
         if concrete_indices in param.values:
             return param.values[concrete_indices]
+
+        # Issue #1223: Dotted-key fallback for Table parameters with * domain.
+        # The parser's Table handler collapses multi-dimensional row headers
+        # into dotted strings (e.g., '9000011.jun.1') producing 2-tuple keys
+        # like ('9000011.jun.1', 'type') for a 4D parameter pdata(i,t,j,*).
+        # The condition evaluator constructs individual-element tuples
+        # ('9000011', 'jun', '1', 'type') which don't match. Try joining
+        # indices before the * position with '.' to construct the dotted key.
+        if param.domain and len(concrete_indices) > 1:
+            dotted_val = _try_dotted_key_lookup(param, concrete_indices)
+            if dotted_val is not None:
+                return dotted_val
+
         # Issue #1057: If the parameter has expression-based values, try to
         # evaluate the expression recursively. E.g., tm(t) = td("target",t)
         # can be resolved if td has static values.

--- a/tests/unit/ir/test_condition_eval_dotted.py
+++ b/tests/unit/ir/test_condition_eval_dotted.py
@@ -57,10 +57,10 @@ class TestDottedKeyLookup:
         assert result is None
 
     def test_full_dotted_string(self):
-        """All indices dotted into single string."""
+        """All indices dotted into single-element tuple."""
         param = _FakeParam(
             domain=("i", "j"),
-            values={"a.b": 99.0},
+            values={("a.b",): 99.0},
         )
         result = _try_dotted_key_lookup(param, ("a", "b"))
         assert result == 99.0

--- a/tests/unit/ir/test_condition_eval_dotted.py
+++ b/tests/unit/ir/test_condition_eval_dotted.py
@@ -51,9 +51,9 @@ class TestDottedKeyLookup:
             domain=("i", "j"),
             values={("a", "b"): 1.0},
         )
-        # This would match directly, but _try_dotted_key_lookup tries dotted
+        # _try_dotted_key_lookup tries partial dotting (range(2,2) is empty)
+        # and full dotting (("a.b",)), but neither matches ("a","b").
         result = _try_dotted_key_lookup(param, ("a", "b"))
-        # With only 2 indices, no dotting is possible (range(2,2) is empty)
         assert result is None
 
     def test_full_dotted_string(self):

--- a/tests/unit/ir/test_condition_eval_dotted.py
+++ b/tests/unit/ir/test_condition_eval_dotted.py
@@ -1,0 +1,66 @@
+"""Test dotted-key parameter lookup in condition evaluation.
+
+Issue #1223: Table parameters with * wildcard domain store multi-dimensional
+row headers as dotted strings. The condition evaluator must try dotted-key
+variants when the individual-element tuple lookup fails.
+"""
+
+import pytest
+
+from src.ir.condition_eval import _try_dotted_key_lookup
+
+
+class _FakeParam:
+    def __init__(self, domain, values):
+        self.domain = domain
+        self.values = values
+
+
+@pytest.mark.unit
+class TestDottedKeyLookup:
+    def test_dotted_3d_star_domain(self):
+        """('a', 'b', 'c', 'type') → ('a.b.c', 'type') lookup."""
+        param = _FakeParam(
+            domain=("i", "t", "j", "*"),
+            values={("a.b.c", "type"): "future", ("a.b.c", "strike"): 100.0},
+        )
+        result = _try_dotted_key_lookup(param, ("a", "b", "c", "type"))
+        assert result == "future"
+
+    def test_dotted_2d_star_domain(self):
+        """('x', 'y', 'cost') → ('x.y', 'cost') lookup."""
+        param = _FakeParam(
+            domain=("i", "j", "*"),
+            values={("x.y", "cost"): 42.0},
+        )
+        result = _try_dotted_key_lookup(param, ("x", "y", "cost"))
+        assert result == 42.0
+
+    def test_no_match_returns_none(self):
+        """Non-matching indices return None."""
+        param = _FakeParam(
+            domain=("i", "*"),
+            values={("a", "type"): "val"},
+        )
+        result = _try_dotted_key_lookup(param, ("z", "type"))
+        assert result is None
+
+    def test_direct_match_not_needed(self):
+        """_try_dotted_key_lookup is only called when direct lookup fails."""
+        param = _FakeParam(
+            domain=("i", "j"),
+            values={("a", "b"): 1.0},
+        )
+        # This would match directly, but _try_dotted_key_lookup tries dotted
+        result = _try_dotted_key_lookup(param, ("a", "b"))
+        # With only 2 indices, no dotting is possible (range(2,2) is empty)
+        assert result is None
+
+    def test_full_dotted_string(self):
+        """All indices dotted into single string."""
+        param = _FakeParam(
+            domain=("i", "j"),
+            values={"a.b": 99.0},
+        )
+        result = _try_dotted_key_lookup(param, ("a", "b"))
+        assert result == 99.0


### PR DESCRIPTION
## Summary

- Added `_try_dotted_key_lookup` in `condition_eval.py` that progressively joins indices with `.` to match Table parameters with `*` wildcard domain
- Fixes 0-instance equation enumeration for all conditioned equations in worst
- worst: Error 483 (0=0 stationarity) → MODEL STATUS 1 Optimal (MCP obj=20.8M, ~0.7% from NLP)

## Details

Table parameters like `pdata(i,t,j,*)` store row headers as dotted strings (`('9000011.jun.1', 'type')`). The condition evaluator was constructing individual-element tuples (`('9000011', 'jun', '1', 'type')`) which didn't match. The fallback tries dotted variants progressively.

## Test plan

- [x] `make test` — 4396 passed, 10 skipped, 1 xfailed
- [x] `make typecheck && make lint && make format` — all clean
- [x] worst: MODEL STATUS 1 Optimal (was Error 483)
- [x] 5 unit tests for `_try_dotted_key_lookup`