### PR TITLE
Partial fix tricp: gradient condition index remapping (#1062)

### DIFF
--- a/docs/issues/ISSUE_1062_tricp-unmatched-slp-sln-variables.md
+++ b/docs/issues/ISSUE_1062_tricp-unmatched-slp-sln-variables.md
@@ -96,8 +96,28 @@ This is similar to the multiplier domain widening pattern but in reverse — her
 
 ---
 
-## Progress (2026-04-01)
+## Sprint 24 Progress
 
-**Blocked by compilation errors.** The tricp MCP has $148/$149 compilation errors (dimension mismatch, uncontrolled set) from the stationarity equations that must be fixed before the unmatched variable issue can be addressed. These compilation errors are tracked in [ISSUE_933_tricp-mcp-compilation-errors.md](ISSUE_933_tricp-mcp-compilation-errors.md).
+### Fix 1: Gradient condition index remapping (compilation fix)
+Added `_remap_condition_to_domain` in `stationarity.py` that remaps gradient
+condition indices to the variable's domain. `SetMembershipTest(e, (n, i))` →
+`SetMembershipTest(e, (n, n))` when the variable domain is `(n, n)`.
 
-The 760 unmatched variable errors described above may still exist but cannot be verified until the compilation errors are resolved.
+**Result:** Compilation errors ($149) resolved. Unmatched variables reduced
+from 760 to 108.
+
+### Remaining: 108 unmatched variables
+The 108 remaining unmatched variables are EDGE instances of `slp`/`slp`
+where the stationarity equation `stat_slp(n,n)` is valid but doesn't
+reference variable `slp`. This is because `slp` has derivative = 1 in
+`eq1` (linear coefficient), so the stationarity reduces to
+`nu_eq1 + bounds = 0` — the variable itself doesn't appear.
+
+**NOT FIXED** — this is a fundamental MCP formulation issue where variables
+with unit-coefficient derivatives produce stationarity equations that
+don't reference the paired variable. GAMS MCP requires the paired
+variable to appear in the equation.
+
+Possible fix: add `0*slp(n,n)` dummy term to force the variable reference
+in the stationarity equation, or use a different MCP formulation for
+linear variables.

--- a/docs/issues/ISSUE_1062_tricp-unmatched-slp-sln-variables.md
+++ b/docs/issues/ISSUE_1062_tricp-unmatched-slp-sln-variables.md
@@ -107,7 +107,7 @@ condition indices to the variable's domain. `SetMembershipTest(e, (n, i))` →
 from 760 to 108.
 
 ### Remaining: 108 unmatched variables
-The 108 remaining unmatched variables are EDGE instances of `slp`/`slp`
+The 108 remaining unmatched variables are EDGE instances of `slp`/`sln`
 where the stationarity equation `stat_slp(n,n)` is valid but doesn't
 reference variable `slp`. This is because `slp` has derivative = 1 in
 `eq1` (linear coefficient), so the stationarity reduces to

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -340,7 +340,7 @@ def _extract_all_conditioned_guard(
     return combined
 
 
-def _remap_condition_to_domain(cond: Expr, var_domain: tuple[str, ...], model_ir: ModelIR) -> Expr:
+def _remap_condition_to_domain(cond: Expr, var_domain: tuple[str, ...]) -> Expr:
     """Remap condition indices to match the variable's domain.
 
     Issue #1062: Gradient conditions may use equation-context indices
@@ -352,9 +352,9 @@ def _remap_condition_to_domain(cond: Expr, var_domain: tuple[str, ...], model_ir
         return cond
 
     new_indices: list[Expr] = []
-    domain_set = set(var_domain)
+    domain_lower = {d.lower() for d in var_domain}
     for pos, idx in enumerate(cond.indices):
-        if isinstance(idx, SymbolRef) and idx.name not in domain_set:
+        if isinstance(idx, SymbolRef) and idx.name.lower() not in domain_lower:
             # This index is from the equation context, not the variable domain.
             # Replace with the variable domain index at this position.
             if pos < len(var_domain):
@@ -1023,9 +1023,7 @@ def build_stationarity_equations(
                     # (e.g., e(n,i)) that don't match the variable domain
                     # (e.g., (n,n)). Replace any non-domain indices with the
                     # variable's domain indices at the corresponding position.
-                    access_cond = _remap_condition_to_domain(
-                        access_cond, var_def.domain, kkt.model_ir
-                    )
+                    access_cond = _remap_condition_to_domain(access_cond, var_def.domain)
 
             # Issue #1147: For MCP compatibility, don't put the access condition
             # on the equation head — GAMS MCP requires equation and variable to

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -340,6 +340,38 @@ def _extract_all_conditioned_guard(
     return combined
 
 
+def _remap_condition_to_domain(cond: Expr, var_domain: tuple[str, ...], model_ir: ModelIR) -> Expr:
+    """Remap condition indices to match the variable's domain.
+
+    Issue #1062: Gradient conditions may use equation-context indices
+    (e.g., SetMembershipTest(e, (n, i))) that don't match the variable
+    domain (e.g., (n, n)). Replace non-domain SymbolRef indices with
+    the variable's domain index at the corresponding position.
+    """
+    if not isinstance(cond, SetMembershipTest) or not var_domain:
+        return cond
+
+    new_indices: list[Expr] = []
+    domain_set = set(var_domain)
+    for pos, idx in enumerate(cond.indices):
+        if isinstance(idx, SymbolRef) and idx.name not in domain_set:
+            # This index is from the equation context, not the variable domain.
+            # Replace with the variable domain index at this position.
+            if pos < len(var_domain):
+                new_indices.append(SymbolRef(var_domain[pos]))
+            else:
+                new_indices.append(idx)
+        else:
+            new_indices.append(idx)
+
+    if any(
+        isinstance(n, SymbolRef) and isinstance(o, SymbolRef) and n.name != o.name
+        for n, o in zip(new_indices, cond.indices, strict=False)
+    ):
+        return SetMembershipTest(cond.set_name, tuple(new_indices))
+    return cond
+
+
 def _find_variable_access_condition(
     var_name: str,
     var_domain: tuple[str, ...],
@@ -986,6 +1018,14 @@ def build_stationarity_equations(
                     )
                 if not unconditioned_cache[var_name]:
                     access_cond = kkt.gradient_conditions[var_name]
+                    # Issue #1062: Remap condition indices to variable domain.
+                    # The gradient condition may use equation-context indices
+                    # (e.g., e(n,i)) that don't match the variable domain
+                    # (e.g., (n,n)). Replace any non-domain indices with the
+                    # variable's domain indices at the corresponding position.
+                    access_cond = _remap_condition_to_domain(
+                        access_cond, var_def.domain, kkt.model_ir
+                    )
 
             # Issue #1147: For MCP compatibility, don't put the access condition
             # on the equation head — GAMS MCP requires equation and variable to

--- a/tests/unit/kkt/test_remap_condition_to_domain.py
+++ b/tests/unit/kkt/test_remap_condition_to_domain.py
@@ -33,12 +33,14 @@ class TestRemapConditionToDomain:
         assert result is cond  # Unchanged
 
     def test_case_insensitive_match(self):
-        """E(N,I) with domain (n,n) → E(n,n) (case-insensitive)."""
+        """E(N,I) with domain (n,n) → E(N,n): N preserved, I replaced."""
         cond = SetMembershipTest("E", (SymbolRef("N"), SymbolRef("I")))
         result = _remap_condition_to_domain(cond, ("n", "n"))
 
         assert isinstance(result, SetMembershipTest)
-        # N is in domain (case-insensitive match), I is not → replaced
+        # N matches domain 'n' case-insensitively → preserved as-is
+        assert result.indices[0].name == "N"
+        # I not in domain → replaced with domain[1] = 'n'
         assert result.indices[1].name == "n"
 
     def test_non_smt_condition_unchanged(self):

--- a/tests/unit/kkt/test_remap_condition_to_domain.py
+++ b/tests/unit/kkt/test_remap_condition_to_domain.py
@@ -1,0 +1,49 @@
+"""Test gradient condition index remapping.
+
+Issue #1062: When a variable's gradient condition uses equation-context
+indices (e.g., e(n,i)) that don't match the variable domain (e.g., (n,n)),
+_remap_condition_to_domain replaces non-domain indices with the variable's
+domain indices at the corresponding position.
+"""
+
+import pytest
+
+from src.ir.ast import SetMembershipTest, SymbolRef
+from src.kkt.stationarity import _remap_condition_to_domain
+
+
+@pytest.mark.unit
+class TestRemapConditionToDomain:
+    def test_replaces_non_domain_index(self):
+        """e(n,i) with domain (n,n) → e(n,n)."""
+        cond = SetMembershipTest("e", (SymbolRef("n"), SymbolRef("i")))
+        result = _remap_condition_to_domain(cond, ("n", "n"))
+
+        assert isinstance(result, SetMembershipTest)
+        assert result.set_name == "e"
+        assert len(result.indices) == 2
+        assert result.indices[0].name == "n"
+        assert result.indices[1].name == "n"
+
+    def test_preserves_matching_indices(self):
+        """e(i,j) with domain (i,j) → unchanged."""
+        cond = SetMembershipTest("e", (SymbolRef("i"), SymbolRef("j")))
+        result = _remap_condition_to_domain(cond, ("i", "j"))
+
+        assert result is cond  # Unchanged
+
+    def test_case_insensitive_match(self):
+        """E(N,I) with domain (n,n) → E(n,n) (case-insensitive)."""
+        cond = SetMembershipTest("E", (SymbolRef("N"), SymbolRef("I")))
+        result = _remap_condition_to_domain(cond, ("n", "n"))
+
+        assert isinstance(result, SetMembershipTest)
+        # N is in domain (case-insensitive match), I is not → replaced
+        assert result.indices[1].name == "n"
+
+    def test_non_smt_condition_unchanged(self):
+        """Non-SetMembershipTest conditions pass through."""
+        from src.ir.ast import Const
+
+        result = _remap_condition_to_domain(Const(1.0), ("n", "n"))
+        assert isinstance(result, Const)


### PR DESCRIPTION
## Summary

- Added `_remap_condition_to_domain` that remaps gradient condition indices to the variable's domain
- Fixes `SetMembershipTest(e, (n, i))` → `SetMembershipTest(e, (n, n))` when variable domain is `(n, n)`
- tricp: 760 errors → 108 (compilation $149 errors resolved)

## Remaining

108 unmatched edge instances where `slp`/`sln` have derivative=1, producing stationarity equations that don't reference the paired variable (fundamental MCP formulation issue).

## Test plan

- [x] `make test` — 4396 passed, 10 skipped, 1 xfailed
- [x] `make typecheck && make lint && make format` — all clean
- [x] tricp: compiles (was $149 errors)