### PR TITLE
Fix twocge: ord(JPN) compilation error + plan (#906)

### DIFF
--- a/docs/issues/ISSUE_1251_twocge-empty-trade-equations-r-eq-rr.md
+++ b/docs/issues/ISSUE_1251_twocge-empty-trade-equations-r-eq-rr.md
@@ -1,0 +1,120 @@
+# twocge: Empty Trade Equations When r=rr (8 MCP Pairing Errors)
+
+**GitHub Issue:** [#1251](https://github.com/jeffreyhorn/nlp2mcp/issues/1251)
+**Status:** OPEN
+**Severity:** Medium — Model compiles but EXECERROR=8 aborts solve
+**Date:** 2026-04-10
+**Last Updated:** 2026-04-10
+**Affected Models:** twocge
+
+---
+
+## Problem Summary
+
+After fixing the `ord(JPN)` compilation error (#906), twocge compiles but
+GAMS aborts the solve with EXECERROR=8 from empty equation MCP pairing errors.
+The trade equations `eqpw(i,r,rr)` and `eqw(i,r,rr)` have condition
+`$(ord(r) <> ord(rr))` which evaluates to false when `r = rr` (same country),
+producing 0=0 equations for those instances. Their multipliers are not fixed.
+
+---
+
+## Current Status
+
+- **Translation**: Success
+- **GAMS compilation**: Success (0 errors)
+- **PATH solve**: EXECERROR=8 (empty equation, variable NOT fixed)
+- **Pipeline category**: path_solve_terminated
+- **Previous fixes**: #906 (ord(JPN) compilation, USA SAM data, post-solve ordering)
+
+---
+
+## Error Details
+
+```
+**** MCP pair eqpw.nu_eqpw has empty equation but associated variable is NOT fixed
+     nu_eqpw(BRD,JPN,JPN)
+     nu_eqpw(BRD,USA,USA)
+     nu_eqpw(MLK,JPN,JPN)
+     nu_eqpw(MLK,USA,USA)
+**** MCP pair eqw.nu_eqw has empty equation but associated variable is NOT fixed
+     nu_eqw(BRD,JPN,JPN)
+     nu_eqw(BRD,USA,USA)
+     nu_eqw(MLK,JPN,JPN)
+     nu_eqw(MLK,USA,USA)
+**** SOLVE from line 672 ABORTED, EXECERROR = 8
+```
+
+---
+
+## Root Cause
+
+The trade equations use `$(ord(r) <> ord(rr))` to exclude same-country pairs:
+
+```gams
+eqpw(i,r,rr).. (pWe(i,r) - pWm(i,rr))$(ord(r) <> ord(rr)) =e= 0;
+eqw(i,r,rr)..  (E(i,r) - M(i,rr))$(ord(r) <> ord(rr)) =e= 0;
+```
+
+For instances where `r = rr` (e.g., `(BRD, JPN, JPN)`), the condition is
+false and the equation body is 0. GAMS requires the paired multiplier to be
+fixed for empty equation instances.
+
+The existing empty equation detector (`src/kkt/empty_equation_detector.py`)
+handles sparse coefficient data but not `ord()` comparison conditions.
+
+---
+
+## Reproduction
+
+**Prerequisite:** GAMSlib raw sources in `data/gamslib/raw/`
+(run `python scripts/gamslib/download_models.py`).
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/twocge.gms -o /tmp/twocge_mcp.gms --quiet
+gams /tmp/twocge_mcp.gms lo=0
+
+# Output:
+# **** MCP pair eqpw.nu_eqpw has empty equation but associated variable is NOT fixed
+# **** SOLVE from line 672 ABORTED, EXECERROR = 8
+```
+
+---
+
+## Potential Fix Approaches
+
+1. **Emit `ord()` condition on multiplier `.fx`**: Detect equations with
+   `$(ord(r) <> ord(rr))` conditions and emit:
+   ```gams
+   nu_eqpw.fx(i,r,rr)$(ord(r) = ord(rr)) = 0;
+   nu_eqw.fx(i,r,rr)$(ord(r) = ord(rr)) = 0;
+   ```
+   This is the most direct fix — negate the equation condition and apply to
+   the multiplier. Requires the emitter to detect `ord()` conditions in the
+   original equation and emit the negated form.
+
+2. **Extend empty equation detector**: Add support for `ord()` comparison
+   conditions in `detect_empty_equation_instances`. When a condition like
+   `$(ord(r) <> ord(rr))` is detected, compute which instances make it false
+   (same-set elements at the same ordinal position) and mark those as empty.
+
+3. **Emit equation condition on multiplier**: The equation `eqpw` has
+   `condition = None` (the `$` is on the body, not the head). If the
+   condition were on the equation head, the existing multiplier `.fx`
+   logic would handle it. Could lift the body condition to the head.
+
+---
+
+## Files Involved
+
+- `src/emit/emit_gams.py` — Multiplier `.fx` emission
+- `src/kkt/stationarity.py` — Equation condition detection
+- `src/kkt/empty_equation_detector.py` — Empty equation detection
+- `data/gamslib/raw/twocge.gms` — Original model (~340 lines)
+
+---
+
+## Related Issues
+
+- #906 (PARTIALLY FIXED) — ord(JPN), USA SAM, post-solve ordering
+- #1133 (FIXED) — fawley empty equation detection (similar pattern)

--- a/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
+++ b/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
@@ -90,6 +90,32 @@ grep -c '^\*\*\*\* ' /tmp/twocge_mcp.lst  # 32 (28 exec + 4 meta)
 2. **Post-solve code ordering**: The emitter should place post-solve parameter assignments after the solve statement, not before.
 3. **Trade equations with cross-index conditioning**: Investigate whether `eqpw(i,r,rr)` with `$(ord(r) <> ord(rr))` is handled by KKT derivation. These may need special support for multi-region equilibrium conditions.
 
+## Sprint 24 Investigation
+
+**Status: NOT FIXED** — errors changed from runtime (28 EXECERROR) to
+compilation (Error 140/154/198/651).
+
+The trade equations `eqpw(i,r,rr)` and `eqw(i,r,rr)` with condition
+`$(ord(r) <> ord(rr))` produce stationarity terms like:
+```
+sum(rr, 1$(ord(JPN) <> ord(JPN)) * nu_eqw(i,r,rr))
+```
+
+The `ord(JPN)` is invalid GAMS (Error 651: ord needs a 1D set, not a
+concrete element). The `_replace_indices_in_expr` ord() handler maps
+the set element `JPN` to itself instead of the equation domain name `r`.
+
+This is the same class as the otpop ord() fix (#1178) but for a different
+code path — the concrete element substitution in stationarity equation
+assembly uses `JPN` (from single-instance evaluation) instead of the
+symbolic set name.
+
+**Remaining issues:**
+1. `ord(JPN)` → should be `ord(r)` or `ord(rr)` (compilation fix)
+2. Missing USA SAM continuation data (parser issue)
+3. Post-solve code ordering (emitter issue)
+
 ## Related Issues
 
 - Issue #901 — twocge dotted table column headers (RESOLVED by Day 7 dotted column header fix)
+- Issue #1178 — otpop ord() remapping (FIXED, related pattern)

--- a/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
+++ b/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
@@ -105,15 +105,29 @@ The `ord(JPN)` is invalid GAMS (Error 651: ord needs a 1D set, not a
 concrete element). The `_replace_indices_in_expr` ord() handler maps
 the set element `JPN` to itself instead of the equation domain name `r`.
 
-This is the same class as the otpop ord() fix (#1178) but for a different
-code path — the concrete element substitution in stationarity equation
-assembly uses `JPN` (from single-instance evaluation) instead of the
-symbolic set name.
+### Fix 2: ord(JPN) compilation error (Sprint 24 Day 10)
 
-**Remaining issues:**
-1. `ord(JPN)` → should be `ord(r)` or `ord(rr)` (compilation fix)
-2. Missing USA SAM continuation data (parser issue)
-3. Post-solve code ordering (emitter issue)
+Root cause: In the `_replace_indices_in_expr` ord() handler, concrete
+elements like `JPN` were being treated as "bound indices" (via ChainMap
+detection) and preserved as-is. The fix: only treat set/alias names as
+bound — concrete elements should still be remapped to the equation domain.
+
+Changed the `bound_index_names` check to also verify the name is a set
+or alias before skipping.
+
+**Result:** Compilation errors ($140/$154/$198/$651) resolved.
+
+### Remaining: 8 empty equation MCP errors
+
+`eqpw(i,r,rr)` and `eqw(i,r,rr)` with `$(ord(r) <> ord(rr))` produce
+empty equations when `r = rr` (same country). The multipliers for these
+instances need to be fixed to 0. The empty equation detector can't handle
+`ord()` comparison conditions.
+
+**Summary of all 3 original issues:**
+1. ✅ Missing USA SAM continuation data — FIXED (by prior parser improvements)
+2. ✅ `ord(JPN)` compilation error — FIXED (bound index check tightened)
+3. ✅ Post-solve code ordering — FIXED (by prior emitter improvements)
 
 ## Related Issues
 

--- a/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
+++ b/docs/issues/ISSUE_906_twocge-missing-usa-sam-post-solve-trade-equations.md
@@ -52,7 +52,10 @@ eqpw(i,r,rr)..  (pWe(i,r) - pWm(i,rr))$(ord(r) <> ord(rr)) =e= 0;
 eqw(i,r,rr)..   (E(i,r) - M(i,rr))$(ord(r) <> ord(rr)) =e= 0;
 ```
 
-These cross-country trade equations are not present in the emitted MCP. They use a third index `rr` with `ord(r) <> ord(rr)` conditioning, which may not be handled by the KKT derivation.
+These cross-country trade equations were initially missing from the emitted MCP
+(as of Sprint 21). They are now emitted in the stationarity equations (as of
+Sprint 24), but the `$(ord(r) <> ord(rr))` condition produces empty equations
+when `r = rr` (same country), causing MCP pairing errors.
 
 ## Reproduction
 
@@ -107,10 +110,12 @@ the set element `JPN` to itself instead of the equation domain name `r`.
 
 ### Fix 2: ord(JPN) compilation error (Sprint 24 Day 10)
 
-Root cause: In the `_replace_indices_in_expr` ord() handler, concrete
-elements like `JPN` were being treated as "bound indices" (via ChainMap
-detection) and preserved as-is. The fix: only treat set/alias names as
-bound — concrete elements should still be remapped to the equation domain.
+Root cause: `ord()` requires a set index variable (e.g., `r` or `rr`), not
+a set element label (e.g., `JPN`). In the `_replace_indices_in_expr` ord()
+handler, element labels like `JPN` in the ChainMap overlay were being
+treated as "bound indices" and preserved as-is. The fix: only treat
+set/alias names as bound — element labels should be remapped to the
+equation domain variable.
 
 Changed the `bound_index_names` check to also verify the name is a set
 or alias before skipping.

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
@@ -1,0 +1,174 @@
+# Plan: Fix twocge Compilation Errors (#906)
+
+**Goal:** Fix `ord(JPN)` compilation errors in twocge stationarity equations
+so the model compiles and reaches PATH solver.
+
+**Estimated effort:** 2-3 hours
+**Models unblocked:** twocge
+
+---
+
+## Current State (Sprint 24)
+
+Two of the three original issues are RESOLVED by prior fixes:
+- **USA SAM data**: ✅ FIXED — 60 values (30 JPN + 30 USA) correctly captured
+- **Post-solve code ordering**: ✅ FIXED — percentage-change assignments no
+  longer emitted before solve
+
+**Remaining:** 4 compilation errors (Error 140/154/198/651) from `ord(JPN)`
+in stationarity equations.
+
+---
+
+## Problem: `ord(JPN)` in Stationarity
+
+### Affected Equations
+
+Four stationarity equations contain `ord(JPN) <> ord(JPN)`:
+- `stat_e(i,r)`: `sum(rr, 1$(ord(JPN) <> ord(JPN)) * nu_eqw(i,r,rr))`
+- `stat_m(i,r)`: `sum(rr, (-1)$(ord(JPN) <> ord(JPN)) * nu_eqw(i,r,rr))`
+- `stat_pwe(i,r)`: `sum(rr, 1$(ord(JPN) <> ord(JPN)) * nu_eqpw(i,r,rr))`
+- `stat_pwm(i,r)`: `sum(rr, (-1)$(ord(JPN) <> ord(JPN)) * nu_eqpw(i,r,rr))`
+
+### GAMS Errors
+
+- **Error 651**: `ord` can only be referenced with a 1-dimensional set
+  (`JPN` is an element, not a set)
+- **Error 140**: Unknown symbol
+- **Error 154**: Set for 'ord' is not controlled
+- **Error 198**: Set used in 'ord' is not ordered
+
+### Root Cause
+
+The original trade equations use `$(ord(r) <> ord(rr))`:
+
+```gams
+eqpw(i,r,rr).. (pWe(i,r) - pWm(i,rr))$(ord(r) <> ord(rr)) =e= 0;
+eqw(i,r,rr)..  (E(i,r) - M(i,rr))$(ord(r) <> ord(rr)) =e= 0;
+```
+
+The equation body is `DollarConditional(expr, Binary(<>, Call(ord, r), Call(ord, rr)))`.
+
+When the stationarity builder processes `∂eqw/∂e(i,r)`, the Jacobian term
+carries the condition `$(ord(r) <> ord(rr))`. During `_replace_indices_in_expr`,
+the symbolic `r` gets replaced with the concrete element `JPN` (from element-
+to-set mapping). But `ord(JPN)` is invalid GAMS — `ord()` requires a set
+variable, not a concrete element.
+
+### Where the Substitution Happens
+
+In `_replace_indices_in_expr` (stationarity.py), the `Call("ord", ...)` handler
+(added in Sprint 24 Day 8 for #1178) remaps concrete elements to equation-domain
+set names. But this handler only fires for the equation domain indices — `r` and
+`rr` are from the CONSTRAINT domain, not the stationarity equation domain (`i`,
+`r`). The `rr` index is NOT in the stationarity equation domain.
+
+Specifically:
+- Stationarity equation domain: `stat_e(i, r)` — indices `i`, `r`
+- Constraint domain: `eqw(i, r, rr)` — indices `i`, `r`, `rr`
+- The `sum(rr, ...)` wraps the multiplier term and binds `rr`
+- Inside the sum, `ord(r)` should stay as `ord(r)` (it's in the stationarity domain)
+- `ord(rr)` should stay as `ord(rr)` (it's bound by the enclosing sum)
+- But `_replace_indices_in_expr` maps `r` → `JPN` and `rr` → `JPN` (concrete elements)
+
+The existing ord() handler checks:
+1. If the argument is a concrete element → map to equation domain
+2. If the argument is a set/alias → check subset relationships
+
+For `r`: it's in the stationarity domain `(i, r)` so it should stay as `r`.
+But the `element_to_set` mapping has `JPN → r`, suggesting `r` was already
+substituted to `JPN` BEFORE reaching the ord() handler.
+
+The substitution `r → JPN` happens in `_substitute_sum_indices` during AD
+sum collapse, or in `_replace_indices_in_expr`'s VarRef/ParamRef handling.
+The ord() handler then tries to reverse-map `JPN` back to `r`, which should
+work for `ord(r)` but fails for `ord(rr)` because `rr` is also mapped to `JPN`
+and the handler picks the wrong domain variable.
+
+### Key Insight
+
+Both `r` and `rr` map to `JPN` (same element). The ord() handler maps `JPN`
+back to the equation domain, but there's only one `r` in the domain —
+`rr` is a sum variable, not an equation domain variable. The handler can't
+distinguish between `r` (domain) and `rr` (sum-bound) when both map to
+the same concrete element.
+
+---
+
+## Fix Approach
+
+### Option A: Preserve ord() arguments during index substitution (~2h)
+
+**Principle:** Don't substitute SymbolRef arguments inside `Call("ord", ...)`
+and `Call("card", ...)` when the argument is a set/alias name that's bound
+by the enclosing sum or the equation domain.
+
+**Implementation:**
+
+1. In `_replace_indices_in_expr`, the `Call("ord", ...)` handler already
+   checks `bound_index_names` (from ChainMap) and `is_set_or_alias`. The
+   issue is that the `ord(r)` and `ord(rr)` arguments arrive as
+   `SymbolRef("JPN")` instead of `SymbolRef("r")` — the substitution
+   happened upstream.
+
+2. The fix should be in the **upstream substitution** — prevent
+   `_substitute_sum_indices` from replacing `SymbolRef` inside `Call("ord")`
+   and `Call("card")`. This was partially done in Sprint 24 Day 8 (the
+   `card/ord` special case in `_apply_index_substitution`), but the
+   existing handler only skips SymbolRef DIRECTLY inside `Call("card"/
+   "ord")`, not SymbolRef inside nested expressions like
+   `Binary(<>, Call(ord, SymbolRef(r)), Call(ord, SymbolRef(rr)))`.
+
+3. Check: does the `_apply_index_substitution` `Call("card"/"ord")` handler
+   from #1178 handle this case? It should — the `SymbolRef("r")` is
+   directly inside `Call("ord", SymbolRef("r"))`.
+
+4. If the upstream handler works correctly, the issue is that the
+   substitution happens AFTER `_apply_index_substitution` — perhaps in
+   `_replace_indices_in_expr` itself.
+
+**Investigation needed:** Trace exactly WHERE `r` → `JPN` substitution
+happens for the `ord(r)` argument. Add debug logging to
+`_replace_indices_in_expr` for the twocge model and check:
+- Does `ord(r)` arrive at `_replace_indices_in_expr` with `SymbolRef("r")`
+  or `SymbolRef("JPN")`?
+- If `SymbolRef("JPN")`, which upstream step substituted it?
+
+### Option B: Fix ord() handler to recognize sum-bound elements (~1h)
+
+If the substitution is in `_replace_indices_in_expr` itself (not upstream),
+fix the `ord()` handler to also recognize names bound by enclosing `Sum`
+nodes (via ChainMap detection) and map them to the correct sum variable
+instead of the equation domain.
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/twocge.gms -o /tmp/twocge_mcp.gms --quiet
+gams /tmp/twocge_mcp.gms lo=0
+
+# Errors:
+# stat_e(i,r).. ... sum(rr, 1$(ord(JPN) <> ord(JPN)) * nu_eqw(i,r,rr)) ...
+#                                  $140,198,651,154,198,651,154
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/kkt/stationarity.py` | `_replace_indices_in_expr` ord() handler |
+| `src/ad/derivative_rules.py` | Possibly `_apply_index_substitution` card/ord handler |
+
+## Risk Assessment
+
+**Medium risk:** The ord() handler is shared by all models. Changes must
+not break the otpop fix (#1178) or the himmel16 alias protection.
+
+## Verification
+
+1. twocge compiles (no Error 651)
+2. otpop still compiles (regression check)
+3. himmel16 still solves correctly (regression check)
+4. `make test` passes

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
@@ -33,7 +33,8 @@ Four stationarity equations contain `ord(JPN) <> ord(JPN)`:
 ### GAMS Errors
 
 - **Error 651**: `ord` can only be referenced with a 1-dimensional set
-  (`JPN` is an element, not a set)
+  (substituted element label `JPN` where a controlled set index variable
+  like `r` is required)
 - **Error 140**: Unknown symbol
 - **Error 154**: Set for 'ord' is not controlled
 - **Error 198**: Set used in 'ord' is not ordered

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_906.md
@@ -145,6 +145,9 @@ instead of the equation domain.
 
 ## Reproduction
 
+**Prerequisite:** GAMSlib raw sources must be downloaded into `data/gamslib/raw/`
+(run `python scripts/gamslib/download_models.py`).
+
 ```bash
 .venv/bin/python -m src.cli data/gamslib/raw/twocge.gms -o /tmp/twocge_mcp.gms --quiet
 gams /tmp/twocge_mcp.gms lo=0

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -2580,19 +2580,6 @@ def _apply_index_substitution(expr: Expr, substitution: dict[str, str]) -> Expr:
         new_child = _apply_index_substitution(expr.child, substitution)
         return Unary(expr.op, new_child)
     elif isinstance(expr, Call):
-        if expr.func in ("card", "ord"):
-            # Issue #906: Don't substitute SymbolRef arguments inside
-            # card/ord — these require set names, not concrete elements.
-            # The downstream _replace_indices_in_expr handles remapping
-            # concrete elements back to domain names, but it's safer to
-            # preserve symbolic names here to avoid ord(JPN) errors.
-            new_args_list: list[Expr] = []
-            for arg in expr.args:
-                if isinstance(arg, SymbolRef) and arg.name in substitution:
-                    new_args_list.append(arg)  # Keep symbolic name
-                else:
-                    new_args_list.append(_apply_index_substitution(arg, substitution))
-            return Call(expr.func, tuple(new_args_list))
         # Recursively substitute in all arguments
         new_args = tuple(_apply_index_substitution(arg, substitution) for arg in expr.args)
         return Call(expr.func, new_args)

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -2580,6 +2580,19 @@ def _apply_index_substitution(expr: Expr, substitution: dict[str, str]) -> Expr:
         new_child = _apply_index_substitution(expr.child, substitution)
         return Unary(expr.op, new_child)
     elif isinstance(expr, Call):
+        if expr.func in ("card", "ord"):
+            # Issue #906: Don't substitute SymbolRef arguments inside
+            # card/ord — these require set names, not concrete elements.
+            # The downstream _replace_indices_in_expr handles remapping
+            # concrete elements back to domain names, but it's safer to
+            # preserve symbolic names here to avoid ord(JPN) errors.
+            new_args_list: list[Expr] = []
+            for arg in expr.args:
+                if isinstance(arg, SymbolRef) and arg.name in substitution:
+                    new_args_list.append(arg)  # Keep symbolic name
+                else:
+                    new_args_list.append(_apply_index_substitution(arg, substitution))
+            return Call(expr.func, tuple(new_args_list))
         # Recursively substitute in all arguments
         new_args = tuple(_apply_index_substitution(arg, substitution) for arg in expr.args)
         return Call(expr.func, new_args)

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -2265,8 +2265,11 @@ def _replace_indices_in_expr(
                         name = arg.name
                         # Skip bound indices (controlled by enclosing sum)
                         if name in bound_index_names:
-                            new_args_list.append(arg)
-                            continue
+                            # Only skip if it's a set/alias name, not a concrete
+                            # element that happens to be in the ChainMap overlay.
+                            if name in model_ir.sets or name in model_ir.aliases:
+                                new_args_list.append(arg)
+                                continue
                         is_set_or_alias = name in model_ir.sets or name in model_ir.aliases
                         if not is_set_or_alias and name in element_to_set:
                             # Concrete element → map to equation domain


### PR DESCRIPTION
## Summary

- Fix ord() handler: only treat set/alias names as bound indices, not concrete elements in ChainMap overlay
- Add card/ord special case in _apply_index_substitution to preserve symbolic args
- twocge: Error 140/154/198/651 → compiles (8 MCP empty equation errors remain)
- All 3 original issues resolved (USA SAM, ord(JPN), post-solve ordering)

## Test plan

- [x] `make test` — 4400 passed, 10 skipped, 1 xfailed
- [x] `make typecheck && make lint && make format` — all clean
- [x] twocge: compiles (was Error 651)
- [x] otpop: still compiles (regression check)