### PR TITLE
Fix harker MCP compilation error: attr_access in loop body emission

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_HARKER.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_HARKER.md
@@ -1,0 +1,147 @@
+# Plan: Fix harker MCP Compilation Error (Error 140)
+
+**Goal:** Fix the GAMS compilation error in harker's MCP output so the
+model can be solved by PATH.
+
+**Estimated effort:** 1 hour
+**Models unblocked:** harker (and potentially other models with model
+attribute access in loop body assignments)
+
+---
+
+## Current State
+
+harker translates successfully but the emitted MCP file fails GAMS
+compilation with Error 140 (Unknown symbol) on this line:
+
+```gams
+objold = harkoli objVal ;
+```
+
+Should be:
+
+```gams
+objold = harkoli.objVal ;
+```
+
+The dot between the model name and attribute is missing.
+
+---
+
+## Root Cause
+
+The harker model uses a `loop` with a filter condition and body
+assignments that reference model attributes:
+
+```gams
+loop(iter$(abs(objold - harkoli.objVal) > 1e-5),
+   objold = harkoli.objVal;
+   solve harkoli maximizing obj using nlp;
+   ...
+);
+```
+
+The emitter has two code paths for loop body trees:
+
+1. **`_loop_tree_to_gams()`** (line 2555 of `original_symbols.py`):
+   Correctly handles `attr_access` nodes with `".".join(children)`.
+
+2. **`_loop_tree_to_gams_subst_dispatch()`** (line 2957): Used by
+   `emit_pre_solve_param_assignments()` to emit parameter assignments
+   from before the first solve in solve-containing loops. This function
+   handles many tree node types but **does NOT handle `attr_access`**,
+   so it falls through to the fallback at line 3040:
+   `" ".join(children)` — producing `harkoli objVal` instead of
+   `harkoli.objVal`.
+
+The `objold = harkoli.objVal` assignment is emitted by
+`emit_pre_solve_param_assignments()` because the loop contains a solve
+statement (so the full loop is skipped by `emit_loop_statements()`),
+but the pre-solve assignment `objold = harkoli.objVal` is extracted
+and emitted separately.
+
+---
+
+## Fix
+
+### Primary: Add `attr_access` handling to `_loop_tree_to_gams_subst_dispatch()`
+
+**File:** `src/emit/original_symbols.py`, line ~2957
+
+Add a case for `attr_access` (and `attr_access_indexed`, `set_attr`)
+to the dispatch function, mirroring the handling in `_loop_tree_to_gams()`:
+
+```python
+if data in ("set_attr", "attr_access"):
+    return ".".join(_tree_to_gams_subst(c, subst) for c in node.children)
+if data == "attr_access_indexed":
+    name = _tree_to_gams_subst(node.children[0], subst)
+    attr = _tree_to_gams_subst(node.children[1], subst)
+    idx = _tree_to_gams_subst(node.children[2], subst)
+    return f"{name}.{attr}({idx})"
+```
+
+This should also fix the `solPrint` assignment in the same loop body:
+```gams
+harkoli.solPrint = 0 ;  (currently: harkoli solPrint = 0 ;)
+```
+
+### Secondary: Check filter condition emission
+
+The filter condition `$(abs(objold - harkoli.objVal) > 1e-5)` goes
+through `_loop_tree_to_gams()` which already handles `attr_access`.
+Verify this works correctly after the fix.
+
+---
+
+## Verification
+
+```bash
+python -m src.cli data/gamslib/raw/harker.gms -o /tmp/harker_mcp.gms --quiet
+
+# Check the emitted line has the dot
+grep "objold.*harkoli" /tmp/harker_mcp.gms
+# Expected: objold = harkoli.objVal ;
+
+# Compile check
+gams /tmp/harker_mcp.gms lo=0 o=/tmp/harker_check.lst
+grep "Error" /tmp/harker_check.lst
+# Expected: no errors
+
+# Solve
+gams /tmp/harker_mcp.gms lo=3 o=/tmp/harker_solve.lst
+grep "MODEL STATUS" /tmp/harker_solve.lst
+# Expected: MODEL STATUS 1 or 2
+```
+
+---
+
+## Other Models Affected
+
+34 models have model attribute access (`.objVal`, `.modelStat`,
+`.solveStat`, `.solPrint`) inside loops. Not all will hit this bug —
+only those processed by `emit_pre_solve_param_assignments()` (loops
+containing solve statements where pre-solve assignments are extracted).
+
+Models to recheck after the fix: cesam2, danwolfe, dyncge, lmp2,
+maxmin, meanvar, partssupply, saras, tricp (all currently failing
+with syntax errors or no solve summary).
+
+---
+
+## Success Criteria
+
+- [ ] `objold = harkoli.objVal ;` emitted with dot (not space)
+- [ ] harker MCP compiles without GAMS errors
+- [ ] harker solves to MODEL STATUS 1 or 2
+- [ ] No test regressions (`make test` passes)
+- [ ] Other models with loop-body attribute access unaffected or improved
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/emit/original_symbols.py` | Add `attr_access`/`set_attr`/`attr_access_indexed` to `_loop_tree_to_gams_subst_dispatch()` |
+| `tests/` | Add test for attr_access in loop body emission |

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -3096,7 +3096,7 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
             """
             if not isinstance(node, Tree):
                 return False
-            if str(node.data) == "attr_access":
+            if str(node.data) in ("attr_access", "attr_access_indexed"):
                 # Check if first child is a model name
                 if node.children and isinstance(node.children[0], Token):
                     ref = str(node.children[0]).lower()

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -3016,6 +3016,13 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
             return f"{idx_part}${cond_part}"
         if data == "tuple_domain":
             return f"({_tree_to_gams_subst(node.children[0], subst)})"
+        if data in ("set_attr", "attr_access"):
+            return ".".join(_tree_to_gams_subst(c, subst) for c in node.children)
+        if data == "attr_access_indexed":
+            name = _tree_to_gams_subst(node.children[0], subst)
+            attr = _tree_to_gams_subst(node.children[1], subst)
+            idx = _tree_to_gams_subst(node.children[2], subst)
+            return f"{name}.{attr}({idx})"
         if data in ("binop", "unaryop"):
             return " ".join(_tree_to_gams_subst(c, subst) for c in node.children)
         if data == "condition":
@@ -3080,6 +3087,29 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
                     return True
             return False
 
+        def _tree_has_model_attr(node: object) -> bool:
+            """Check if a tree contains a model attribute reference.
+
+            Model attribute references (e.g., harkoli.objVal) depend on
+            a prior solve result and should not be emitted as standalone
+            pre-solve assignments in the MCP context.
+            """
+            if not isinstance(node, Tree):
+                return False
+            if str(node.data) == "attr_access":
+                # Check if first child is a model name
+                if node.children and isinstance(node.children[0], Token):
+                    ref = str(node.children[0]).lower()
+                    if ref in model_names:
+                        return True
+            return any(_tree_has_model_attr(c) for c in node.children)
+
+        model_names = {
+            name.lower()
+            for name in list(model_ir.model_equation_map.keys())
+            + ([model_ir.model_name] if model_ir.model_name else [])
+        }
+
         # Extract pre-solve param assignments (including from inner loops)
         def _extract_pre_solve(stmts: list, sub: dict[str, str]) -> None:
             for stmt in stmts:
@@ -3114,6 +3144,11 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
                     continue
                 name = _lhs_name(stmt)
                 if name is None or name not in param_names:
+                    continue
+                # Skip assignments that reference model attributes
+                # (e.g., objold = harkoli.objVal) — these depend on a
+                # prior solve result and are meaningless in the MCP context.
+                if _tree_has_model_attr(stmt):
                     continue
                 gams_text = _tree_to_gams_subst(stmt, sub)
                 assign_lines.append(gams_text)

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -3116,9 +3116,9 @@ class TestLoopAttrAccessEmission:
         idx = Tree("index_list", [Tree("index_simple", [Token("ID", "i")])])
         node = Tree(
             "attr_access_indexed",
-            [Token("ID", "x"), Token("ID", "l"), idx],
+            [Token("ID", "x"), Token("ID", "scaleOpt"), idx],
         )
-        assert _loop_tree_to_gams(node) == "x.l(i)"
+        assert _loop_tree_to_gams(node) == "x.scaleOpt(i)"
 
     def test_set_attr_emits_dot(self):
         """set_attr node should emit 'i.ord'."""
@@ -3178,7 +3178,7 @@ class TestLoopAttrAccessEmission:
         assert "objVal" not in result
 
     def test_non_model_attr_not_filtered(self):
-        """Non-model attr_access (e.g., x.l) should still be emitted."""
+        """Non-model attr_access (e.g., x.scaleOpt) should still be emitted."""
         from lark import Token, Tree
 
         from src.emit.original_symbols import emit_pre_solve_param_assignments
@@ -3191,7 +3191,7 @@ class TestLoopAttrAccessEmission:
                 Token("EQUALS", "="),
                 Tree(
                     "attr_access",
-                    [Token("ID", "x"), Token("ID", "l")],
+                    [Token("ID", "x"), Token("ID", "scaleOpt")],
                 ),
                 Token("SEMICOLON", ";"),
             ],
@@ -3223,4 +3223,4 @@ class TestLoopAttrAccessEmission:
 
         result = emit_pre_solve_param_assignments(model)
         assert "myparam" in result
-        assert "x.l" in result
+        assert "x.scaleOpt" in result

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -3093,3 +3093,134 @@ class TestVarLevelLoopStatements:
             )
         ]
         assert emit_var_level_loop_statements(model) == ""
+
+
+class TestLoopAttrAccessEmission:
+    """Tests for attr_access handling in loop body emission (Issue: harker fix)."""
+
+    def test_attr_access_emits_dot(self):
+        """attr_access node should emit 'model.attr', not 'model attr'."""
+        from lark import Token, Tree
+
+        from src.emit.original_symbols import _loop_tree_to_gams
+
+        node = Tree("attr_access", [Token("ID", "harkoli"), Token("ID", "objVal")])
+        assert _loop_tree_to_gams(node) == "harkoli.objVal"
+
+    def test_attr_access_indexed_emits_dot_with_indices(self):
+        """attr_access_indexed should emit 'model.attr(idx)'."""
+        from lark import Token, Tree
+
+        from src.emit.original_symbols import _loop_tree_to_gams
+
+        idx = Tree("index_list", [Tree("index_simple", [Token("ID", "i")])])
+        node = Tree(
+            "attr_access_indexed",
+            [Token("ID", "x"), Token("ID", "l"), idx],
+        )
+        assert _loop_tree_to_gams(node) == "x.l(i)"
+
+    def test_set_attr_emits_dot(self):
+        """set_attr node should emit 'i.ord'."""
+        from lark import Token, Tree
+
+        from src.emit.original_symbols import _loop_tree_to_gams
+
+        node = Tree("set_attr", [Token("ID", "i"), Token("SET_ATTR_K", "ord")])
+        assert _loop_tree_to_gams(node) == "i.ord"
+
+    def test_model_attr_assignment_filtered(self):
+        """Assignments referencing model attributes should be skipped."""
+        from lark import Token, Tree
+
+        from src.emit.original_symbols import emit_pre_solve_param_assignments
+        from src.ir.symbols import LoopStatement
+
+        assign = Tree(
+            "assign",
+            [
+                Tree("lvalue", [Token("ID", "objold")]),
+                Token("EQUALS", "="),
+                Tree(
+                    "attr_access",
+                    [Token("ID", "m"), Token("ID", "objVal")],
+                ),
+                Token("SEMICOLON", ";"),
+            ],
+        )
+
+        model = ModelIR()
+        model.sets["iter"] = SetDef(name="iter", domain=(), members=["i1", "i2"])
+        model.params["objold"] = ParameterDef(name="objold", domain=(), values={(): 0.0})
+        model.model_equation_map["m"] = ["eq1"]
+
+        solve = Tree("solve", [Token("ID", "m")])
+        body = Tree("loop_body", [assign, solve])
+        loop_node = Tree(
+            "loop_stmt",
+            [
+                Token("LOOP", "loop"),
+                Tree("id_list", [Token("ID", "iter")]),
+                body,
+            ],
+        )
+        model.loop_statements = [
+            LoopStatement(
+                indices=("iter",),
+                body_stmts=[assign, solve],
+                location=None,
+                raw_node=loop_node,
+            )
+        ]
+
+        result = emit_pre_solve_param_assignments(model)
+        assert "objold" not in result
+        assert "objVal" not in result
+
+    def test_non_model_attr_not_filtered(self):
+        """Non-model attr_access (e.g., x.l) should still be emitted."""
+        from lark import Token, Tree
+
+        from src.emit.original_symbols import emit_pre_solve_param_assignments
+        from src.ir.symbols import LoopStatement
+
+        assign = Tree(
+            "assign",
+            [
+                Tree("lvalue", [Token("ID", "myparam")]),
+                Token("EQUALS", "="),
+                Tree(
+                    "attr_access",
+                    [Token("ID", "x"), Token("ID", "l")],
+                ),
+                Token("SEMICOLON", ";"),
+            ],
+        )
+
+        model = ModelIR()
+        model.sets["iter"] = SetDef(name="iter", domain=(), members=["i1"])
+        model.params["myparam"] = ParameterDef(name="myparam", domain=(), values={(): 0.0})
+        model.model_equation_map["mymodel"] = ["eq1"]
+
+        solve = Tree("solve", [Token("ID", "mymodel")])
+        body = Tree("loop_body", [assign, solve])
+        loop_node = Tree(
+            "loop_stmt",
+            [
+                Token("LOOP", "loop"),
+                Tree("id_list", [Token("ID", "iter")]),
+                body,
+            ],
+        )
+        model.loop_statements = [
+            LoopStatement(
+                indices=("iter",),
+                body_stmts=[assign, solve],
+                location=None,
+                raw_node=loop_node,
+            )
+        ]
+
+        result = emit_pre_solve_param_assignments(model)
+        assert "myparam" in result
+        assert "x.l" in result


### PR DESCRIPTION
## Summary

- Fixes two bugs in `emit_pre_solve_param_assignments()` that caused harker's MCP to fail GAMS compilation with Error 140 (Unknown symbol)
- harker now compiles and solves to **MODEL STATUS 1 Optimal**

## Bug 1: Missing `attr_access` handler

`_loop_tree_to_gams_subst_dispatch()` lacked handlers for `attr_access`, `set_attr`, and `attr_access_indexed` tree nodes. These fell through to the space-join fallback, producing `harkoli objVal` instead of `harkoli.objVal`.

## Bug 2: Model attribute assignments emitted out of context

`objold = harkoli.objVal` was emitted as a standalone pre-solve assignment, but it references a model attribute that only has meaning after a prior solve. Added `_tree_has_model_attr()` filter to skip assignments whose RHS contains model attribute references.

## NLP Reference Note

harker is a multi-solve model. The MCP transforms the first model (`hark`, competitive equilibrium, NLP obj=986.5), but the pipeline database stores the objective from the last solve (`harkoli` oligopoly, obj=706.3). The objective comparison mismatch is a pre-existing multi-solve infrastructure issue, not a translation bug.

## Test plan

- [x] `make format && make lint` pass
- [x] `make test` — 4455 passed, 0 failed
- [x] harker MCP compiles without GAMS errors
- [x] harker solves to MODEL STATUS 1 Optimal