### PR TITLE
Sprint 24 Day 12 — close prep: file Sprint 25 issues, update docs

### DIFF
--- a/docs/issues/ISSUE_1268_decomp-attr-access-handlers-missing-in-subst-dispatcher.md
+++ b/docs/issues/ISSUE_1268_decomp-attr-access-handlers-missing-in-subst-dispatcher.md
@@ -1,0 +1,112 @@
+# decomp: `attr_access` Handlers Missing in `_loop_tree_to_gams_subst_dispatch`
+
+**GitHub Issue:** [#1268](https://github.com/jeffreyhorn/nlp2mcp/issues/1268)
+**Status:** OPEN — Deferred to Sprint 25
+**Severity:** Medium — Silently emits invalid GAMS (`Error 140`) for any single-model multi-solve script that reads `eq.m` or `var.l` inside a loop body
+**Date:** 2026-04-18
+**Last Updated:** 2026-04-18
+**Affected Models:** any single-model multi-solve script that passes the `multi_solve_driver_out_of_scope` gate and has `.m` / `.l` attribute reads inside a loop (none currently in the in-scope corpus; surfaced by `decomp` investigation)
+**Labels:** `sprint-25`
+
+---
+
+## Problem Summary
+
+`src/emit/original_symbols.py` has two loop-body dispatchers:
+
+- `_loop_tree_to_gams` — no token substitution (canonical path)
+- `_loop_tree_to_gams_subst_dispatch` — applies a token-substitution map during emission (used for pre-solve parameter assignments inside loops)
+
+The **substituting** dispatcher is missing rule handlers for `attr_access` and `attr_access_indexed` nodes. These nodes are the parse-tree shape for `eq.m` / `var.l` / `x.fx` attribute reads. When they fall through to the generic space-joining fallback, the grammar's silent `.` token is lost and the emitter produces output like:
+
+```gams
+ctank = - tbal m ;
+```
+
+instead of
+
+```gams
+ctank = -tbal.m;
+```
+
+GAMS rejects the first form with `Error 140: Unknown symbol`.
+
+---
+
+## Why This Was Deferred
+
+The two models in the GAMSlib corpus that triggered this bug — `decomp` and `danwolfe` — are **multi-solve Dantzig–Wolfe driver scripts**. They were categorically excluded from the nlp2mcp pipeline in Sprint 24 (PR #1265) because no single KKT snapshot can reproduce their converged iterative objective. Fixing the emitter bug would not recover either model's catalog reference value, so the emitter fix was deprioritized in favor of the gate.
+
+However, the bug is **real and silent** for any future single-model multi-solve pattern (e.g., warm-start / rolling-horizon styles that read `var.l` between solves of the same model). These patterns are **not** caught by the multi-solve-driver gate, so they would hit this bug unannounced. Fixing the emitter now prevents a class of future silent corruption.
+
+Full deferral rationale: `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_DECOMP.md` §"Why Not Fix The Emission Bugs" #1.
+
+---
+
+## Reproduction
+
+Tooling: the existing `decomp` source at `data/gamslib/raw/decomp.gms` triggers the bug under `--allow-multi-solve` (the dev escape hatch added in PR #1265):
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/decomp.gms \
+    --allow-multi-solve -o /tmp/decomp_mcp.gms
+gams /tmp/decomp_mcp.gms lo=0
+# → Error 140 on line containing `ctank = - tbal m ;`
+```
+
+Inspect the offending output:
+
+```bash
+grep -n "tbal m\|tbal\.m" /tmp/decomp_mcp.gms | head -5
+```
+
+Expected after fix: `ctank = -tbal.m;` (single token, dot preserved).
+
+---
+
+## Root Cause (Code-Level)
+
+- `src/emit/original_symbols.py::_loop_tree_to_gams` (canonical) handles `attr_access` / `attr_access_indexed` at approximately lines 3109–3115, emitting `<symbol>.<attr>` with no surrounding spaces.
+- `src/emit/original_symbols.py::_loop_tree_to_gams_subst_dispatch` (substituting variant) lacks these handlers; unmatched tree nodes fall through to a generic `" ".join(children)` path that drops silent tokens like `.`.
+
+The fix is a direct port of the canonical-path logic.
+
+---
+
+## Suggested Fix
+
+1. Copy the `attr_access` / `attr_access_indexed` branch from `_loop_tree_to_gams` into `_loop_tree_to_gams_subst_dispatch`.
+2. Confirm the symbol / attr tokens go through the same substitution map (substitution must NOT apply to the attr keyword itself).
+3. Add a unit test for the substituting dispatcher that exercises a `<var>.l` read inside a loop body, asserting the rendered string contains `<var>.l` (no whitespace before `.`).
+
+**Do not** do this as part of the larger dispatcher refactor — those are tracked separately (see #1271) to keep the diffs independently reviewable.
+
+---
+
+## Out of Scope (Do NOT Reopen)
+
+- Decomposition semantics for `decomp`/`danwolfe`: covered by the multi-solve-driver gate (PR #1265, issue #1222). These models stay excluded.
+- Dispatcher unification: tracked as #1271.
+- KKT gradient dropping under multi-model `_solve_objectives`: tracked as #1269.
+
+---
+
+## Estimated Effort
+
+1–2 hours (direct port + small regression test).
+
+---
+
+## References
+
+- `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_DECOMP.md` §"Why Not Fix The Emission Bugs" #1
+- `docs/issues/completed/ISSUE_1222_decomp-multi-solve-benders-unsupported.md` — the parent exclusion doc
+- PR #1265 (merged) — multi-solve-driver gate
+- Sibling issues: #1269 (KKT assembly), #1270 (gate extension), #1271 (dispatcher refactor)
+
+---
+
+## Files Involved
+
+- `src/emit/original_symbols.py` (lines 3045–3137 — both dispatchers)
+- `tests/unit/emit/` (new test file, or addition to an existing `test_loop_emit_*.py`)

--- a/docs/issues/ISSUE_1268_decomp-bound-scalar-handlers-missing-in-subst-dispatcher.md
+++ b/docs/issues/ISSUE_1268_decomp-bound-scalar-handlers-missing-in-subst-dispatcher.md
@@ -1,11 +1,11 @@
-# decomp: `attr_access` Handlers Missing in `_loop_tree_to_gams_subst_dispatch`
+# decomp: `bound_scalar` / `bound_indexed` Handlers Missing in `_loop_tree_to_gams_subst_dispatch`
 
 **GitHub Issue:** [#1268](https://github.com/jeffreyhorn/nlp2mcp/issues/1268)
 **Status:** OPEN — Deferred to Sprint 25
-**Severity:** Medium — Silently emits invalid GAMS (`Error 140`) for any single-model multi-solve script that reads `eq.m` or `var.l` inside a loop body
+**Severity:** Medium — Silently emits invalid GAMS (`Error 140`) for any single-model multi-solve script that reads `eq.m` / `var.l` / `x.up` / `x.lo` / `x.fx` inside a loop body
 **Date:** 2026-04-18
-**Last Updated:** 2026-04-18
-**Affected Models:** any single-model multi-solve script that passes the `multi_solve_driver_out_of_scope` gate and has `.m` / `.l` attribute reads inside a loop (none currently in the in-scope corpus; surfaced by `decomp` investigation)
+**Last Updated:** 2026-04-19
+**Affected Models:** any single-model multi-solve script that passes the `multi_solve_driver_out_of_scope` gate and has bound-attribute reads inside a loop (none currently in the in-scope corpus; surfaced by `decomp` investigation)
 **Labels:** `sprint-25`
 
 ---
@@ -17,7 +17,9 @@
 - `_loop_tree_to_gams` — no token substitution (canonical path)
 - `_loop_tree_to_gams_subst_dispatch` — applies a token-substitution map during emission (used for pre-solve parameter assignments inside loops)
 
-The **substituting** dispatcher is missing rule handlers for `attr_access` and `attr_access_indexed` nodes. These nodes are the parse-tree shape for `eq.m` / `var.l` / `x.fx` attribute reads. When they fall through to the generic space-joining fallback, the grammar's silent `.` token is lost and the emitter produces output like:
+The **substituting** dispatcher is missing rule handlers for `bound_scalar` and `bound_indexed` nodes. The GAMS grammar (`src/gams/gams_grammar.lark`) tokenizes the bound-attribute keywords `.l`, `.m`, `.lo`, `.up`, `.fx` as the `BOUND_K` terminal, so reads like `tbal.m` / `util.l` / `x.up` parse to `bound_scalar` / `bound_indexed` nodes — **not** `attr_access` / `attr_access_indexed`, which the grammar reserves for non-bound attributes like `.val` / `.stage` / `.scaleOpt` (and which the substituting dispatcher already handles at lines 3109–3115).
+
+When `bound_scalar` / `bound_indexed` nodes fall through to the generic space-joining fallback at the bottom of the substituting dispatcher, the grammar's silent `.` token is lost and the emitter produces output like:
 
 ```gams
 ctank = - tbal m ;
@@ -66,17 +68,17 @@ Expected after fix: `ctank = -tbal.m;` (single token, dot preserved).
 
 ## Root Cause (Code-Level)
 
-- `src/emit/original_symbols.py::_loop_tree_to_gams` (canonical) handles `attr_access` / `attr_access_indexed` at approximately lines 3109–3115, emitting `<symbol>.<attr>` with no surrounding spaces.
-- `src/emit/original_symbols.py::_loop_tree_to_gams_subst_dispatch` (substituting variant) lacks these handlers; unmatched tree nodes fall through to a generic `" ".join(children)` path that drops silent tokens like `.`.
+- `src/emit/original_symbols.py::_loop_tree_to_gams` (canonical, defined at ~line 2556) handles `bound_indexed` at ~line 2632 and `bound_scalar` at ~line 2639, emitting `<symbol>.<attr>` (and the indexed variant with parentheses) with no surrounding spaces. The `attr_access` / `attr_access_indexed` branches in the canonical dispatcher are at ~lines 2645 / 2649 and handle the **non-bound** attribute rules (`.val`, `.stage`, etc.).
+- `src/emit/original_symbols.py::_loop_tree_to_gams_subst_dispatch` (substituting variant, defined at ~line 3047) **does** handle `attr_access` / `attr_access_indexed` (lines 3109–3115) but **lacks** `bound_scalar` / `bound_indexed` handlers entirely. Unmatched tree nodes fall through to the generic `" ".join(children)` fallback at line 3165, which drops silent tokens like `.`.
 
-The fix is a direct port of the canonical-path logic.
+The fix is a direct port of the `bound_scalar` / `bound_indexed` branches from the canonical dispatcher.
 
 ---
 
 ## Suggested Fix
 
-1. Copy the `attr_access` / `attr_access_indexed` branch from `_loop_tree_to_gams` into `_loop_tree_to_gams_subst_dispatch`.
-2. Confirm the symbol / attr tokens go through the same substitution map (substitution must NOT apply to the attr keyword itself).
+1. Copy the `bound_scalar` / `bound_indexed` branches from `_loop_tree_to_gams` (~lines 2632–2644) into `_loop_tree_to_gams_subst_dispatch`, routing child recursion through `_tree_to_gams_subst` instead of `_loop_tree_to_gams` so the substitution map applies to the symbol name.
+2. The attribute keyword itself (`l`, `m`, `lo`, `up`, `fx`) is a `BOUND_K` token — do NOT apply substitution to it.
 3. Add a unit test for the substituting dispatcher that exercises a `<var>.l` read inside a loop body, asserting the rendered string contains `<var>.l` (no whitespace before `.`).
 
 **Do not** do this as part of the larger dispatcher refactor — those are tracked separately (see #1271) to keep the diffs independently reviewable.
@@ -108,5 +110,6 @@ The fix is a direct port of the canonical-path logic.
 
 ## Files Involved
 
-- `src/emit/original_symbols.py` (lines 3045–3137 — both dispatchers)
+- `src/emit/original_symbols.py` — canonical dispatcher `_loop_tree_to_gams` (~line 2556 onward, with `bound_*` branches at ~2632–2644) and substituting dispatcher `_loop_tree_to_gams_subst_dispatch` (~line 3047 onward)
+- `src/gams/gams_grammar.lark` (`BOUND_K` terminal at ~line 375; `ref_bound` / `cond_bound` rules at ~365–370 and ~451–453)
 - `tests/unit/emit/` (new test file, or addition to an existing `test_loop_emit_*.py`)

--- a/docs/issues/ISSUE_1269_decomp-kkt-assembly-drops-gradients-multi-model.md
+++ b/docs/issues/ISSUE_1269_decomp-kkt-assembly-drops-gradients-multi-model.md
@@ -1,0 +1,114 @@
+# decomp: KKT Assembly Drops Gradient Terms Under Multi-Model `_solve_objectives`
+
+**GitHub Issue:** [#1269](https://github.com/jeffreyhorn/nlp2mcp/issues/1269)
+**Status:** OPEN — Deferred to Sprint 25
+**Severity:** Medium — Silent correctness bug; affects any source file that declares multiple `Model` blocks with distinct objective variables
+**Date:** 2026-04-18
+**Last Updated:** 2026-04-18
+**Affected Models:** any source file with ≥2 `Model` declarations and ≥2 distinct solve targets (currently `decomp` + `danwolfe` only, both excluded by the multi-solve-driver gate; future single-model multi-solve files would also hit this if the gate is extended)
+**Labels:** `sprint-25`
+
+---
+
+## Problem Summary
+
+When a GAMS source declares multiple `Model` blocks with different objective variables — e.g., `Model sub / ... /; Model master / ... /;` with solve statements `solve sub minimizing tank` and `solve master minimizing mobj` — the KKT assembly pipeline silently drops gradient terms for equations that belong to the non-selected model.
+
+Concretely on `decomp`:
+
+- `src/ir/normalize.py::normalize_model` correctly keeps all three equations (`cbal`, `tbal`, `convex`) in `ModelIR.equations`.
+- Downstream KKT assembly / emission produces stationarity only for `cbal`'s variables and emits zero gradient contributions from `tbal` / `convex` — as if those equations didn't exist. The resulting MCP is structurally under-constrained.
+
+Root cause suspicion: `_solve_objectives` is a dict keyed by model name (`{sub: ObjectiveIR(objvar=tank), master: ObjectiveIR(objvar=mobj)}`). The objective-extraction step picks one entry (ordering-dependent) and the rest of KKT assembly walks only that objective's gradient closure, quietly skipping equations tied to the other model's constraints.
+
+---
+
+## Why This Was Deferred
+
+Same reason as #1268: `decomp` and `danwolfe` are Dantzig–Wolfe driver scripts whose catalog objectives are iterative fixed points. Fixing KKT assembly would not recover either model's reference value, so the fix was skipped in favor of the gate (PR #1265).
+
+The bug still matters for:
+
+1. **Any future single-model multi-solve** that declares a second placeholder `Model` (e.g., for diagnostic purposes) — silently produces wrong KKT.
+2. **Extension of the multi-solve gate** (see #1270) that keeps such files in-scope.
+3. **Schema soundness** — the IR currently accepts multi-model declarations without defining the semantics. Declaring semantics one way or the other eliminates ambiguity.
+
+Full deferral rationale: `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_DECOMP.md` §"Why Not Fix The Emission Bugs" #2.
+
+---
+
+## Reproduction
+
+Use `--allow-multi-solve` to bypass the gate and inspect the resulting MCP:
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/decomp.gms \
+    --allow-multi-solve -o /tmp/decomp_mcp.gms
+grep -E "stat_|tbal|convex" /tmp/decomp_mcp.gms
+```
+
+Expected behavior after fix: stationarity equations reference `tbal` / `convex` terms (or the docs explicitly declare multi-model declarations out of scope and the CLI refuses before KKT assembly).
+
+---
+
+## Root Cause Investigation Needed
+
+The bug originates in the coupling between:
+
+- `ModelIR._solve_objectives` (Sprint 22 addition, Issue #1154): dict storing per-model objective info
+- `src/ir/normalize.py::normalize_model` (lines ≈164–192): objective extraction and equation pruning
+- `src/ir/model_ir.py::get_solved_model_equations`: selects which equations feed KKT
+
+Questions to answer in Sprint 25:
+
+1. Which entry of `_solve_objectives` does `normalize_model` currently select, and on what basis (first-inserted? last-solved? alphabetical?)?
+2. Are the "orphaned" equations (`tbal`, `convex` in `decomp`) filtered by `model_equation_map[selected_model]`, or do they pass through and only lose gradients downstream?
+3. Is the intent to emit KKT for a single model (the last `solve` target seems most natural) and drop the rest, or to emit a joint system?
+
+---
+
+## Proposed Semantics (For Discussion)
+
+Recommended: **emit KKT for exactly one solved model (the last `solve` statement's target)** and explicitly refuse multi-model declarations where this heuristic is ambiguous. Enforce the decision in `validate_single_optimization` (alongside the multi-solve-driver gate) rather than in normalize/KKT-assembly, so the error is raised early with a clear message.
+
+---
+
+## Out of Scope (Do NOT Reopen)
+
+- Decomposition semantics: covered by multi-solve-driver gate; `decomp`/`danwolfe` stay excluded regardless of this fix.
+- Emitter attr_access bug: tracked as #1268.
+
+---
+
+## Regression Guards
+
+After any fix:
+
+- `ibm1` (single declared model, 5 solves on it) must continue to translate and match.
+- `partssupply` (2 declared models, 2 distinct solve targets, no equation-marginal feedback) must continue to translate and match — this is the canary for the "multi-model without driver loop" pattern.
+
+Both are covered by `tests/integration/test_decomp_skipped.py::test_cli_does_not_flag_*`.
+
+---
+
+## Estimated Effort
+
+4–6 hours (root-cause hand-tracing + semantics decision + targeted fix + regression tests).
+
+---
+
+## References
+
+- `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_DECOMP.md` §"Why Not Fix The Emission Bugs" #2
+- `docs/issues/completed/ISSUE_1222_decomp-multi-solve-benders-unsupported.md`
+- PR #1265 (merged) — multi-solve gate
+- Sibling issues: #1268 (emitter), #1270 (gate extension), #1271 (dispatcher refactor)
+
+---
+
+## Files Involved
+
+- `src/ir/normalize.py` (lines ≈164–192)
+- `src/ir/model_ir.py::get_solved_model_equations`
+- `src/validation/driver.py` (possibly extended to refuse ambiguous multi-model declarations)
+- `src/kkt/` (stationarity assembly consumers of `_solve_objectives`)

--- a/docs/issues/ISSUE_1269_decomp-kkt-assembly-drops-gradients-multi-model.md
+++ b/docs/issues/ISSUE_1269_decomp-kkt-assembly-drops-gradients-multi-model.md
@@ -84,10 +84,8 @@ Recommended: **emit KKT for exactly one solved model (the last `solve` statement
 
 After any fix:
 
-- `ibm1` (single declared model, 5 solves on it) must continue to translate and match.
-- `partssupply` (2 declared models, 2 distinct solve targets, no equation-marginal feedback) must continue to translate and match — this is the canary for the "multi-model without driver loop" pattern.
-
-Both are covered by `tests/integration/test_decomp_skipped.py::test_cli_does_not_flag_*`.
+- `ibm1` (single declared model, 5 solves on it) must continue to translate and match. Covered by `tests/integration/test_decomp_skipped.py::test_cli_does_not_flag_ibm1` and the synthetic-fixture companion `test_cli_does_not_flag_synthetic_single_model_multi_solve`, plus the unit-level guard `tests/unit/validation/test_driver.py::test_scan_single_model_multi_solve_is_not_driver`.
+- `partssupply` (2 declared models, 2 distinct solve targets, no equation-marginal feedback) must continue to translate and match — this is the canary for the "multi-model without driver loop" pattern. Covered by `tests/unit/validation/test_driver.py::test_scan_partssupply_style_variable_level_is_not_driver`. An integration-level CLI guard for `partssupply` is NOT currently in `tests/integration/test_decomp_skipped.py`; consider adding one as part of this fix so end-to-end parity matches the ibm1 coverage.
 
 ---
 

--- a/docs/issues/ISSUE_1270_multi-solve-gate-saras-style-top-level-marginal-reads.md
+++ b/docs/issues/ISSUE_1270_multi-solve-gate-saras-style-top-level-marginal-reads.md
@@ -1,0 +1,130 @@
+# Multi-Solve Gate: Extend Detector for `saras`-Style Top-Level `eq.m` Feedback
+
+**GitHub Issue:** [#1270](https://github.com/jeffreyhorn/nlp2mcp/issues/1270)
+**Status:** OPEN — Deferred to Sprint 25
+**Severity:** High — Known gap in the driver-detection gate; allows a class of driver scripts through
+**Date:** 2026-04-18
+**Last Updated:** 2026-04-18
+**Affected Models:** `saras` (two-stage primal-dual calibration) and any other two-stage calibration pattern that reads `eq.m` at top level between `solve` statements
+**Labels:** `sprint-25`
+
+---
+
+## Problem Summary
+
+The multi-solve-driver gate added in PR #1265 (`src/validation/driver.py::scan_multi_solve_driver`) flags a file as a driver script only when **three conditions all hold**:
+
+1. `len(declared_models) ≥ 2`
+2. `len(solve_targets) ≥ 2` (distinct model names across all `solve` statements)
+3. `≥ 1 equation marginal (eq.m) accessed inside a loop that also contains a solve`
+
+Condition 3 was deliberately narrowed to "inside a solve-containing loop" to avoid false positives on post-solve reporting — the common GAMSlib pattern where a `.m` value is written into a display parameter for table output after a single solve.
+
+This narrow rule correctly catches `decomp` and `danwolfe` (classical Dantzig–Wolfe iteration) but **misses `saras`-style two-stage calibration**, which reads `eq.m` at *top level* (outside any `loop`) between two `solve` statements. The receiving parameter then feeds the second solve's constraints. This is semantically a driver script — the converged objective is a fixed point across the two solves — but the gate lets it through with `is_driver=False`, and the resulting MCP represents only the second solve's KKT, not the converged primal-dual result.
+
+---
+
+## Why This Was Deferred
+
+`decomp` and `danwolfe` were the immediate DW targets for Sprint 24 and matched the strict rule cleanly. `saras` was identified as a known gap during the Sprint 24 audit (`AUDIT_MULTI_SOLVE_DRIVERS.md`) but extending the rule risked breaking the ~dozen post-solve-reporting patterns in the corpus. The narrow rule was shipped (PR #1265) and the broader detection is tracked here.
+
+Full context: `SPRINT_LOG.md` Day 8 §"Known gap (deferred)"; `PLAN_FIX_DECOMP.md` §"Known gap (deferred to Sprint 25)".
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/saras.gms -o /tmp/saras_mcp.gms
+# → currently: translates to an MCP (gate does not fire)
+# → desired:   exit 4 with the `multi_solve_driver_out_of_scope` message
+```
+
+Confirm the gate's report:
+
+```bash
+.venv/bin/python -c "
+import sys; sys.setrecursionlimit(50000)
+from src.ir.parser import parse_model_file
+from src.validation.driver import scan_multi_solve_driver
+ir = parse_model_file('data/gamslib/raw/saras.gms')
+r = scan_multi_solve_driver(ir)
+print('is_driver =', r.is_driver)
+print('declared =', r.declared_models)
+print('targets  =', r.solve_targets)
+print('marginals=', r.equation_marginals)
+"
+# → is_driver=False; equation_marginals=[]  (the top-level reads don't qualify)
+```
+
+---
+
+## Candidate Approaches (Decide in Sprint 25)
+
+### Approach A — Cross-reference parameters to constraints
+
+Flag an `eq.m` read whose receiving parameter is later referenced in another declared model's constraint body. Tighter false-positive profile because post-solve reporting writes `eq.m` into *display* parameters, not into KKT-relevant coefficients.
+
+**Pros:** Principled — matches the semantic definition of dual feedback.
+**Cons:** Requires parameter-usage tracking across equation bodies; moderately complex to implement reliably.
+
+### Approach B — Sequence awareness (between two solves)
+
+Flag `eq.m` reads that appear **between** two `solve` statements in source order, whether or not inside a loop.
+
+**Pros:** Simple to implement.
+**Cons:** Still catches post-solve reporting placed between two solves in multi-stage display code. May need an additional exclusion for `display` / `put` / `abort` statements in the vicinity.
+
+### Approach C — Explicit corpus allowlist
+
+Add `multi_solve_driver_out_of_scope` to specific models (including `saras`) directly in `gamslib_status.json`, bypassing the detector.
+
+**Pros:** Zero detection-logic churn.
+**Cons:** Does not scale to new corpora; treats symptoms rather than cause.
+
+**Recommendation:** Start with Approach A. It has the cleanest semantics and the tests can be written to distinguish reporting from feedback.
+
+---
+
+## Scope of Work
+
+- `src/validation/driver.py::scan_multi_solve_driver` — detector extension.
+- `src/validation/driver.py::MultiSolveReport` — may need a new field to distinguish top-level-between-solves reads from in-loop reads for better user messaging.
+- `tests/unit/validation/test_driver.py` — add fixtures:
+  - `saras`-style (top-level between solves, parameter then feeds second solve) → **must flag**
+  - Post-solve reporting (top-level after single solve, parameter goes to `display`) → **must NOT flag**
+  - Multi-stage display (top-level between two solves but parameter unused in later solves) → **must NOT flag**
+- `tests/integration/test_decomp_skipped.py` — add synthetic fixture for the saras-style pattern exercising CLI exit-code 4.
+
+---
+
+## Regression Guards (must continue to pass)
+
+- `ibm1` (1 model, 5 solves on same model) — not a driver, must translate.
+- `partssupply` (2 models, 2 targets, post-solve reporting reads `var.l`, not `eq.m`) — not a driver, must translate.
+- All currently-matching models — no false positives.
+
+---
+
+## Estimated Effort
+
+2–3 hours for Approach A + test matrix. Add 1–2 hours if the scope extends to parameter-usage tracking across solves.
+
+---
+
+## References
+
+- `docs/planning/EPIC_4/SPRINT_24/SPRINT_LOG.md` Day 8 §"Known gap (deferred)"
+- `docs/planning/EPIC_4/SPRINT_24/AUDIT_MULTI_SOLVE_DRIVERS.md`
+- `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_DECOMP.md` §"Known gap (deferred to Sprint 25)"
+- PR #1265 (merged) — multi-solve-driver gate
+- Sibling issues: #1268 (emitter), #1269 (KKT assembly), #1271 (dispatcher refactor)
+
+---
+
+## Files Involved
+
+- `src/validation/driver.py` — detector and report
+- `tests/unit/validation/test_driver.py` — unit tests
+- `tests/integration/test_decomp_skipped.py` — CLI integration tests
+- `data/gamslib/raw/saras.gms` — reference corpus example

--- a/docs/issues/ISSUE_1271_refactor-collapse-loop-tree-dispatchers.md
+++ b/docs/issues/ISSUE_1271_refactor-collapse-loop-tree-dispatchers.md
@@ -20,7 +20,7 @@
 Every time a new grammar rule needs emitter support, a handler must be added in **both** functions. This has repeatedly caused silent-correctness bugs where the substituting path falls behind the canonical path:
 
 - **Sprint 24 partssupply (PR #1264):** missing `dollar_cond` / `dollar_cond_paren` / `bracket_expr` / `brace_expr` / `yes_cond` / `no_cond` handlers. Fixed by copy-pasting from the canonical path.
-- **Sprint 25 decomp (#1268):** missing `attr_access` / `attr_access_indexed` handlers. Same class of bug.
+- **Sprint 25 decomp (#1268):** missing `bound_scalar` / `bound_indexed` handlers (the grammar's forms for `.l` / `.m` / `.lo` / `.up` / `.fx` reads, tokenized as `BOUND_K` — NOT `attr_access`, which the substituting dispatcher already handles). Same class of bug.
 
 Each occurrence takes 1–2 hours to diagnose and fix. They will keep recurring as the grammar grows.
 

--- a/docs/issues/ISSUE_1271_refactor-collapse-loop-tree-dispatchers.md
+++ b/docs/issues/ISSUE_1271_refactor-collapse-loop-tree-dispatchers.md
@@ -1,0 +1,111 @@
+# Refactor: Collapse `_loop_tree_to_gams` and `_loop_tree_to_gams_subst_dispatch` Into One Dispatcher
+
+**GitHub Issue:** [#1271](https://github.com/jeffreyhorn/nlp2mcp/issues/1271)
+**Status:** OPEN — Deferred to Sprint 25
+**Severity:** Medium — Pure maintenance debt; actively causes bugs when new grammar-rule handlers are added
+**Date:** 2026-04-18
+**Last Updated:** 2026-04-18
+**Affected Area:** `src/emit/original_symbols.py` loop-body emission paths
+**Labels:** `sprint-25`
+
+---
+
+## Problem Summary
+
+`src/emit/original_symbols.py` has two near-duplicate dispatcher functions that walk the same parse-tree shape and emit GAMS source:
+
+- **`_loop_tree_to_gams`** — canonical path, no token substitution.
+- **`_loop_tree_to_gams_subst_dispatch`** — same walker, but applies a token-substitution map during emission (used for pre-solve parameter assignments inside loops that must rewrite loop indices).
+
+Every time a new grammar rule needs emitter support, a handler must be added in **both** functions. This has repeatedly caused silent-correctness bugs where the substituting path falls behind the canonical path:
+
+- **Sprint 24 partssupply (PR #1264):** missing `dollar_cond` / `dollar_cond_paren` / `bracket_expr` / `brace_expr` / `yes_cond` / `no_cond` handlers. Fixed by copy-pasting from the canonical path.
+- **Sprint 25 decomp (#1268):** missing `attr_access` / `attr_access_indexed` handlers. Same class of bug.
+
+Each occurrence takes 1–2 hours to diagnose and fix. They will keep recurring as the grammar grows.
+
+---
+
+## Why This Was Deferred
+
+The copy-paste approach was the correct short-term call during Sprint 24 because:
+
+1. Sprint 24's primary objective was alias differentiation, not emitter cleanup.
+2. The unified dispatcher requires a full regression test (diff every translated MCP before/after) to be safe — that's ~1 hour of verification work alone.
+3. Unifying during a sprint focused on correctness fixes risked conflating two unrelated diff lines.
+
+Deferral note: `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_PARTSSUPPLY.md` §"Refactor opportunity".
+
+---
+
+## Proposal
+
+Single parameterized dispatcher with an optional substitution map:
+
+```python
+def _loop_tree_to_gams(
+    tree: Tree,
+    *,
+    token_subst: Mapping[str, str] | None = None,
+) -> str:
+    """Walk a loop-body subtree and emit GAMS source.
+
+    When ``token_subst`` is None (default), behavior is identical to the
+    pre-refactor ``_loop_tree_to_gams``. When provided, ID tokens are
+    rewritten through the map during emission, matching the behavior
+    previously in ``_loop_tree_to_gams_subst_dispatch``.
+    """
+```
+
+The `_loop_tree_to_gams_subst_dispatch` name is removed (or kept as a thin wrapper during a deprecation period if external code imports it).
+
+---
+
+## Scope of Work
+
+1. **Unify the two dispatchers.** Preserve every existing handler path exactly. The substitution point is a single `if token_subst is not None: name = token_subst.get(name, name)` inside each ID-emission branch.
+2. **Update callers.** Every site that called `_loop_tree_to_gams_subst_dispatch(tree, subst_map)` now calls `_loop_tree_to_gams(tree, token_subst=subst_map)`.
+3. **Regression test: full-corpus MCP diff.** Before/after, translate every currently-solving GAMSlib model (roughly 60 models) and byte-diff the generated `.gms` output. Any non-zero diff must be investigated. Commit the pre-refactor output to a tmpdir, not to the repo.
+4. **Unit coverage.** Add tests under `tests/unit/emit/` that exercise both call shapes (with and without `token_subst`) across the handler classes — plain IDs, indexed refs, `attr_access`, `dollar_cond`, `sum` expressions, function calls. These pin the parity guarantee.
+5. **Changelog.** Document the rename in `CHANGELOG.md` under `[Unreleased]`.
+
+---
+
+## Explicitly Out of Scope
+
+- **Do not** take the opportunity to fix emission bugs in this PR. Bugs in the current emitter remain as bugs after the refactor; they are fixed in separate PRs (#1268, #1269). Mixing a mechanical refactor with behavior changes defeats the regression diff.
+- **Do not** change the name of handler methods inside the unified dispatcher. Keep patches small and obviously equivalent.
+
+---
+
+## Regression Guards
+
+- Full fast test suite (`make test`) — zero new failures.
+- `scripts/gamslib/run_full_test.py --only-parse --quiet` — no new parse failures.
+- Byte-diff of MCP outputs for all currently-solving models — zero diffs.
+
+---
+
+## Estimated Effort
+
+- Mechanical unification: 2–3 hours.
+- Full-corpus MCP diff regression: 1–2 hours (depending on corpus size on the developer machine).
+- Unit test additions: 1 hour.
+- **Total: 4–6 hours.**
+
+---
+
+## References
+
+- `docs/planning/EPIC_4/SPRINT_24/PLAN_FIX_PARTSSUPPLY.md` §"Refactor opportunity"
+- PR #1264 (merged) — latest change hitting both dispatchers
+- Sibling issue: #1268 (the next emitter bug that will cost 1–2 hours under the current duplication)
+
+---
+
+## Files Involved
+
+- `src/emit/original_symbols.py` — both dispatcher functions
+- Any caller of `_loop_tree_to_gams_subst_dispatch` (grep for references)
+- `tests/unit/emit/` — new parity tests
+- `CHANGELOG.md` — `[Unreleased]` entry

--- a/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
@@ -716,7 +716,7 @@ Unknowns surfaced during Sprint 24 execution that were not in the initial 26-ite
 ### KU-30: Emitter Dispatcher Duplication
 
 **Priority:** Medium
-**Discovery:** Two near-duplicate dispatchers in `src/emit/original_symbols.py` — `_loop_tree_to_gams` and `_loop_tree_to_gams_subst_dispatch`. Every new grammar-rule handler (`dollar_cond`, `bracket_expr`, `attr_access`, etc.) must be added in both places. Sprint 24 hit this repeatedly (PR #1264 for partssupply; will recur for the decomp attr_access fix in Sprint 25).
+**Discovery:** Two near-duplicate dispatchers in `src/emit/original_symbols.py` — `_loop_tree_to_gams` and `_loop_tree_to_gams_subst_dispatch`. Every new grammar-rule handler (`dollar_cond`, `bracket_expr`, `bound_scalar`, etc.) must be added in both places. Sprint 24 hit this repeatedly (PR #1264 for partssupply; will recur for the decomp `bound_scalar` / `bound_indexed` fix in Sprint 25 — #1268).
 
 **Resolution Plan:** Collapse into a single dispatcher that takes an optional `token_subst_map` parameter. Behavior identical under either call shape.
 

--- a/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
@@ -2,8 +2,8 @@
 
 **Created:** 2026-04-03
 **Sprint:** 24 (Prep Task 1)
-**Status:** Initial — all unknowns pending verification
-**Last Updated:** 2026-04-03
+**Status:** End-of-sprint — all prep-time unknowns verified; new discoveries logged in §"End-of-Sprint Discoveries"
+**Last Updated:** 2026-04-18 (Day 12 close prep)
 
 ---
 
@@ -672,5 +672,86 @@ This document catalogs assumptions and unknowns for Sprint 24 (Alias Differentia
 ---
 
 **Document Created:** 2026-04-03
-**Total Unknowns:** 26
+**Total Unknowns:** 26 (prep) + 6 (end-of-sprint discoveries, KU-27..KU-32)
 **Sprint 23 Carryforward:** 3 KUs (Sprint 23 KU-28 → KU-22, KU-29 → KU-23, KU-32 → KU-24)
+
+---
+
+## End-of-Sprint Discoveries (Day 12 Close Prep)
+
+Unknowns surfaced during Sprint 24 execution that were not in the initial 26-item set. These are logged here for Sprint 25 planning; each has a corresponding GitHub issue filed with the `sprint-25` label.
+
+### KU-27: Lark Grammar Ambiguity for `/ all - eq /`
+
+**Priority:** Resolved (defensive fix landed)
+**Discovery:** The test `test_model_all_except_single` failed reliably on CI but passed locally. Initial hypothesis (xdist parser shared state) was wrong. Root cause: Lark 1.1.9 (pinned in `requirements.txt`, used by CI) and Lark 1.2+ (installed locally via `pyproject.toml`'s `>=1.1.9`) disambiguate the input `all - eq1` differently. Lark 1.2+ picks `model_all_except`; 1.1.9 picks `model_subtraction` with children `[ID("all"), ID("eq1")]`.
+
+**Resolution:** `src/ir/parser.py::_extract_model_refs` now rewrites the `model_subtraction` tree to exclusion semantics when the first ID is `all` (case-insensitive). Version-independent. PR #1267 merged.
+
+**Lingering risk:** Whenever a grammar rule allows a keyword-like string (`"all"i`, etc.) in a position where `ID` also matches, Lark disambiguation may differ across versions. Audit similar rules during Sprint 25 grammar work.
+
+**Tracking:** #1266 (CLOSED)
+
+### KU-28: `requirements.txt` Pinning Divergence from `pyproject.toml`
+
+**Priority:** Medium — Process
+**Discovery:** `pyproject.toml` uses `>=` lower bounds (`lark>=1.1.9`, `click>=8.0.0`), while `requirements.txt` pins exact versions (`lark==1.1.9`, `pytest==7.4.4`). CI uses `requirements.txt`, local dev typically uses `pip install -e ".[dev]"`. This created a silent "CI fails, local passes" divergence on KU-27.
+
+**How to apply in Sprint 25:** when debugging CI-only failures, `pip install -r requirements.txt` first to match the CI environment before assuming nondeterminism. Consider reconciling the two files (either keep `requirements.txt` as the single source of truth with ≥ constraints, or document the deliberate divergence).
+
+**Tracking:** No GitHub issue — captured as a process note in `MEMORY.md`.
+
+### KU-29: Multi-Solve-Driver Gate — `saras`-Style Top-Level Marginal Reads
+
+**Priority:** High
+**Discovery:** The three-condition driver detector from PR #1265 correctly flags `decomp` and `danwolfe` (DW iteration with `eq.m` reads inside a solve-containing loop). It does **not** catch calibration scripts like `saras` where `eq.m` is read at top level between solves. Broadening to "anywhere in source" was rejected because it produces false positives on post-solve reporting.
+
+**How to Verify / Candidate Approaches:**
+- Cross-reference: flag `eq.m` reads whose receiving parameter later appears in another declared model's constraints (tighter false-positive profile).
+- Sequence awareness: flag reads that appear *between* two `solve` statements.
+- Explicit corpus allowlist in `gamslib_status.json` for known calibration scripts.
+
+**Tracking:** #1270 (`sprint-25`)
+
+### KU-30: Emitter Dispatcher Duplication
+
+**Priority:** Medium
+**Discovery:** Two near-duplicate dispatchers in `src/emit/original_symbols.py` — `_loop_tree_to_gams` and `_loop_tree_to_gams_subst_dispatch`. Every new grammar-rule handler (`dollar_cond`, `bracket_expr`, `attr_access`, etc.) must be added in both places. Sprint 24 hit this repeatedly (PR #1264 for partssupply; will recur for the decomp attr_access fix in Sprint 25).
+
+**Resolution Plan:** Collapse into a single dispatcher that takes an optional `token_subst_map` parameter. Behavior identical under either call shape.
+
+**Tracking:** #1271 (`sprint-25`)
+
+### KU-31: decomp Emitter/Assembly Bugs (Single-Model Multi-Solve Path)
+
+**Priority:** Medium
+**Discovery:** The multi-solve-driver gate excludes `decomp` and `danwolfe` (PR #1265), but two real emitter/assembly bugs surfaced during that investigation and would affect any future **single-model multi-solve** scenario (which the gate does NOT catch):
+
+1. `_loop_tree_to_gams_subst_dispatch` missing `attr_access` / `attr_access_indexed` handlers → emits `ctank = - tbal m` instead of `ctank = -tbal.m` (#1268).
+2. KKT assembly drops gradient terms for equations belonging to non-selected models when `_solve_objectives` has multiple entries (#1269).
+
+**Tracking:** #1268 (emitter), #1269 (assembly)
+
+### KU-32: Validation Scope for `sameas()` Guards Across GAMS Element Types
+
+**Priority:** Low
+**Discovery:** KU-05 (`sameas` guard generation correctness) was only partially verified. The IR builder emits `sameas()` calls correctly and the emitter passes them through as GAMS built-ins, but *runtime* behavior across numeric / string / dotted element types and compile-time performance with/without guards on large models was not benchmarked.
+
+**How to Verify:** Compile a representative MCP from each GAMSlib category (CGE, alias-quadratic, CES with dotted elements) and confirm PATH produces identical results with and without guards. Benchmark compile time on the largest matching model.
+
+**Tracking:** Subsumed into Sprint 25 alias-differentiation follow-up (no dedicated issue; covered by the open alias issues #1138-#1147, #1150).
+
+---
+
+## Close-Prep Relabeling Summary (Day 12)
+
+15 open issues previously labeled `sprint-24` were relabeled `sprint-25`:
+
+- **Alias differentiation carryforward (12):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150, #1177
+- **Translation timeouts (3):** #1169 (lop), #1185 (mexls), #1192 (gtm)
+
+Plus 4 newly-filed Sprint 25 tracking issues:
+- #1268 — decomp emitter `attr_access` handlers (KU-31 #1)
+- #1269 — decomp KKT assembly multi-model gradient drop (KU-31 #2)
+- #1270 — saras-style multi-solve gate extension (KU-29)
+- #1271 — emitter dispatcher unification (KU-30)

--- a/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
@@ -679,7 +679,7 @@ This document catalogs assumptions and unknowns for Sprint 24 (Alias Differentia
 
 ## End-of-Sprint Discoveries (Day 12 Close Prep)
 
-Unknowns surfaced during Sprint 24 execution that were not in the initial 26-item set. These are logged here for Sprint 25 planning; each has a corresponding GitHub issue filed with the `sprint-25` label.
+Unknowns surfaced during Sprint 24 execution that were not in the initial 26-item set. These are logged here for Sprint 25 planning. Each entry's `Tracking:` line points to the authoritative record — a Sprint 25 GitHub issue where one was filed, an already-closed issue for discoveries resolved in-sprint (KU-27 → #1266), or this document itself for process notes that do not warrant a GitHub issue (KU-28).
 
 ### KU-27: Lark Grammar Ambiguity for `/ all - eq /`
 
@@ -699,7 +699,7 @@ Unknowns surfaced during Sprint 24 execution that were not in the initial 26-ite
 
 **How to apply in Sprint 25:** when debugging CI-only failures, `pip install -r requirements.txt` first to match the CI environment before assuming nondeterminism. Consider reconciling the two files (either keep `requirements.txt` as the single source of truth with ≥ constraints, or document the deliberate divergence).
 
-**Tracking:** No GitHub issue — captured as a process note in `MEMORY.md`.
+**Tracking:** No GitHub issue — captured in this Known Unknowns document as a process note.
 
 ### KU-29: Multi-Solve-Driver Gate — `saras`-Style Top-Level Marginal Reads
 

--- a/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_24/KNOWN_UNKNOWNS.md
@@ -727,7 +727,7 @@ Unknowns surfaced during Sprint 24 execution that were not in the initial 26-ite
 **Priority:** Medium
 **Discovery:** The multi-solve-driver gate excludes `decomp` and `danwolfe` (PR #1265), but two real emitter/assembly bugs surfaced during that investigation and would affect any future **single-model multi-solve** scenario (which the gate does NOT catch):
 
-1. `_loop_tree_to_gams_subst_dispatch` missing `attr_access` / `attr_access_indexed` handlers → emits `ctank = - tbal m` instead of `ctank = -tbal.m` (#1268).
+1. `_loop_tree_to_gams_subst_dispatch` missing `bound_scalar` / `bound_indexed` handlers → emits `ctank = - tbal m` instead of `ctank = -tbal.m` for reads of `.l` / `.m` / `.lo` / `.up` / `.fx` (which the grammar tokenizes as `BOUND_K`, NOT `attr_access`) (#1268).
 2. KKT assembly drops gradient terms for equations belonging to non-selected models when `_solve_objectives` has multiple entries (#1269).
 
 **Tracking:** #1268 (emitter), #1269 (assembly)
@@ -747,11 +747,12 @@ Unknowns surfaced during Sprint 24 execution that were not in the initial 26-ite
 
 15 open issues previously labeled `sprint-24` were relabeled `sprint-25`:
 
-- **Alias differentiation carryforward (12):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150, #1177
+- **Alias differentiation carryforward (11):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150
+- **`model_infeasible` carryforward (1):** #1177 (chenery — root cause is alias-related per KU-16, but the issue doc categorizes it as `model_infeasible` / post-$171 domain widening)
 - **Translation timeouts (3):** #1169 (lop), #1185 (mexls), #1192 (gtm)
 
 Plus 4 newly-filed Sprint 25 tracking issues:
-- #1268 — decomp emitter `attr_access` handlers (KU-31 #1)
+- #1268 — decomp emitter `bound_scalar` / `bound_indexed` handlers (KU-31 #1)
 - #1269 — decomp KKT assembly multi-model gradient drop (KU-31 #2)
 - #1270 — saras-style multi-solve gate extension (KU-29)
 - #1271 — emitter dispatcher unification (KU-30)

--- a/docs/planning/EPIC_4/SPRINT_24/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_24/SPRINT_LOG.md
@@ -393,13 +393,14 @@ This rules out the critical false-positive classes:
 
 | # | Title | From |
 |---|---|---|
-| #1268 | decomp: add `attr_access` handlers to `_loop_tree_to_gams_subst_dispatch` | PLAN_FIX_DECOMP "Why Not Fix" §1 |
+| #1268 | decomp: add `bound_scalar` / `bound_indexed` handlers to `_loop_tree_to_gams_subst_dispatch` | PLAN_FIX_DECOMP "Why Not Fix" §1 |
 | #1269 | decomp: KKT assembly drops `tbal`/`convex` gradients under multi-model `_solve_objectives` | PLAN_FIX_DECOMP "Why Not Fix" §2 |
 | #1270 | Multi-solve gate: extend detector for saras-style top-level `eq.m` feedback | SPRINT_LOG Day 8 "Known gap" |
 | #1271 | Refactor: collapse `_loop_tree_to_gams` / `_loop_tree_to_gams_subst_dispatch` into one dispatcher | PLAN_FIX_PARTSSUPPLY §"Refactor opportunity" |
 
 **Relabeled sprint-24 → sprint-25 (15 open):**
-- **Alias differentiation carryforward (12):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150, #1177
+- **Alias differentiation carryforward (11):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150
+- **`model_infeasible` carryforward (1):** #1177 (chenery, post-$171 domain widening — root cause is alias-related per KU-16 but the issue is categorized as `model_infeasible` in its doc, so it's listed here rather than with the alias-differentiation bucket)
 - **Translation timeouts / runtime bugs (3):** #1169 (lop), #1185 (mexls), #1192 (gtm)
 
 **Key end-of-sprint discoveries (full detail in `KNOWN_UNKNOWNS.md`):**

--- a/docs/planning/EPIC_4/SPRINT_24/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_24/SPRINT_LOG.md
@@ -379,13 +379,37 @@ This rules out the critical false-positive classes:
 
 ### Day 12 — Sprint Close Prep
 
-**Status:** NOT STARTED
+**Status:** COMPLETE
+**Branch:** `sprint24-day12-close-prep`
 
 | Task | Status |
 |---|---|
-| File deferred issues (sprint-25 label) | |
-| Update KNOWN_UNKNOWNS.md | |
-| Update SPRINT_LOG.md | |
+| File deferred issues (sprint-25 label) | ✅ 4 new issues filed (#1268–#1271); 15 open sprint-24 issues relabeled sprint-25 |
+| Update KNOWN_UNKNOWNS.md | ✅ 6 end-of-sprint discoveries logged (KU-27..KU-32) |
+| Update SPRINT_LOG.md | ✅ |
+| Run `make test` | ✅ 4522 passed, 10 skipped, 1 xfailed (no regressions from Day 11) |
+
+**New Sprint 25 tracking issues filed:**
+
+| # | Title | From |
+|---|---|---|
+| #1268 | decomp: add `attr_access` handlers to `_loop_tree_to_gams_subst_dispatch` | PLAN_FIX_DECOMP "Why Not Fix" §1 |
+| #1269 | decomp: KKT assembly drops `tbal`/`convex` gradients under multi-model `_solve_objectives` | PLAN_FIX_DECOMP "Why Not Fix" §2 |
+| #1270 | Multi-solve gate: extend detector for saras-style top-level `eq.m` feedback | SPRINT_LOG Day 8 "Known gap" |
+| #1271 | Refactor: collapse `_loop_tree_to_gams` / `_loop_tree_to_gams_subst_dispatch` into one dispatcher | PLAN_FIX_PARTSSUPPLY §"Refactor opportunity" |
+
+**Relabeled sprint-24 → sprint-25 (15 open):**
+- **Alias differentiation carryforward (12):** #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150, #1177
+- **Translation timeouts / runtime bugs (3):** #1169 (lop), #1185 (mexls), #1192 (gtm)
+
+**Key end-of-sprint discoveries (full detail in `KNOWN_UNKNOWNS.md`):**
+
+- **KU-27** — Lark 1.1.9 vs 1.2+ grammar disambiguation for `/ all - eq1 /`. Fixed defensively in PR #1267; audit similar `"keyword"i | ID`-style rules during Sprint 25 grammar work.
+- **KU-28** — `requirements.txt` pins vs `pyproject.toml` lower-bounds produce silent CI/local divergences. Process note: `pip install -r requirements.txt` first when debugging CI-only failures.
+- **KU-29** — Multi-solve gate doesn't catch saras-style top-level marginal reads (→ #1270).
+- **KU-30** — Emitter dispatcher duplication (→ #1271).
+- **KU-31** — decomp emitter/assembly bugs that would affect future single-model multi-solve cases (→ #1268, #1269).
+- **KU-32** — `sameas()` guard validation across GAMS element types (subsumed into open alias issues).
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 24 Day 12 close-prep work (per `PLAN_PROMPTS.md` Day 12 prompt):

- **4 new Sprint 25 tracking issues** filed (`sprint-25` label), each backed by a matching `docs/issues/ISSUE_{NNNN}_*.md` doc with full reproduction, root-cause, scope, regression guards, and effort estimate:
  - #1268 — decomp: `attr_access` handlers missing in `_loop_tree_to_gams_subst_dispatch`
  - #1269 — decomp: KKT assembly drops `tbal`/`convex` gradients under multi-model `_solve_objectives`
  - #1270 — Multi-solve gate: extend detector for `saras`-style top-level `eq.m` feedback
  - #1271 — Refactor: collapse `_loop_tree_to_gams` and `_loop_tree_to_gams_subst_dispatch` into one dispatcher
- **15 still-open `sprint-24` issues relabeled `sprint-25`** (12 alias-differentiation carryforward + 3 translation timeouts / runtime bugs): #1138, #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1150, #1169, #1177, #1185, #1192.
- **`KNOWN_UNKNOWNS.md`** extended with 6 end-of-sprint discoveries (KU-27..KU-32) covering the Lark disambiguation root cause, the `requirements.txt` vs `pyproject.toml` divergence, and each of the 4 new tracking issues.
- **`SPRINT_LOG.md`** Day 12 entry marked `COMPLETE` with the full new-issues / relabeling summary.

No source code is modified — this is close-prep bookkeeping only.

## Why this matters

Sprint 25 kickoff needs an accurate, deduplicated backlog of deferred work. Without this pass, the 4 end-of-sprint discoveries (decomp emitter, decomp KKT assembly, saras-style gate, dispatcher duplication) would live only in prose inside SPRINT_LOG.md and never become trackable GitHub issues. Relabeling prevents the `sprint-24` label from becoming misleading (open issues labeled for a completed sprint).

## Test plan

- [x] `make test` — 4522 passed, 10 skipped, 1 xfailed (no regressions; the +2 from PR #1267 are preserved)
- [x] Docs-only diff — no Python / grammar / schema files touched, so typecheck/lint/format were skipped per the workflow instructions
- [x] All 4 new issue docs cross-reference the filed GitHub issues and cite specific source-file line numbers where applicable
- [x] KNOWN_UNKNOWNS.md end-of-sprint section links every new KU to either a closed PR (KU-27) or an open Sprint 25 issue (KU-29/30/31)