### PR TITLE
Fix turkey and china MCP compilation and solve issues

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_TURKEY.md
+++ b/docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_TURKEY.md
@@ -1,0 +1,272 @@
+# Plan: Fix turkey MCP (Compilation Errors → Solve to Optimality)
+
+**Goal:** Fix the turkey model so it compiles, solves, and reaches
+optimality.
+
+**Related issue reference:** Sprint 24 Day 11 triage — turkey classified
+as `path_syntax_error` (`compilation_error`)
+**Estimated effort:** 3–5 hours (2 compilation blockers + potential
+solve-time issues)
+**Models potentially unblocked:** turkey (may share patterns with other
+large agricultural sector models)
+**NLP reference objective:** 29330.1580
+
+---
+
+## Pre-fix State
+
+The turkey model (Turkish Agricultural Sector Model, SEQ=108) parses
+and translates successfully, but the generated MCP file fails to compile
+in GAMS with 9 errors:
+
+```
+****  161  Conflicting dimensions in element     (6 occurrences on set ao)
+****  116  Label is unknown                      (1 occurrence: "other-q")
+****  257  Solve statement not checked because of previous errors
+****  141  Symbol declared but no values have been assigned
+```
+
+Errors 161 and 116 are the root causes; 257 and 141 are cascading
+failures from the unresolved compilation.
+
+---
+
+## Model Structure
+
+Turkey is a large agricultural sector model (NLP with LP linearization):
+- 38 crops (`c`), 24 annual (`ca ⊂ c`), 14 tree (`ct ⊂ c`)
+- 5 livestock commodities (`cl`), 7 livestock types (`l`)
+- 50 regions (`r`), 4 soil types (`s`), 4 quarters (`tq`)
+- Dynamic set `cll(cl,l)` populated at runtime from demand data
+- Post-solve reporting uses 2D mapping set `ao(ctp,c)` with dotted
+  notation
+- Objective: maximize `cps` (consumer + producer surplus)
+
+---
+
+## Issue 1: 2D Mapping Set `ao` Emitted as 1D (Error 161)
+
+### Root Cause
+
+The original model declares `ao` as a 2D mapping set using GAMS
+dotted notation:
+
+```gams
+Set ao 'aggregated output'
+    / grains.(wheat, corn, rye, rice, barley)
+      pulses.(chickpea, drybean, lentil)
+      vegetables.(potato, onion, gr-pepper, tomato, cucumber, melon)
+      ... /;
+```
+
+The parser stores these as 1D members with dotted names:
+`['grains.wheat', 'grains.corn', ...]` with `domain: ()`.
+
+The emitter outputs:
+
+```gams
+ao /grains.wheat, grains.corn, .../
+```
+
+GAMS interprets the dotted elements as 2D (since dots separate
+dimensions in GAMS), but the set declaration has no domain —
+Error 161 "Conflicting dimensions in element".
+
+### Key Insight: Post-Solve Only
+
+The set `ao` and the related parameter `acctg` appear **only** in the
+post-solve reporting section (`$sTitle Value Accounting`, lines
+1108–1136 of the original model).  They are NOT referenced by any
+equation, variable, or constraint in the optimization model.  The same
+applies to set `ctp` and parameters `procc`, `prot`, `areac`,
+`costsum`, `acctg`.
+
+### Fix Strategy
+
+**Option A (recommended):** Exclude post-solve-only symbols from the
+MCP output.  Detect that `ao`, `ctp`, `acctg`, `procc`, `prot`,
+`areac`, `costsum` are unreferenced by any equation/variable/constraint
+and omit them.  This eliminates the error entirely without modifying set
+emission logic.
+
+**Option B (general fix):** When emitting a set whose members contain
+dots and whose IR domain is empty, infer the dimensionality from the
+member notation and emit with the correct domain.  E.g., detect that
+`ao` members have `ctp.c` structure and emit `ao(ctp,c) / ... /`.
+
+Option A is simpler and sufficient for turkey.  Option B is more general
+but more complex and risks regressions.
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/emit/emit_gams.py` or `src/emit/original_symbols.py` | Skip unreferenced post-solve sets/params |
+
+---
+
+## Issue 2: Missing Wildcard Labels in Parameter Data (Error 116)
+
+### Root Cause
+
+The parameters `tradel(l,cl,*)` and `tradec(c,*)` use wildcard domains.
+Their data tables include columns like `"other-q"` where all values are
+zero.  The emitter omits zero-valued entries from inline data
+declarations.
+
+When assignment statements reference `tradel(l,cl,"other-q")`, GAMS
+sees `"other-q"` as an unknown label because it never appeared in any
+set or parameter data — Error 116.
+
+The affected assignments are pre-solve computations needed for the
+model:
+
+```gams
+qdl(cl,l) = tradel(l,cl,"production") + tradel(l,cl,"import-q")
+          - tradel(l,cl,"export-q") - tradel(l,cl,"other-q");
+qdc(c) = tradec(c,"production") + tradec(c,"import-q")
+        - tradec(c,"export-q") - tradec(c,"other-q");
+```
+
+### Fix Strategy
+
+When emitting wildcard-domain parameters, collect all unique wildcard
+labels that appear in **assignment statements** referencing the
+parameter.  If a label has no nonzero data entries, emit at least one
+dummy entry (e.g., a comment or a zero-valued placeholder) — OR declare
+the missing labels via a helper set.
+
+Alternatively, in the emitter's computed parameter assignment phase,
+detect references to wildcard parameters with labels not present in the
+data and replace them with `0` (since missing GAMS data defaults to 0).
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/emit/original_symbols.py` or `src/emit/emit_gams.py` | Handle missing wildcard labels |
+
+---
+
+## Issue 3: Dynamic Set `cll` Has No Compile-Time Members
+
+### Root Cause
+
+The set `cll(cl,l)` is declared empty and populated at runtime:
+
+```gams
+Set cll(cl,l) 'tuples of livestock commodities and livestock in model';
+cll(cl,l) = yes$betal(cl,l);
+```
+
+The IR has `cll.members = []`.  Multiple equations use `$cll(cl,l)` as
+a condition:
+
+```gams
+mball(cl,l)$cll(cl,l)..  yieldl(cl,l)*xlive(l)/1000 =g= salesl(cl,l);
+ndeml(cl,l)$cll(cl,l)..  natconl(cl,l) =e= ...;
+```
+
+The Jacobian code cannot evaluate `cll` membership statically, so it
+includes all `(cl,l)` instances by default (per the warning).  This may
+cause:
+- Spurious equation instances in the KKT system
+- Unmatched multiplier variables for empty instances
+- Incorrect stationarity equations
+
+### Fix Strategy
+
+Pre-evaluate `cll(cl,l)` from the data.  Since
+`cll(cl,l) = yes$betal(cl,l)` and `betal` is computed from `qdl`,
+`demandl`, and `pdl` (all derived from table data), the members of
+`cll` can be determined at IR build time by evaluating the chain:
+
+1. `qdl(cl,l) = tradel(l,cl,"production") + ...`
+2. `pdl(cl,l) = pricel(cl,l,"1979")`
+3. `demandl(l,cl) = ...` (population-based)
+4. `betal(cl,l) = pdl(cl,l) / qdl(cl,l) / demandl(l,cl)`
+5. `cll(cl,l) = yes$betal(cl,l)` — nonzero where betal is nonzero
+
+If full evaluation is too complex, a simpler approach: populate `cll`
+members from the sparsity pattern of `tradel` data (any `(cl,l)` pair
+that has production data is likely in `cll`).
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/ir/parser.py` or `src/emit/original_symbols.py` | Pre-evaluate dynamic set from data |
+
+---
+
+## Potential Issue 4: Empty Equation Instances (Post-Compilation)
+
+After compilation errors are resolved, the model may encounter unmatched
+multiplier variables (similar to china's Issue 2) for equation instances
+where all variable coefficients are zero.  The empty equation detector
+(enhanced for china) should handle this, but turkey's larger scale and
+dynamic sets may expose additional edge cases.
+
+### Diagnosis
+
+Run the MCP after fixing Issues 1–3 and check for `EXECERROR` /
+unmatched variables.  Apply the same `detect_empty_equation_instances()`
+analysis.
+
+---
+
+## Verification
+
+**Prerequisite:** Raw GAMSlib sources are gitignored. Download them
+first: `python scripts/gamslib/download_models.py --model turkey`
+
+```bash
+# Generate MCP
+python -m src.cli data/gamslib/raw/turkey.gms -o /tmp/turkey_mcp.gms --quiet
+
+# Compile
+gams /tmp/turkey_mcp.gms lo=3 o=/tmp/turkey_solve.lst
+# Expected: no compilation errors (Errors 161, 116 fixed)
+
+grep "MODEL STATUS" /tmp/turkey_solve.lst
+# Target: MODEL STATUS 1 (Optimal) or 2 (Locally Optimal)
+
+grep "nlp2mcp_obj_val" /tmp/turkey_solve.lst | grep "="
+# Expected: ~29330.1580 (matching NLP reference)
+```
+
+---
+
+## Success Criteria
+
+- [ ] No compilation errors (Errors 161, 116 resolved)
+- [ ] No unmatched variable errors
+- [ ] turkey solves to MODEL STATUS 1 or 2
+- [ ] Objective matches NLP reference (29330.1580) within tolerance
+- [ ] No test regressions (`make test` passes)
+
+---
+
+## Recommended Fix Order
+
+1. **Issue 1** (ao set dimension) — unblocks compilation; likely
+   solvable by excluding post-solve symbols
+2. **Issue 2** (missing wildcard labels) — unblocks compilation
+3. **Issue 3** (dynamic set cll) — fixes equation enumeration
+4. **Issue 4** (empty equations) — diagnose after 1–3 are fixed
+
+Issues 1 and 2 are compilation blockers and relatively isolated.
+Issue 3 is deeper and may require data-flow analysis to pre-evaluate
+the dynamic set.
+
+---
+
+## Related
+
+- **china model**: Fixed in PR #1261 plan; shared the
+  `path_syntax_error` / `compilation_error` triage classification.
+  China's fixes (parameter ordering, empty inequality detection,
+  stationarity Jacobian for subset-domain variables) may partially
+  apply if turkey has similar subset patterns.
+- **Issue #1133** (fawley): Empty equation detection framework — already
+  extended for inequalities in the china fix.

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -2383,12 +2383,44 @@ def emit_gams_mcp(
                     idx_str = _format_map_indices(inst)
                     empty_fx_lines.append(f"{mult_name}.fx({idx_str}) = 0;")
                 else:
-                    # Scalar equation
                     empty_fx_lines.append(f"{mult_name}.fx = 0;")
         if empty_fx_lines:
             if add_comments:
                 sections.append("* Fix multipliers for empty equation instances (no variables)")
             sections.extend(empty_fx_lines)
+            sections.append("")
+
+    # Also fix inequality multipliers for empty equation instances.
+    relevant_ineqs: set[str] | None = None
+    if ref_mults is not None:
+        relevant_ineqs = set()
+        for eq_name in kkt.model_ir.inequalities:
+            mult_name = create_ineq_multiplier_name(eq_name)
+            if mult_name in ref_mults:
+                relevant_ineqs.add(eq_name)
+    empty_ineq_instances = detect_empty_equation_instances(
+        kkt.model_ir,
+        relevant_equations=relevant_ineqs,
+        include_inequalities=True,
+    )
+    if empty_ineq_instances:
+        empty_ineq_fx: list[str] = []
+        for eq_name, instances in sorted(empty_ineq_instances.items()):
+            mult_name = create_ineq_multiplier_name(eq_name)
+            if ref_mults is not None and mult_name not in ref_mults:
+                continue
+            for inst in sorted(instances):
+                if inst:
+                    idx_str = _format_map_indices(inst)
+                    empty_ineq_fx.append(f"{mult_name}.fx({idx_str}) = 0;")
+                else:
+                    empty_ineq_fx.append(f"{mult_name}.fx = 0;")
+        if empty_ineq_fx:
+            if add_comments:
+                sections.append(
+                    "* Fix multipliers for empty inequality instances (no variables)"
+                )
+            sections.extend(empty_ineq_fx)
             sections.append("")
 
     # Model MCP

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -2391,13 +2391,14 @@ def emit_gams_mcp(
             sections.append("")
 
     # Also fix inequality multipliers for empty equation instances.
-    relevant_ineqs: set[str] | None = None
+    relevant_ineqs: set[str] = set()
     if ref_mults is not None:
-        relevant_ineqs = set()
         for eq_name in kkt.model_ir.inequalities:
             mult_name = create_ineq_multiplier_name(eq_name)
             if mult_name in ref_mults:
                 relevant_ineqs.add(eq_name)
+    else:
+        relevant_ineqs = set(kkt.model_ir.inequalities)
     empty_ineq_instances = detect_empty_equation_instances(
         kkt.model_ir,
         relevant_equations=relevant_ineqs,
@@ -2417,9 +2418,7 @@ def emit_gams_mcp(
                     empty_ineq_fx.append(f"{mult_name}.fx = 0;")
         if empty_ineq_fx:
             if add_comments:
-                sections.append(
-                    "* Fix multipliers for empty inequality instances (no variables)"
-                )
+                sections.append("* Fix multipliers for empty inequality instances (no variables)")
             sections.extend(empty_ineq_fx)
             sections.append("")
 

--- a/src/emit/equations.py
+++ b/src/emit/equations.py
@@ -546,7 +546,9 @@ def emit_equation_definitions(
         lines.append("* Stationarity equations")
         for eq_name in sorted(kkt.stationarity.keys()):
             eq_def = kkt.stationarity[eq_name]
-            eq_str, aliases = emit_equation_def(eq_name, eq_def)
+            eq_str, aliases = emit_equation_def(
+                eq_name, eq_def, skip_lead_lag_inference=True
+            )
             lines.append(eq_str)
             _merge_alias_dicts(all_aliases, aliases)
         lines.append("")

--- a/src/emit/equations.py
+++ b/src/emit/equations.py
@@ -546,9 +546,7 @@ def emit_equation_definitions(
         lines.append("* Stationarity equations")
         for eq_name in sorted(kkt.stationarity.keys()):
             eq_def = kkt.stationarity[eq_name]
-            eq_str, aliases = emit_equation_def(
-                eq_name, eq_def, skip_lead_lag_inference=True
-            )
+            eq_str, aliases = emit_equation_def(eq_name, eq_def, skip_lead_lag_inference=True)
             lines.append(eq_str)
             _merge_alias_dicts(all_aliases, aliases)
         lines.append("")

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -593,6 +593,12 @@ def emit_original_sets(
 
     for set_name, set_def in model_ir.sets.items():
         set_name_lower = set_name.lower()
+        if (
+            not set_def.domain
+            and set_def.members
+            and any("." in str(m) for m in set_def.members)
+        ):
+            continue
         phase = set_phases.get(set_name_lower, 1)
         phase_sets[phase - 1].append((set_name, set_def))
 
@@ -1044,6 +1050,48 @@ def collect_missing_param_labels(model_ir: ModelIR) -> set[str]:
 
         missing.update(all_first_labels - emitted_first_labels)
 
+    wildcard_params: dict[str, tuple[set[int], set[str]]] = {}
+    for pname, pdef in model_ir.params.items():
+        domain = list(pdef.domain)
+        if not domain:
+            continue
+        wc_positions = {i for i, d in enumerate(domain) if d == "*"}
+        if not wc_positions:
+            continue
+        data_labels: set[str] = set()
+        dsize = len(domain)
+        for key_tuple, value in pdef.values.items():
+            if isinstance(value, (int, float)) and value == 0:
+                continue
+            expanded = _expand_table_key(key_tuple, dsize)
+            if expanded is None:
+                continue
+            for pos in wc_positions:
+                if pos < len(expanded):
+                    data_labels.add(expanded[pos].lower())
+        wildcard_params[pname.lower()] = (wc_positions, data_labels)
+
+    if wildcard_params:
+
+        def _collect_wc_refs(expr: Expr) -> None:
+            if isinstance(expr, ParamRef):
+                plow = expr.name.lower()
+                if plow in wildcard_params:
+                    wc_pos, data_labs = wildcard_params[plow]
+                    for pos in wc_pos:
+                        if pos < len(expr.indices):
+                            idx = expr.indices[pos]
+                            if isinstance(idx, str):
+                                raw = idx.strip("'\"")
+                                if raw.lower() not in data_labs:
+                                    missing.add(raw)
+            for child in expr.children():
+                _collect_wc_refs(child)
+
+        for pdef in model_ir.params.values():
+            for _, expr in pdef.expressions:
+                _collect_wc_refs(expr)
+
     return missing
 
 
@@ -1284,9 +1332,10 @@ def _topological_sort_statements(
             for i in indices:
                 sorted_stmts.append(stmts[i])
             emitted_phases.add(pkey)
-            # Mark param as defined once its LAST phase is emitted
-            if pkey == last_phase_key[pname_low]:
-                defined.add(pname_low)
+            # Mark param as defined once any phase is emitted so that
+            # other parameters in a cycle can proceed (the emitted phase
+            # provides enough values for downstream reads).
+            defined.add(pname_low)
         remaining = still_blocked
 
     return sorted_stmts

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -1095,7 +1095,8 @@ def collect_missing_param_labels(model_ir: ModelIR) -> set[str]:
         for key_tuple, value in pdef.values.items():
             if isinstance(value, (int, float)) and value == 0:
                 continue
-            expanded = _expand_table_key(key_tuple, dsize)
+            normalized_key = key_tuple if isinstance(key_tuple, tuple) else (key_tuple,)
+            expanded = _expand_table_key(normalized_key, dsize)
             if expanded is None:
                 continue
             for pos in wc_positions:

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -593,11 +593,7 @@ def emit_original_sets(
 
     for set_name, set_def in model_ir.sets.items():
         set_name_lower = set_name.lower()
-        if (
-            not set_def.domain
-            and set_def.members
-            and any("." in str(m) for m in set_def.members)
-        ):
+        if not set_def.domain and set_def.members and any("." in str(m) for m in set_def.members):
             continue
         phase = set_phases.get(set_name_lower, 1)
         phase_sets[phase - 1].append((set_name, set_def))
@@ -1081,10 +1077,21 @@ def collect_missing_param_labels(model_ir: ModelIR) -> set[str]:
                     for pos in wc_pos:
                         if pos < len(expr.indices):
                             idx = expr.indices[pos]
-                            if isinstance(idx, str):
-                                raw = idx.strip("'\"")
-                                if raw.lower() not in data_labs:
-                                    missing.add(raw)
+                            if not isinstance(idx, str):
+                                continue
+                            stripped = idx.strip()
+                            is_quoted = (
+                                len(stripped) >= 2
+                                and stripped[0] == stripped[-1]
+                                and stripped[0] in {"'", '"'}
+                            )
+                            if not is_quoted:
+                                continue
+                            raw = stripped[1:-1]
+                            if raw.lower() in sets_and_aliases_lower:
+                                continue
+                            if raw.lower() not in data_labs:
+                                missing.add(raw)
             for child in expr.children():
                 _collect_wc_refs(child)
 
@@ -1240,7 +1247,6 @@ def _topological_sort_statements(
 
     # phase_key = "param:N" where N is the phase number for that param
     phases: list[tuple[str, str, list[int], set[str]]] = []  # (key, param, indices, deps)
-    last_phase_key: dict[str, str] = {}  # param -> key of its last phase
 
     for pname_low, chain in param_chains.items():
         # cum_deps tracks all external dependencies seen so far across all
@@ -1256,7 +1262,6 @@ def _topological_sort_statements(
                 # New dependency boundary — close current phase
                 pkey = f"{pname_low}:{phase_num}"
                 phases.append((pkey, pname_low, list(phase_indices), set(cum_deps)))
-                last_phase_key[pname_low] = pkey
                 phase_num += 1
                 phase_indices = []
             cum_deps |= stmt_reads[i]
@@ -1264,7 +1269,6 @@ def _topological_sort_statements(
         if phase_indices:
             pkey = f"{pname_low}:{phase_num}"
             phases.append((pkey, pname_low, list(phase_indices), set(cum_deps)))
-            last_phase_key[pname_low] = pkey
 
     # Kahn's-style sort at the phase level.
     # A phase is ready when its deps are satisfied AND all prior phases of

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -606,6 +606,22 @@ def emit_original_sets(
         for d in sdef.domain:
             referenced_sets.add(d.lower())
 
+    def _collect_set_refs(expr: Expr) -> None:
+        if isinstance(expr, SetMembershipTest):
+            referenced_sets.add(expr.set_name.lower())
+        for child in expr.children():
+            _collect_set_refs(child)
+
+    for eq_def in model_ir.equations.values():
+        if eq_def.lhs_rhs:
+            for side in eq_def.lhs_rhs:
+                _collect_set_refs(side)
+        if eq_def.condition is not None:
+            _collect_set_refs(eq_def.condition)
+    for pdef in model_ir.params.values():
+        for _, expr in pdef.expressions:
+            _collect_set_refs(expr)
+
     for set_name, set_def in model_ir.sets.items():
         set_name_lower = set_name.lower()
         if (

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -591,9 +591,29 @@ def emit_original_sets(
     # Partition sets into lists by phase, preserving original order
     phase_sets: list[list[tuple[str, SetDef]]] = [[] for _ in range(max_phase)]
 
+    referenced_sets: set[str] = set()
+    for eq_def in model_ir.equations.values():
+        for d in eq_def.domain:
+            referenced_sets.add(d.lower())
+    for var_def in model_ir.variables.values():
+        for d in var_def.domain:
+            referenced_sets.add(d.lower())
+    for pdef in model_ir.params.values():
+        for d in pdef.domain:
+            if d != "*":
+                referenced_sets.add(d.lower())
+    for sdef in model_ir.sets.values():
+        for d in sdef.domain:
+            referenced_sets.add(d.lower())
+
     for set_name, set_def in model_ir.sets.items():
         set_name_lower = set_name.lower()
-        if not set_def.domain and set_def.members and any("." in str(m) for m in set_def.members):
+        if (
+            not set_def.domain
+            and set_def.members
+            and any("." in str(m) for m in set_def.members)
+            and set_name_lower not in referenced_sets
+        ):
             continue
         phase = set_phases.get(set_name_lower, 1)
         phase_sets[phase - 1].append((set_name, set_def))

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -472,14 +472,12 @@ def _param_ref_is_zero(
     resolved_strs: list[str] = [r for r in resolved if r is not None]
 
     if hasattr(pdef, "values") and pdef.values:
-        key: str | tuple[str, ...]
-        if not resolved_strs:
-            key = ()
-        elif len(resolved_strs) > 1:
-            key = tuple(resolved_strs)
-        else:
-            key = resolved_strs[0]
-        return pdef.values.get(key, 0) == 0
+        key: tuple[str, ...] = tuple(resolved_strs)
+        if key in pdef.values:
+            return pdef.values.get(key, 0) == 0
+        if len(resolved_strs) == 1:
+            return pdef.values.get(resolved_strs[0], 0) == 0
+        return True
 
     if hasattr(pdef, "expressions") and pdef.expressions:
         inner_map = dict(val_map)

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -314,12 +314,11 @@ def _all_coefficients_zero(
         has_exprs = hasattr(pdef, "expressions") and pdef.expressions
         if not has_values and not has_exprs:
             return False
-        if not has_values and has_exprs:
+        if has_exprs:
             if _computed_param_covers_instance(pdef, index_map, model_ir):
                 return False
-            continue
-        if not has_values:
-            return False
+            if not has_values:
+                continue
 
         nonzero_index = _get_nonzero_index(pdef, index_map, model_ir)
         if nonzero_index is None:
@@ -486,7 +485,6 @@ def _param_ref_is_zero(
                 inner_map[dname] = resolved_strs[i]
                 inner_map[dname.lower()] = resolved_strs[i]
 
-        any_covers = False
         for expr_tuple in pdef.expressions:
             if not isinstance(expr_tuple, tuple) or len(expr_tuple) < 2:
                 return False
@@ -498,14 +496,17 @@ def _param_ref_is_zero(
                 dom = getattr(pdef, "domain", None) or [None] * (j + 1)
                 if j < len(dom) and dom[j] is not None:
                     expected = inner_map.get(dom[j]) or inner_map.get(str(dom[j]).lower())
-                    if expected and not _assign_index_matches(aidx, expected, model_ir):
+                    if (
+                        expected
+                        and isinstance(aidx, str)
+                        and not _assign_index_matches(aidx, expected, model_ir)
+                    ):
                         covers = False
                         break
             if covers:
-                any_covers = True
                 if not _expr_has_zero_factor(expr_tuple[1], inner_map, model_ir, depth + 1):
                     return False
-        return any_covers
+        return True
 
     return False
 

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -39,15 +39,19 @@ def _resolve_alias_target(name: str, model_ir: ModelIR) -> str:
 def detect_empty_equation_instances(
     model_ir: ModelIR,
     relevant_equations: set[str] | None = None,
+    include_inequalities: bool = False,
 ) -> dict[str, set[tuple[str, ...]]]:
     """Find equation instances where no variable appears (all coefficients zero).
 
-    For each equality equation, checks every domain instance to see if ALL
-    variable-referencing terms have zero coefficients. Returns a mapping from
-    equation name to the set of domain-value tuples that are empty.
+    For each equality (and optionally inequality) equation, checks every
+    domain instance to see if ALL variable-referencing terms have zero
+    coefficients. Returns a mapping from equation name to the set of
+    domain-value tuples that are empty.
 
     Args:
         model_ir: Model IR with equations, sets, parameters
+        relevant_equations: If provided, only check these equations.
+        include_inequalities: If True, also scan inequality equations.
 
     Returns:
         Dict mapping equation name → set of empty instance tuples.
@@ -55,7 +59,11 @@ def detect_empty_equation_instances(
     """
     result: dict[str, set[tuple[str, ...]]] = {}
 
-    for eq_name in model_ir.equalities:
+    eq_names = list(model_ir.equalities)
+    if include_inequalities:
+        eq_names.extend(model_ir.inequalities)
+
+    for eq_name in eq_names:
         if relevant_equations is not None and eq_name not in relevant_equations:
             continue
         eq_def = model_ir.equations.get(eq_name)
@@ -300,22 +308,201 @@ def _all_coefficients_zero(
     """
     for pname in access.sum_coeffs:
         pdef = model_ir.params.get(pname)
-        if pdef is None or not hasattr(pdef, "values") or not pdef.values:
-            return False  # Unknown/missing data → conservatively not all-zero
+        if pdef is None:
+            return False
+        has_values = hasattr(pdef, "values") and pdef.values
+        has_exprs = hasattr(pdef, "expressions") and pdef.expressions
+        if not has_values and not has_exprs:
+            return False
+        if not has_values and has_exprs:
+            if _computed_param_covers_instance(pdef, index_map, model_ir):
+                return False
+            continue
+        if not has_values:
+            return False
 
-        # Build a pre-indexed set of equation-domain values that have nonzero
-        # entries, keyed by the matched domain positions. This makes per-instance
-        # checks O(1) instead of scanning the full values dict.
         nonzero_index = _get_nonzero_index(pdef, index_map, model_ir)
         if nonzero_index is None:
-            return False  # Can't index → conservatively not all-zero
-
-        # Check if this instance's index values appear in nonzero entries
+            return False
         inst_key = tuple(index_map[k] for k in sorted(index_map))
         if inst_key in nonzero_index:
-            return False  # Found nonzero coefficient
+            return False
 
-    return True  # All coefficients are zero
+    return True
+
+
+def _computed_param_covers_instance(
+    pdef: object,
+    index_map: dict[str, str],
+    model_ir: ModelIR,
+) -> bool:
+    """Check if any assignment expression of a computed parameter could produce
+    a nonzero value for the given equation instance.
+
+    Returns True (could be nonzero) if unsure.
+    """
+    domain = getattr(pdef, "domain", None)
+    expressions = getattr(pdef, "expressions", None)
+    if not domain or not expressions:
+        return True
+
+    domain_lower = [str(d).lower() for d in domain]
+    domain_roots = [_resolve_alias_target(str(d), model_ir) for d in domain]
+
+    eq_pos_map: dict[int, str] = {}
+    used: set[int] = set()
+    for idx_name in sorted(index_map.keys()):
+        idx_lower = idx_name.lower()
+        idx_root = _resolve_alias_target(idx_name, model_ir)
+        exact = [p for p, dl in enumerate(domain_lower) if p not in used and dl == idx_lower]
+        if len(exact) == 1:
+            eq_pos_map[exact[0]] = idx_name
+            used.add(exact[0])
+        else:
+            alias = [
+                p for p, dr in enumerate(domain_roots) if p not in used and dr == idx_root
+            ]
+            if len(alias) == 1:
+                eq_pos_map[alias[0]] = idx_name
+                used.add(alias[0])
+
+    if not eq_pos_map:
+        return True
+
+    for expr_tuple in expressions:
+        if not isinstance(expr_tuple, tuple) or len(expr_tuple) < 2:
+            return True
+        assign_indices = expr_tuple[0]
+        if not isinstance(assign_indices, tuple):
+            return True
+
+        covers = True
+        val_map: dict[str, str] = {}
+        for param_pos, eq_idx_name in eq_pos_map.items():
+            if param_pos >= len(assign_indices):
+                break
+            assign_idx = assign_indices[param_pos]
+            eq_value = index_map[eq_idx_name]
+            if not _assign_index_matches(assign_idx, eq_value, model_ir):
+                covers = False
+                break
+            val_map[assign_idx] = eq_value
+            val_map[assign_idx.lower()] = eq_value
+        if covers:
+            if _expr_has_zero_factor(expr_tuple[1], val_map, model_ir):
+                continue
+            return True
+
+    return False
+
+
+def _assign_index_matches(assign_idx: str, eq_value: str, model_ir: ModelIR) -> bool:
+    """Check if an assignment index pattern matches a specific element value.
+
+    String literal → exact match. Set name → membership check. Otherwise wildcard.
+    """
+    if (assign_idx.startswith('"') and assign_idx.endswith('"')) or (
+        assign_idx.startswith("'") and assign_idx.endswith("'")
+    ):
+        return assign_idx[1:-1].lower() == eq_value.lower()
+
+    sdef = model_ir.sets.get(assign_idx)
+    if sdef is None:
+        adef = model_ir.aliases.get(assign_idx)
+        if adef:
+            sdef = model_ir.sets.get(getattr(adef, "target", ""))
+
+    if sdef is not None:
+        members = list(sdef.members) if hasattr(sdef, "members") and sdef.members else []
+        if members:
+            return eq_value.lower() in {m.lower() for m in members}
+        if getattr(sdef, "domain", None):
+            for parent in sdef.domain:
+                parent_members = _resolve_set_members(parent, model_ir)
+                if parent_members:
+                    return eq_value.lower() in {m.lower() for m in parent_members}
+        return True
+
+    return True
+
+
+def _expr_has_zero_factor(
+    expr: Expr, val_map: dict[str, str], model_ir: ModelIR, depth: int = 0
+) -> bool:
+    """Check if a multiplicative expression has a provably-zero factor."""
+    if depth > 3:
+        return False
+    if isinstance(expr, Binary):
+        if expr.op == "*":
+            return _expr_has_zero_factor(
+                expr.left, val_map, model_ir, depth
+            ) or _expr_has_zero_factor(expr.right, val_map, model_ir, depth)
+        if expr.op == "/":
+            return _expr_has_zero_factor(expr.left, val_map, model_ir, depth)
+    if isinstance(expr, ParamRef):
+        return _param_ref_is_zero(expr, val_map, model_ir, depth)
+    return False
+
+
+def _param_ref_is_zero(
+    pref: ParamRef, val_map: dict[str, str], model_ir: ModelIR, depth: int
+) -> bool:
+    """Check if a ParamRef evaluates to zero for the bound index values."""
+    pdef = model_ir.params.get(pref.name)
+    if pdef is None:
+        return False
+
+    resolved: list[str | None] = []
+    for idx in pref.indices:
+        if isinstance(idx, str):
+            if (idx.startswith('"') and idx.endswith('"')) or (
+                idx.startswith("'") and idx.endswith("'")
+            ):
+                resolved.append(idx[1:-1])
+            else:
+                val = val_map.get(idx) or val_map.get(idx.lower())
+                resolved.append(val)
+        else:
+            resolved.append(None)
+
+    if any(r is None for r in resolved):
+        return False
+
+    if hasattr(pdef, "values") and pdef.values:
+        key: str | tuple[str, ...] = (
+            tuple(resolved) if len(resolved) > 1 else resolved[0]  # type: ignore[assignment]
+        )
+        return pdef.values.get(key, 0) == 0
+
+    if hasattr(pdef, "expressions") and pdef.expressions:
+        inner_map = dict(val_map)
+        for i, dname in enumerate(getattr(pdef, "domain", None) or []):
+            if i < len(resolved):
+                inner_map[dname] = resolved[i]  # type: ignore[assignment]
+                inner_map[dname.lower()] = resolved[i]  # type: ignore[assignment]
+
+        any_covers = False
+        for expr_tuple in pdef.expressions:
+            if not isinstance(expr_tuple, tuple) or len(expr_tuple) < 2:
+                return False
+            assign_indices = expr_tuple[0]
+            if not isinstance(assign_indices, tuple):
+                return False
+            covers = True
+            for j, aidx in enumerate(assign_indices):
+                dom = (getattr(pdef, "domain", None) or [None] * (j + 1))
+                if j < len(dom) and dom[j] is not None:
+                    expected = inner_map.get(dom[j]) or inner_map.get(str(dom[j]).lower())
+                    if expected and not _assign_index_matches(aidx, expected, model_ir):
+                        covers = False
+                        break
+            if covers:
+                any_covers = True
+                if not _expr_has_zero_factor(expr_tuple[1], inner_map, model_ir, depth + 1):
+                    return False
+        return any_covers
+
+    return False
 
 
 # Cache for pre-indexed nonzero entries per parameter

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -359,9 +359,7 @@ def _computed_param_covers_instance(
             eq_pos_map[exact[0]] = idx_name
             used.add(exact[0])
         else:
-            alias = [
-                p for p, dr in enumerate(domain_roots) if p not in used and dr == idx_root
-            ]
+            alias = [p for p, dr in enumerate(domain_roots) if p not in used and dr == idx_root]
             if len(alias) == 1:
                 eq_pos_map[alias[0]] = idx_name
                 used.add(alias[0])
@@ -382,6 +380,9 @@ def _computed_param_covers_instance(
             if param_pos >= len(assign_indices):
                 break
             assign_idx = assign_indices[param_pos]
+            if not isinstance(assign_idx, str):
+                covers = True
+                break
             eq_value = index_map[eq_idx_name]
             if not _assign_index_matches(assign_idx, eq_value, model_ir):
                 covers = False
@@ -468,18 +469,20 @@ def _param_ref_is_zero(
     if any(r is None for r in resolved):
         return False
 
+    resolved_strs: list[str] = [r for r in resolved if r is not None]
+
     if hasattr(pdef, "values") and pdef.values:
         key: str | tuple[str, ...] = (
-            tuple(resolved) if len(resolved) > 1 else resolved[0]  # type: ignore[assignment]
+            tuple(resolved_strs) if len(resolved_strs) > 1 else resolved_strs[0]
         )
         return pdef.values.get(key, 0) == 0
 
     if hasattr(pdef, "expressions") and pdef.expressions:
         inner_map = dict(val_map)
         for i, dname in enumerate(getattr(pdef, "domain", None) or []):
-            if i < len(resolved):
-                inner_map[dname] = resolved[i]  # type: ignore[assignment]
-                inner_map[dname.lower()] = resolved[i]  # type: ignore[assignment]
+            if i < len(resolved_strs):
+                inner_map[dname] = resolved_strs[i]
+                inner_map[dname.lower()] = resolved_strs[i]
 
         any_covers = False
         for expr_tuple in pdef.expressions:
@@ -490,7 +493,7 @@ def _param_ref_is_zero(
                 return False
             covers = True
             for j, aidx in enumerate(assign_indices):
-                dom = (getattr(pdef, "domain", None) or [None] * (j + 1))
+                dom = getattr(pdef, "domain", None) or [None] * (j + 1)
                 if j < len(dom) and dom[j] is not None:
                     expected = inner_map.get(dom[j]) or inner_map.get(str(dom[j]).lower())
                     if expected and not _assign_index_matches(aidx, expected, model_ir):

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -472,9 +472,13 @@ def _param_ref_is_zero(
     resolved_strs: list[str] = [r for r in resolved if r is not None]
 
     if hasattr(pdef, "values") and pdef.values:
-        key: str | tuple[str, ...] = (
-            tuple(resolved_strs) if len(resolved_strs) > 1 else resolved_strs[0]
-        )
+        key: str | tuple[str, ...]
+        if not resolved_strs:
+            key = ()
+        elif len(resolved_strs) > 1:
+            key = tuple(resolved_strs)
+        else:
+            key = resolved_strs[0]
         return pdef.values.get(key, 0) == 0
 
     if hasattr(pdef, "expressions") and pdef.expressions:

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -377,11 +377,10 @@ def _computed_param_covers_instance(
         val_map: dict[str, str] = {}
         for param_pos, eq_idx_name in eq_pos_map.items():
             if param_pos >= len(assign_indices):
-                break
+                return True
             assign_idx = assign_indices[param_pos]
             if not isinstance(assign_idx, str):
-                covers = True
-                break
+                return True
             eq_value = index_map[eq_idx_name]
             if not _assign_index_matches(assign_idx, eq_value, model_ir):
                 covers = False
@@ -394,6 +393,9 @@ def _computed_param_covers_instance(
             return True
 
     return False
+
+
+_lowered_members_cache: dict[str, frozenset[str]] = {}
 
 
 def _assign_index_matches(assign_idx: str, eq_value: str, model_ir: ModelIR) -> bool:
@@ -413,14 +415,22 @@ def _assign_index_matches(assign_idx: str, eq_value: str, model_ir: ModelIR) -> 
             sdef = model_ir.sets.get(getattr(adef, "target", ""))
 
     if sdef is not None:
-        members = list(sdef.members) if hasattr(sdef, "members") and sdef.members else []
-        if members:
-            return eq_value.lower() in {m.lower() for m in members}
-        if getattr(sdef, "domain", None):
-            for parent in sdef.domain:
-                parent_members = _resolve_set_members(parent, model_ir)
-                if parent_members:
-                    return eq_value.lower() in {m.lower() for m in parent_members}
+        cache_key = getattr(sdef, "name", assign_idx).lower()
+        if cache_key not in _lowered_members_cache:
+            members = list(sdef.members) if hasattr(sdef, "members") and sdef.members else []
+            if members:
+                _lowered_members_cache[cache_key] = frozenset(m.lower() for m in members)
+            elif getattr(sdef, "domain", None):
+                for parent in sdef.domain:
+                    parent_members = _resolve_set_members(parent, model_ir)
+                    if parent_members:
+                        _lowered_members_cache[cache_key] = frozenset(
+                            m.lower() for m in parent_members
+                        )
+                        break
+        cached = _lowered_members_cache.get(cache_key)
+        if cached:
+            return eq_value.lower() in cached
         return True
 
     return True

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -1949,9 +1949,6 @@ def _apply_offset_substitution(
     if not ref_info:
         return expr
 
-    # Elements from the equation indices are constraint dimensions, not offsets
-    eq_elements = set(rep_eq_indices)
-
     def _sub(e: Expr) -> Expr:
         if isinstance(e, (VarRef, ParamRef, MultiplierRef)):
             if not e.indices:
@@ -1959,7 +1956,7 @@ def _apply_offset_substitution(
             new_indices: list[str | IndexOffset] = []
             changed = False
             for idx in e.indices:
-                if isinstance(idx, str) and idx not in eq_elements:
+                if isinstance(idx, str):
                     mapped = element_to_set.get(idx)
                     if mapped and mapped in ref_info:
                         ref_elem, pos_map, ref_pos = ref_info[mapped]
@@ -4849,6 +4846,21 @@ def _add_indexed_jacobian_terms(
                         uncontrolled = free_in_deriv - controlled
                         if uncontrolled:
                             sum_indices = tuple(sorted(uncontrolled))
+                            sameas_conds: list[Expr] = []
+                            for free_idx in sum_indices:
+                                free_def = kkt.model_ir.sets.get(free_idx)
+                                if free_def and hasattr(free_def, "domain") and free_def.domain:
+                                    for parent in free_def.domain:
+                                        if parent.lower() in controlled:
+                                            sameas_conds.append(
+                                                Call("sameas", (SymbolRef(free_idx), SymbolRef(parent)))
+                                            )
+                                            break
+                            if sameas_conds:
+                                guard: Expr = sameas_conds[0]
+                                for sc in sameas_conds[1:]:
+                                    guard = Binary("and", guard, sc)
+                                term = DollarConditional(value_expr=term, condition=guard)
                             term = Sum(sum_indices, term)
 
                     # Issue #1049: Guard multiplier terms with $(sameas(...))

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -1924,10 +1924,14 @@ def _apply_offset_substitution(
     element to IndexOffset(domain_var, offset) so downstream replacement
     produces r(i-1) instead of r(i).
 
-    Only applies to elements that are:
-    1. In the same set as the representative variable index
-    2. NOT in the representative equation indices (those are constraint
-       dimensions, not lead/lag offsets — e.g., j4 in maxdist(i3,j4))
+    Applies to ALL string indices whose element_to_set mapping matches a
+    variable domain set in ref_info.  Equation indices from different
+    domain sets are naturally excluded because they map to sets not in
+    ref_info (which is built from var_domain only).  Equation indices
+    from the SAME domain set as the variable ARE eligible for offset
+    substitution — this is required for subset-superset patterns (e.g.,
+    mb(ca) → xfert(ca) where crec(ca_eq, ca_var) needs the equation
+    element converted to an offset expression).
     """
     from src.ad.index_mapping import resolve_set_members
 
@@ -4841,7 +4845,7 @@ def _add_indexed_jacobian_terms(
                     # Skip when _did_dim_mismatch_alias_fix already handled Sum wrapping
                     # and renamed the derivative indices.
                     if not _did_dim_mismatch_alias_fix:
-                        controlled = var_domain_set | mult_domain_set
+                        controlled = {d.lower() for d in var_domain_set | mult_domain_set}
                         free_in_deriv = _collect_free_indices(indexed_deriv, kkt.model_ir)
                         uncontrolled = free_in_deriv - controlled
                         if uncontrolled:

--- a/src/kkt/stationarity.py
+++ b/src/kkt/stationarity.py
@@ -4853,7 +4853,10 @@ def _add_indexed_jacobian_terms(
                                     for parent in free_def.domain:
                                         if parent.lower() in controlled:
                                             sameas_conds.append(
-                                                Call("sameas", (SymbolRef(free_idx), SymbolRef(parent)))
+                                                Call(
+                                                    "sameas",
+                                                    (SymbolRef(free_idx), SymbolRef(parent)),
+                                                )
                                             )
                                             break
                             if sameas_conds:
@@ -4877,9 +4880,11 @@ def _add_indexed_jacobian_terms(
                         and len(var_domain) > len(mult_domain)
                         and len(group_entries) < len(instances)
                     ):
-                        guard = _build_sameas_guard(var_domain, instances, group_entries, kkt)
-                        if guard is not None:
-                            term = DollarConditional(value_expr=term, condition=guard)
+                        sameas_guard = _build_sameas_guard(
+                            var_domain, instances, group_entries, kkt
+                        )
+                        if sameas_guard is not None:
+                            term = DollarConditional(value_expr=term, condition=sameas_guard)
 
                     expr = Binary("+", expr, term)
 
@@ -4915,9 +4920,9 @@ def _add_indexed_jacobian_terms(
                 # nonzero Jacobian entry.  Handles both single-entry (.fx) and
                 # multi-entry (scalar equation summing over a subset) cases.
                 if var_domain and len(entries) < len(instances):
-                    guard = _build_sameas_guard(var_domain, instances, entries, kkt)
-                    if guard is not None:
-                        term = DollarConditional(value_expr=term, condition=guard)
+                    sameas_guard = _build_sameas_guard(var_domain, instances, entries, kkt)
+                    if sameas_guard is not None:
+                        term = DollarConditional(value_expr=term, condition=sameas_guard)
 
                 expr = Binary("+", expr, term)
 

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -1557,6 +1557,50 @@ class TestCollectMissingParamLabels:
         missing = collect_missing_param_labels(model)
         assert missing == set()
 
+    def test_wildcard_last_dim_quoted_literal_all_zero(self):
+        """Quoted literal at non-first wildcard position with all-zero data is missing."""
+        model = ModelIR()
+        model.sets["i"] = SetDef(name="i", members=["a", "b"])
+        model.params["tbl"] = ParameterDef(
+            name="tbl",
+            domain=("i", "*"),
+            values={("a", "col1"): 1.0, ("b", "col2"): 0.0},
+        )
+        model.params["out"] = ParameterDef(
+            name="out",
+            domain=("i",),
+            values={},
+            expressions=[
+                (
+                    ("i",),
+                    Binary("-", ParamRef("tbl", ("i", '"col1"')), ParamRef("tbl", ("i", '"col2"'))),
+                ),
+            ],
+        )
+        missing = collect_missing_param_labels(model)
+        assert "col2" in missing
+
+    def test_wildcard_index_variable_not_treated_as_missing(self):
+        """Set/index variable at wildcard position should NOT be flagged as missing."""
+        model = ModelIR()
+        model.sets["i"] = SetDef(name="i", members=["a", "b"])
+        model.sets["j"] = SetDef(name="j", members=["x", "y"])
+        model.params["tbl"] = ParameterDef(
+            name="tbl",
+            domain=("i", "*"),
+            values={("a", "x"): 1.0},
+        )
+        model.params["out"] = ParameterDef(
+            name="out",
+            domain=("i",),
+            values={},
+            expressions=[
+                (("i",), ParamRef("tbl", ("i", "j"))),
+            ],
+        )
+        missing = collect_missing_param_labels(model)
+        assert "j" not in missing
+
 
 @pytest.mark.unit
 class TestSubsetValueAssignments:

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -822,6 +822,51 @@ class TestEmitComputedParameterAssignments:
         assert "y(i) =" in result
         assert "x(i) + 1" in result
 
+    def test_multi_phase_cycle_ordering(self):
+        """Parameters in a cycle with multiple phases are ordered correctly.
+
+        syield depends on sys, sys depends on syield — a cycle. The topological
+        sort should split syield into phases at the sys dependency boundary and
+        mark the param as defined after any phase, allowing the cycle to proceed.
+        """
+        model = ModelIR()
+        model.sets["s"] = SetDef(name="s", members=["s1"])
+        model.sets["f"] = SetDef(name="f", members=["normal"])
+        model.sets["c"] = SetDef(name="c", members=["wheat"])
+
+        # sys(s,f) = sum(c, syield(c,s,f))  [reads syield]
+        expr_sys = ParamRef("syield", ("c", "s", "f"))
+        model.params["sys"] = ParameterDef(
+            name="sys",
+            domain=("s", "f"),
+            values={},
+            expressions=[(("s", "f"), expr_sys)],
+        )
+        # syield phase 0: syield(c,s,f) = mcp(s,c)  [no dep on sys]
+        # syield phase 1: syield("straw",s,f) = sys(s,f)  [reads sys]
+        expr_phase0 = ParamRef("mcp", ("s", "c"))
+        expr_phase1 = ParamRef("sys", ("s", "f"))
+        model.params["syield"] = ParameterDef(
+            name="syield",
+            domain=("c", "s", "f"),
+            values={},
+            expressions=[
+                (("c", "s", '"normal"'), expr_phase0),
+                (('"straw"', "s", "f"), expr_phase1),
+            ],
+        )
+        model.params["mcp"] = ParameterDef(
+            name="mcp", domain=("s", "c"), values={("s1", "wheat"): 1.0}
+        )
+
+        result = emit_computed_parameter_assignments(model)
+        lines = [ln.strip() for ln in result.strip().splitlines() if ln.strip()]
+        # syield phase 0 must come before sys (so sys can read syield)
+        # sys must come before syield phase 1 (which reads sys)
+        syield_first = next(i for i, ln in enumerate(lines) if "syield" in ln.lower())
+        sys_line = next(i for i, ln in enumerate(lines) if ln.lower().startswith("sys("))
+        assert syield_first < sys_line, "syield phase 0 should precede sys"
+
 
 @pytest.mark.unit
 class TestSetElementQuoting:

--- a/tests/unit/kkt/test_empty_equation_detector.py
+++ b/tests/unit/kkt/test_empty_equation_detector.py
@@ -159,7 +159,7 @@ class TestEmptyEquationDetector:
             expressions=[(("cf", "ca"), Binary("*", Const(1.0), Const(1.0)))],
         )
 
-        # Equation: eq(ca).. sum(cf, coeff(ca,cf)*x(cf)) =E= 0
+        # Equation: eq(ca).. sum(cf, coeff(ca,cf)*x(cf)) =G= 0
         eq_lhs = Sum(
             ("cf",),
             Binary("*", ParamRef("coeff", ("ca", "cf")), VarRef("x", ("cf",))),

--- a/tests/unit/kkt/test_empty_equation_detector.py
+++ b/tests/unit/kkt/test_empty_equation_detector.py
@@ -118,3 +118,62 @@ class TestEmptyEquationDetector:
         # With filter including mbal
         result = detect_empty_equation_instances(ir, relevant_equations={"mbal"})
         assert "mbal" in result
+
+    def test_include_inequalities_scans_inequalities(self):
+        """include_inequalities=True should scan ModelIR.inequalities."""
+        ir = _make_fawley_like_model()
+        # Move mbal to inequalities
+        ir.equalities = []
+        ir.inequalities = ["mbal"]
+        ir.equations["mbal"] = EquationDef(
+            name="mbal",
+            domain=("c",),
+            relation=Rel.GE,
+            lhs_rhs=ir.equations["mbal"].lhs_rhs,
+        )
+
+        # Without include_inequalities — should find nothing
+        result = detect_empty_equation_instances(ir)
+        assert "mbal" not in result
+
+        # With include_inequalities — should find vacuum-res
+        result = detect_empty_equation_instances(ir, include_inequalities=True)
+        assert "mbal" in result
+        assert ("vacuum-res",) in result["mbal"]
+
+    def test_computed_param_expressions_detect_empty(self):
+        """Coefficient params with expressions (no .values) should be analyzed."""
+        ir = ModelIR()
+        ir.sets["ca"] = SetDef(name="ca", members=["wheat", "seed"])
+        ir.sets["cf"] = SetDef(name="cf", domain=("ca",), members=["wheat"])
+
+        from src.ir.symbols import VariableDef
+
+        ir.variables["x"] = VariableDef(name="x", domain=("ca",))
+
+        # Computed coefficient: coeff(ca, cf) assigned only for cf members
+        ir.params["coeff"] = ParameterDef(
+            name="coeff",
+            domain=("ca", "cf"),
+            values={},
+            expressions=[(("cf", "ca"), Binary("*", Const(1.0), Const(1.0)))],
+        )
+
+        # Equation: eq(ca).. sum(cf, coeff(ca,cf)*x(cf)) =E= 0
+        eq_lhs = Sum(
+            ("cf",),
+            Binary("*", ParamRef("coeff", ("ca", "cf")), VarRef("x", ("cf",))),
+        )
+        ir.equations["eq"] = EquationDef(
+            name="eq",
+            domain=("ca",),
+            relation=Rel.GE,
+            lhs_rhs=(eq_lhs, Const(0.0)),
+        )
+        ir.inequalities = ["eq"]
+
+        result = detect_empty_equation_instances(ir, include_inequalities=True)
+        assert "eq" in result
+        # "seed" is not in cf, so the assignment doesn't cover it
+        assert ("seed",) in result["eq"]
+        assert ("wheat",) not in result["eq"]


### PR DESCRIPTION
## Summary

- **Turkey (SEQ=108):** Fix 2 compilation errors blocking the turkey model
  - Skip sets with dotted 2D members and no domain (GAMS Error 161)
  - Extend wildcard label detection to register zero-only labels at any wildcard position (GAMS Error 116)
- **China (SEQ=59):** Fix 3 issues blocking the china model
  - Fix topological sort for cyclic parameter assignment ordering (GAMS Error 141)
  - Extend empty equation detector for inequalities and computed parameters (unmatched variables)
  - Fix stationarity Jacobian transpose for subset-domain variables (incorrect KKT coefficients)
- Plan document: `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_TURKEY.md`

## Test plan

- [ ] `make test` passes (4460 passed, 0 failed)
- [ ] Turkey MCP compiles without errors (solve blocked by demo license — model exceeds 1000 row/col NLP limit)
- [ ] China MCP compiles and solves to MODEL STATUS 1
- [ ] No regressions in existing models