### PR TITLE
Plan: fix fawley empty equation multipliers (#1133)

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -13,10 +13,10 @@ analysis and design that led to the fix.
 
 ---
 
-## Current State
+## Pre-fix State (Before PR #1240)
 
-fawley translates successfully but GAMS aborts the SOLVE with
-`EXECERROR = 1`:
+Before the fix landed in PR #1240, fawley translated successfully but
+GAMS aborted the SOLVE with `EXECERROR = 1`:
 
 ```
 **** MCP pair mbal.nu_mbal has empty equation but associated variable is NOT fixed
@@ -72,8 +72,9 @@ This `.fx` statement is not emitted.
 
 ### Approach: Detect and fix multipliers for empty equation instances
 
-After assembling the KKT system and before emission, scan each equality
-equation instance for empty bodies.  For instances where all variable
+During GAMS emission, after emitting the equation definitions and
+before emitting the model statement, scan each equality equation
+instance for empty bodies.  For instances where all variable
 coefficients are zero (the equation reduces to a constant), fix the
 corresponding multiplier to zero.
 

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -1,0 +1,195 @@
+# Plan: Fix fawley MCP EXECERROR (Empty Equation + Unfixed Multiplier)
+
+**Goal:** Fix the GAMS execution error that prevents fawley's MCP from
+solving.
+
+**Issue:** #1133 (fawley: Empty mbal equation for vacuum-res)
+**Estimated effort:** 2–3 hours
+**Models unblocked:** fawley (and potentially other models with empty
+equation instances due to sparse data)
+
+---
+
+## Current State
+
+fawley translates successfully but GAMS aborts the SOLVE with
+`EXECERROR = 1`:
+
+```
+**** MCP pair mbal.nu_mbal has empty equation but associated variable is NOT fixed
+     nu_mbal(vacuum-res)
+**** SOLVE from line 350 ABORTED, EXECERROR = 1
+```
+
+The element `vacuum-res` appears in set `c` but has no entries in any
+process yield table, blend possibility, or recipe.  The equation
+`mbal('vacuum-res')` evaluates to `0 =E= 0` (all coefficients zero),
+making it an empty equation.  GAMS requires that the multiplier variable
+for an empty MCP equation be fixed (`.fx = 0`), otherwise it aborts.
+
+---
+
+## Model Structure
+
+Fawley is a refinery blending LP with:
+- 18 commodities (`c`), 8 processes (`p`), 3 transport modes (`tr`)
+- 4 product types (`cf`), 3 crude types (`cr`), 1 import (`ci`)
+- Objective: maximize `profit` (scalar, via chain of defining equations)
+
+The `mbal(c)` equation tracks material balance for each commodity:
+```gams
+mbal(c).. u(c)$(cr(c)) + sum(p, ap(c,p)*z(p)) + sum(tr, at(c,tr)*trans(tr))
+          + import(c)$(ci(c))
+    =E= sum(cfq$(bposs(cfq,c)), bq(c,cfq)) + invent(c)
+         + sum((cfr,r), recipes(cfr,c,r)*rb(cfr,r));
+```
+
+For `vacuum-res`: `cr('vacuum-res')` is false, no `ap('vacuum-res',p)`
+entries exist, no `at('vacuum-res',tr)` entries, no `bposs` entries,
+no `recipes` entries → all terms are zero.
+
+---
+
+## Root Cause
+
+The emitter pairs `mbal(c)` with `nu_mbal(c)` in the MCP model
+statement for ALL elements of `c`, including `vacuum-res`.  When the
+equation body evaluates to `0 =E= 0`, GAMS requires the multiplier
+to be fixed:
+
+```gams
+nu_mbal.fx('vacuum-res') = 0;
+```
+
+This `.fx` statement is not emitted.
+
+---
+
+## Fix Strategy
+
+### Approach: Detect and fix multipliers for empty equation instances
+
+After assembling the KKT system and before emission, scan each equality
+equation instance for empty bodies.  For instances where all variable
+coefficients are zero (the equation reduces to a constant), fix the
+corresponding multiplier to zero.
+
+**Implementation options:**
+
+**Option A: Emission-time detection (simplest)**
+
+In `src/emit/emit_gams.py`, after the equation definitions are emitted
+and before the model statement, add a pass that:
+
+1. For each indexed equality equation, evaluate which instances have
+   non-zero variable coefficients
+2. For instances where the body is all-zero, emit
+   `nu_<eq>.fx(<element>) = 0;`
+
+This can use the Jacobian to check: if no row in `J_eq` corresponds to
+a given equation instance, or if all derivatives in that row are zero,
+the equation is empty.
+
+**Option B: IR-level detection (more robust)**
+
+Add a helper in `src/kkt/` that uses the Jacobian structure to identify
+empty equation instances, and store them in the KKTSystem. The emitter
+then reads this list and emits `.fx` statements.
+
+### Recommended: Option A
+
+It's the simplest path — the Jacobian already has the information. For
+each equation in the MCP, check which instances have Jacobian rows with
+at least one non-zero derivative.  Instances with no non-zero entries
+get their multiplier fixed to 0.
+
+```python
+# In emit_gams_mcp(), after equation definitions:
+for eq_name in kkt.multipliers_eq:
+    mult_name = create_eq_multiplier_name(eq_name)
+    eq_def = kkt.model_ir.equations.get(eq_name)
+    if not eq_def or not eq_def.domain:
+        continue  # scalar equations can't have empty instances
+    # Find equation instances with no Jacobian entries
+    for row_id in range(kkt.J_eq.num_rows):
+        rname, ridx = kkt.J_eq.index_mapping.row_to_eq[row_id]
+        if rname != eq_name:
+            continue
+        has_nonzero = any(
+            kkt.J_eq.get_derivative(row_id, col_id) is not None
+            for col_id in range(kkt.J_eq.index_mapping.num_vars)
+        )
+        if not has_nonzero:
+            idx_str = ",".join(f"'{i}'" for i in ridx)
+            sections.append(f"{mult_name}.fx({idx_str}) = 0;")
+```
+
+---
+
+## Secondary Issue: Stationarity Equations Look Trivial
+
+The stationarity equations for scalar intermediate variables
+(`purchase`, `recurrent`, `revenue`, `transport`) look trivial:
+
+```gams
+stat_purchase.. 1 + nu_dpur =E= 0;
+stat_revenue.. -1 + nu_drev =E= 0;
+```
+
+These are **actually correct** — they solve to `nu_dpur = -1` and
+`nu_drev = 1`. The constant term is the objective gradient (negated
+for MAX), and the multiplier term is from the defining equation's
+Jacobian. These equations constrain the multipliers to specific values,
+which is correct for scalar variables defined by a single equation.
+
+At initialization (`nu_dpur.l = 0`), they appear infeasible (LHS=0,
+RHS=-1), but PATH solves them trivially. **This is not a bug.**
+
+---
+
+## Verification
+
+```bash
+python -m src.cli data/gamslib/raw/fawley.gms -o /tmp/fawley_mcp.gms --quiet
+
+# Check the .fx statement is emitted
+grep "nu_mbal.fx" /tmp/fawley_mcp.gms
+# Expected: nu_mbal.fx('vacuum-res') = 0;
+
+# Compile and solve
+gams /tmp/fawley_mcp.gms lo=3 o=/tmp/fawley_solve.lst
+grep "MODEL STATUS" /tmp/fawley_solve.lst
+# Expected: MODEL STATUS 1 Optimal
+
+grep "nlp2mcp_obj_val" /tmp/fawley_solve.lst | grep "="
+# Expected: ~2899.25 (matching NLP reference)
+```
+
+---
+
+## Success Criteria
+
+- [ ] `nu_mbal.fx('vacuum-res') = 0;` emitted in the MCP file
+- [ ] GAMS compilation succeeds (no EXECERROR)
+- [ ] fawley solves to MODEL STATUS 1 or 2
+- [ ] Objective matches NLP reference (2899.25) within tolerance
+- [ ] No test regressions (`make test` passes)
+- [ ] Other models with empty equation instances unaffected or improved
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/emit/emit_gams.py` | Add empty-equation multiplier fixing after equation definitions |
+| `tests/` | Add test for empty equation multiplier fixing |
+| `docs/issues/completed/ISSUE_1133*` | Update status to FIXED |
+
+---
+
+## Related Issues
+
+- **#1133**: fawley empty mbal equation (this fix)
+- **#1130** (FIXED): fawley table column alignment
+- **#1041**: cesam2 empty equation (similar pattern, different model)

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -104,24 +104,21 @@ at least one non-zero derivative.  Instances with no non-zero entries
 get their multiplier fixed to 0.
 
 ```python
-# In emit_gams_mcp(), after equation definitions:
-for eq_name in kkt.multipliers_eq:
+# Actual implementation uses detect_empty_equation_instances() from
+# src/kkt/empty_equation_detector.py, which analyzes equation bodies
+# directly rather than scanning the Jacobian. The emitter uses
+# _format_map_indices() for proper UEL quoting/escaping.
+#
+# In emit_gams_mcp(), the existing Issue #1133 block:
+empty_eq_instances = detect_empty_equation_instances(
+    kkt.model_ir, relevant_equations=relevant_eqs
+)
+for eq_name, instances in sorted(empty_eq_instances.items()):
     mult_name = create_eq_multiplier_name(eq_name)
-    eq_def = kkt.model_ir.equations.get(eq_name)
-    if not eq_def or not eq_def.domain:
-        continue  # scalar equations can't have empty instances
-    # Find equation instances with no Jacobian entries
-    for row_id in range(kkt.J_eq.num_rows):
-        rname, ridx = kkt.J_eq.index_mapping.row_to_eq[row_id]
-        if rname != eq_name:
-            continue
-        has_nonzero = any(
-            kkt.J_eq.get_derivative(row_id, col_id) is not None
-            for col_id in range(kkt.J_eq.index_mapping.num_vars)
-        )
-        if not has_nonzero:
-            idx_str = ",".join(f"'{i}'" for i in ridx)
-            sections.append(f"{mult_name}.fx({idx_str}) = 0;")
+    for inst in sorted(instances):
+        if inst:
+            idx_str = _format_map_indices(inst)
+            lines.append(f"{mult_name}.fx({idx_str}) = 0;")
 ```
 
 ---
@@ -159,22 +156,24 @@ grep "nu_mbal.fx" /tmp/fawley_mcp.gms
 # Compile and solve
 gams /tmp/fawley_mcp.gms lo=3 o=/tmp/fawley_solve.lst
 grep "MODEL STATUS" /tmp/fawley_solve.lst
-# Expected: MODEL STATUS 1 Optimal
+# Current result: MODEL STATUS 5 (Locally Infeasible) on cold start.
+# The empty equation fix resolves the EXECERROR abort; STATUS 5 is a
+# separate convergence issue for this LP-as-MCP model.
 
 grep "nlp2mcp_obj_val" /tmp/fawley_solve.lst | grep "="
-# Expected: ~2899.25 (matching NLP reference)
+# Expected: ~2899.25 if solve succeeds; STATUS 5 yields a non-optimal point
 ```
 
 ---
 
 ## Success Criteria
 
-- [ ] `nu_mbal.fx('vacuum-res') = 0;` emitted in the MCP file
-- [ ] GAMS compilation succeeds (no EXECERROR)
-- [ ] fawley solves to MODEL STATUS 1 or 2
+- [x] `nu_mbal.fx('vacuum-res') = 0;` emitted in the MCP file
+- [x] GAMS compilation succeeds (no EXECERROR)
+- [ ] fawley solves to MODEL STATUS 1 or 2 (stretch goal — may need presolve)
 - [ ] Objective matches NLP reference (2899.25) within tolerance
-- [ ] No test regressions (`make test` passes)
-- [ ] Other models with empty equation instances unaffected or improved
+- [x] No test regressions (`make test` passes)
+- [x] Other models with empty equation instances unaffected or improved
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -158,6 +158,9 @@ RHS=-1), but PATH solves them trivially. **This is not a bug.**
 
 ## Verification
 
+**Prerequisite:** Raw GAMSlib sources are gitignored. Download them first:
+`python scripts/gamslib/download_models.py`
+
 ```bash
 python -m src.cli data/gamslib/raw/fawley.gms -o /tmp/fawley_mcp.gms --quiet
 

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -7,6 +7,9 @@ solving.
 **Estimated effort:** 2–3 hours
 **Models unblocked:** fawley (and potentially other models with empty
 equation instances due to sparse data)
+**Code fix:** Landed in PR #1240 (`detect_empty_equation_instances` in
+`src/kkt/empty_equation_detector.py`). This document records the
+analysis and design that led to the fix.
 
 ---
 
@@ -96,20 +99,20 @@ Add a helper in `src/kkt/` that uses the Jacobian structure to identify
 empty equation instances, and store them in the KKTSystem. The emitter
 then reads this list and emits `.fx` statements.
 
-### Recommended: Option A
+### Implemented: Option B (IR-level detection)
 
-It's the simplest path — the Jacobian already has the information. For
-each equation in the MCP, check which instances have Jacobian rows with
-at least one non-zero derivative.  Instances with no non-zero entries
-get their multiplier fixed to 0.
+Option A (Jacobian scanning) was initially prototyped but replaced with
+Option B: a dedicated `detect_empty_equation_instances()` module in
+`src/kkt/empty_equation_detector.py`. This analyzes equation bodies
+directly to identify instances where all variable coefficients are zero,
+which is more robust than Jacobian row scanning and avoids O(n×m) cost.
+
+The emitter uses `_format_map_indices()` for proper UEL quoting and
+filters by `kkt.referenced_multipliers` to avoid referencing undeclared
+variables.
 
 ```python
-# Actual implementation uses detect_empty_equation_instances() from
-# src/kkt/empty_equation_detector.py, which analyzes equation bodies
-# directly rather than scanning the Jacobian. The emitter uses
-# _format_map_indices() for proper UEL quoting/escaping.
-#
-# In emit_gams_mcp(), the existing Issue #1133 block:
+# In emit_gams_mcp(), the Issue #1133 block:
 empty_eq_instances = detect_empty_equation_instances(
     kkt.model_ir, relevant_equations=relevant_eqs
 )

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -49,7 +49,8 @@ mbal(c).. u(c)$(cr(c)) + sum(p, ap(c,p)*z(p)) + sum(tr, at(c,tr)*trans(tr))
 
 For `vacuum-res`: `cr('vacuum-res')` is false, no `ap('vacuum-res',p)`
 entries exist, no `at('vacuum-res',tr)` entries, no `bposs` entries,
-no `recipes` entries → all terms are zero.
+no `recipes` entries, and `invent(c)` is a parameter (not a variable)
+with value zero for `vacuum-res` → all terms are zero.
 
 ---
 
@@ -115,12 +116,15 @@ filters by `kkt.referenced_multipliers` to avoid referencing undeclared
 variables.
 
 ```python
-# In emit_gams_mcp(), the Issue #1133 block:
+# In emit_gams_mcp(), the Issue #1133 block (simplified;
+# full version also filters by referenced_multipliers):
 empty_eq_instances = detect_empty_equation_instances(
     kkt.model_ir, relevant_equations=relevant_eqs
 )
 for eq_name, instances in sorted(empty_eq_instances.items()):
     mult_name = create_eq_multiplier_name(eq_name)
+    if ref_mults is not None and mult_name not in ref_mults:
+        continue
     for inst in sorted(instances):
         if inst:
             idx_str = _format_map_indices(inst)

--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_FAWLEY.md
@@ -95,9 +95,11 @@ the equation is empty.
 
 **Option B: IR-level detection (more robust)**
 
-Add a helper in `src/kkt/` that uses the Jacobian structure to identify
-empty equation instances, and store them in the KKTSystem. The emitter
-then reads this list and emits `.fx` statements.
+Add a helper in `src/kkt/empty_equation_detector.py` that analyzes
+equation bodies together with coefficient sparsity to identify empty
+equation instances. The emitter calls this helper directly and emits
+`.fx` statements from the returned results, without storing them in the
+`KKTSystem`.
 
 ### Implemented: Option B (IR-level detection)
 
@@ -122,6 +124,8 @@ for eq_name, instances in sorted(empty_eq_instances.items()):
         if inst:
             idx_str = _format_map_indices(inst)
             lines.append(f"{mult_name}.fx({idx_str}) = 0;")
+        else:
+            lines.append(f"{mult_name}.fx = 0;")
 ```
 
 ---

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -1000,42 +1000,6 @@ def _emit_nlp_presolve(
     sections.append("")
 
 
-def _emit_empty_equation_fixes(kkt: KKTSystem) -> list[str]:
-    """Emit .fx=0 for multipliers of empty equation instances.
-
-    Issue #1133: When an indexed equation evaluates to 0=0 for certain
-    domain elements (all variable coefficients are zero), GAMS requires
-    the corresponding MCP multiplier to be fixed.  Detect empty instances
-    by scanning the equality Jacobian for rows with no non-zero entries.
-    """
-    if kkt.J_eq is None or kkt.J_eq.index_mapping is None:
-        return []
-
-    # Collect equation instances that have at least one non-zero Jacobian entry
-    nonempty_rows: set[int] = set()
-    for row_id in range(kkt.J_eq.num_rows):
-        for col_id in range(kkt.J_eq.index_mapping.num_vars):
-            if kkt.J_eq.get_derivative(row_id, col_id) is not None:
-                nonempty_rows.add(row_id)
-                break
-
-    # Find empty rows and emit .fx for their multipliers
-    lines: list[str] = []
-    for row_id in range(kkt.J_eq.num_rows):
-        if row_id in nonempty_rows:
-            continue
-        eq_name, eq_indices = kkt.J_eq.index_mapping.row_to_eq[row_id]
-        if not eq_indices:
-            continue  # scalar equations — can't have partial empty instances
-        mult_name = create_eq_multiplier_name(eq_name)
-        if mult_name not in kkt.multipliers_eq:
-            continue
-        idx_str = ",".join(f"'{i}'" for i in eq_indices)
-        lines.append(f"{_quote_symbol(mult_name)}.fx({idx_str}) = 0;")
-
-    return lines
-
-
 def emit_gams_mcp(
     kkt: KKTSystem,
     model_name: str = "mcp_model",
@@ -2446,19 +2410,6 @@ def emit_gams_mcp(
     model_code = emit_model_mcp(kkt, model_name, suppressed_fx_equations=suppressed_fx)
     sections.append(model_code)
     sections.append("")
-
-    # Issue #1133: Fix multipliers for empty equation instances.
-    # When an indexed equation evaluates to 0=0 for some domain elements
-    # (e.g., mbal('vacuum-res') in fawley where no process/blend data
-    # exists), GAMS requires the corresponding multiplier to be .fx=0.
-    # Detect via Jacobian sparsity: if no row in J_eq has non-zero
-    # derivatives for a given equation instance, it's empty.
-    empty_eq_fix_lines = _emit_empty_equation_fixes(kkt)
-    if empty_eq_fix_lines:
-        if add_comments:
-            sections.append("* Fix multipliers for empty equation instances")
-        sections.extend(empty_eq_fix_lines)
-        sections.append("")
 
     # Issue #835: Enable scaleOpt when any variable has .scale attributes
     if scale_lines:

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -1000,6 +1000,42 @@ def _emit_nlp_presolve(
     sections.append("")
 
 
+def _emit_empty_equation_fixes(kkt: KKTSystem) -> list[str]:
+    """Emit .fx=0 for multipliers of empty equation instances.
+
+    Issue #1133: When an indexed equation evaluates to 0=0 for certain
+    domain elements (all variable coefficients are zero), GAMS requires
+    the corresponding MCP multiplier to be fixed.  Detect empty instances
+    by scanning the equality Jacobian for rows with no non-zero entries.
+    """
+    if kkt.J_eq is None or kkt.J_eq.index_mapping is None:
+        return []
+
+    # Collect equation instances that have at least one non-zero Jacobian entry
+    nonempty_rows: set[int] = set()
+    for row_id in range(kkt.J_eq.num_rows):
+        for col_id in range(kkt.J_eq.index_mapping.num_vars):
+            if kkt.J_eq.get_derivative(row_id, col_id) is not None:
+                nonempty_rows.add(row_id)
+                break
+
+    # Find empty rows and emit .fx for their multipliers
+    lines: list[str] = []
+    for row_id in range(kkt.J_eq.num_rows):
+        if row_id in nonempty_rows:
+            continue
+        eq_name, eq_indices = kkt.J_eq.index_mapping.row_to_eq[row_id]
+        if not eq_indices:
+            continue  # scalar equations — can't have partial empty instances
+        mult_name = create_eq_multiplier_name(eq_name)
+        if mult_name not in kkt.multipliers_eq:
+            continue
+        idx_str = ",".join(f"'{i}'" for i in eq_indices)
+        lines.append(f"{_quote_symbol(mult_name)}.fx({idx_str}) = 0;")
+
+    return lines
+
+
 def emit_gams_mcp(
     kkt: KKTSystem,
     model_name: str = "mcp_model",
@@ -2410,6 +2446,19 @@ def emit_gams_mcp(
     model_code = emit_model_mcp(kkt, model_name, suppressed_fx_equations=suppressed_fx)
     sections.append(model_code)
     sections.append("")
+
+    # Issue #1133: Fix multipliers for empty equation instances.
+    # When an indexed equation evaluates to 0=0 for some domain elements
+    # (e.g., mbal('vacuum-res') in fawley where no process/blend data
+    # exists), GAMS requires the corresponding multiplier to be .fx=0.
+    # Detect via Jacobian sparsity: if no row in J_eq has non-zero
+    # derivatives for a given equation instance, it's empty.
+    empty_eq_fix_lines = _emit_empty_equation_fixes(kkt)
+    if empty_eq_fix_lines:
+        if add_comments:
+            sections.append("* Fix multipliers for empty equation instances")
+        sections.extend(empty_eq_fix_lines)
+        sections.append("")
 
     # Issue #835: Enable scaleOpt when any variable has .scale attributes
     if scale_lines:


### PR DESCRIPTION
## Summary

- Planning document for the fawley empty-equation multiplier fix (Issue #1133)
- Documents root cause analysis, model structure, fix strategy, and verification steps
- The actual code fix landed in PR #1240 (`detect_empty_equation_instances` in `src/kkt/empty_equation_detector.py`)

## Context

`mbal('vacuum-res')` evaluates to `0 =E= 0` because vacuum-res has no entries in any process yield, blend, or recipe table. GAMS requires the MCP multiplier for an empty equation to be `.fx = 0`. The fix detects empty equation instances via IR-level analysis and emits the necessary `.fx` statements.