### PR TITLE
Double pipeline timeouts (translate 300→600s, solve 60→120s, compile-check 30→60s)

### DIFF
--- a/scripts/gamslib/batch_translate.py
+++ b/scripts/gamslib/batch_translate.py
@@ -262,7 +262,7 @@ def translate_single_model(
             text=True,
         )
 
-        translate_timeout = 300  # seconds
+        translate_timeout = 600  # seconds (bumped 300 -> 600 to accommodate larger models)
         try:
             stdout, stderr = proc.communicate(timeout=translate_timeout)
             elapsed = time.perf_counter() - start_time
@@ -370,7 +370,7 @@ def validate_mcp_file(mcp_path: Path) -> dict[str, Any]:
             cmd,
             capture_output=True,
             text=True,
-            timeout=30,  # 30 second timeout for compile check
+            timeout=60,  # 60 second timeout for compile check (bumped 30 -> 60)
         )
 
         elapsed = time.perf_counter() - start_time
@@ -393,7 +393,7 @@ def validate_mcp_file(mcp_path: Path) -> dict[str, Any]:
         return {
             "valid": False,
             "validation_time_seconds": round(time.perf_counter() - start_time, 4),
-            "error": "Validation timeout after 30 seconds",
+            "error": "Validation timeout after 60 seconds",
         }
     except Exception as e:
         return {

--- a/scripts/gamslib/batch_translate.py
+++ b/scripts/gamslib/batch_translate.py
@@ -334,6 +334,7 @@ def validate_mcp_file(mcp_path: Path) -> dict[str, Any]:
     import shutil
 
     start_time = time.perf_counter()
+    compile_check_timeout = 60  # seconds (bumped 30 -> 60 in PR #1274)
 
     # Find GAMS executable
     gams_exe = shutil.which("gams")
@@ -370,7 +371,7 @@ def validate_mcp_file(mcp_path: Path) -> dict[str, Any]:
             cmd,
             capture_output=True,
             text=True,
-            timeout=60,  # 60 second timeout for compile check (bumped 30 -> 60)
+            timeout=compile_check_timeout,
         )
 
         elapsed = time.perf_counter() - start_time
@@ -393,7 +394,7 @@ def validate_mcp_file(mcp_path: Path) -> dict[str, Any]:
         return {
             "valid": False,
             "validation_time_seconds": round(time.perf_counter() - start_time, 4),
-            "error": "Validation timeout after 60 seconds",
+            "error": f"Validation timeout after {compile_check_timeout} seconds",
         }
     except Exception as e:
         return {

--- a/scripts/gamslib/run_full_test.py
+++ b/scripts/gamslib/run_full_test.py
@@ -500,7 +500,7 @@ def run_solve_stage(
     if args.verbose:
         logger.info("    [SOLVE] Starting...")
 
-    result = solve_func(mcp_path, timeout=60)
+    result = solve_func(mcp_path, timeout=120)
 
     # Update model in database
     solve_date = datetime.now(UTC).isoformat()
@@ -718,7 +718,7 @@ def _run_convexity_check(
             logger.info("    [CONVEXITY] Reusing existing warm-start solve result")
     else:
         solve_func = get_solve_function()
-        warm_result = solve_func(presolve_path, timeout=60)
+        warm_result = solve_func(presolve_path, timeout=120)
 
     # Compare
     cvx = check_convexity_from_results(cold_result, warm_result)

--- a/scripts/gamslib/test_solve.py
+++ b/scripts/gamslib/test_solve.py
@@ -908,12 +908,12 @@ def compare_solutions(
     return result
 
 
-def solve_mcp(mcp_path: Path, timeout: int = 60) -> dict[str, Any]:
+def solve_mcp(mcp_path: Path, timeout: int = 120) -> dict[str, Any]:
     """Solve an MCP model using PATH solver.
 
     Args:
         mcp_path: Path to the MCP .gms file
-        timeout: Maximum solve time in seconds (default: 60)
+        timeout: Maximum solve time in seconds (default: 120)
 
     Returns:
         Dictionary with solve results:
@@ -1306,7 +1306,7 @@ def run_batch_solve(args: argparse.Namespace) -> int:
             continue
 
         # Solve MCP
-        result = solve_mcp(mcp_file, timeout=60)
+        result = solve_mcp(mcp_file, timeout=120)
 
         if args.verbose:
             logger.info(f"  Status: {result['status']}")

--- a/tests/unit/diagnostics/test_convexity_numerical.py
+++ b/tests/unit/diagnostics/test_convexity_numerical.py
@@ -186,10 +186,10 @@ class TestCompareResults:
     def test_error_details_in_fallback_conclusion(self):
         """When solves fail, error details should appear in the conclusion."""
         cold = _fail(error="GAMS executable not found")
-        warm = _fail(error="Timeout after 60 seconds")
+        warm = _fail(error="Timeout after 120 seconds")
         result = _compare_results(cold, warm)
         assert "GAMS executable not found" in result.conclusion
-        assert "Timeout after 60 seconds" in result.conclusion
+        assert "Timeout after 120 seconds" in result.conclusion
 
     def test_missing_fields_not_trusted(self):
         """Result dicts missing status/solver_status should not be trusted."""


### PR DESCRIPTION
## Summary

Doubles every wall-clock timeout in the GAMSlib pipeline scripts. Motivation: the Sprint 24 Day 13 retest (PR #1273) surfaced 10 models still timing out in translate and some marginal solve-side timeouts; several are close to the old caps and likely to succeed with more headroom (the genuinely-intractable ones are unaffected).

## Changes

| Location | Before | After | Stage |
|---|---|---|---|
| `scripts/gamslib/batch_translate.py::translate_timeout` | 300 s | **600 s** | `nlp2mcp` subprocess |
| `scripts/gamslib/batch_translate.py` compile-check `subprocess.run(..., timeout=...)` | 30 s | **60 s** | Post-emit GAMS compile smoke |
| `scripts/gamslib/test_solve.py::solve_mcp(timeout=...)` default | 60 s | **120 s** | PATH solve via GAMS (`reslim` + outer `subprocess.run`) |
| `scripts/gamslib/run_full_test.py` primary `solve_func(..., timeout=60)` | 60 s | **120 s** | Main solve call |
| `scripts/gamslib/run_full_test.py` warm-start `solve_func(presolve_path, timeout=60)` | 60 s | **120 s** | `--nlp-presolve` retry |

Supporting edits:
- Docstring `solve_mcp` default-parameter description updated from "60" to "120"
- Error message `"Validation timeout after 30 seconds"` updated to `"... 60 seconds"` (matches new compile-check cap)
- `tests/unit/diagnostics/test_convexity_numerical.py::test_error_details_in_fallback_conclusion` updated to assert the new `"Timeout after 120 seconds"` string that `solve_mcp` would emit under the new default

## Impact

- **Translation**: could recover models that were just over 300 s (candidates: `iswnm`, `sarf`, and possibly some of the 10 timeouts listed in issue #1185). No downside for models that were well under.
- **Solve**: PATH rarely needs > 60 s on this corpus; the headroom mainly helps flaky runs on slower hardware and any model where `reslim=60` was the binding constraint.
- **Pipeline wall time**: if all 10 translate timeouts now run to 600 s, worst-case pipeline wall time grows by roughly (600−300)×10 ≈ 50 min. Typical runs are unaffected because successful translates finish well before the cap.

## Test plan

- [x] `make typecheck` — clean
- [x] `make lint` — clean
- [x] `make format` — clean
- [x] `make test` — **4,522 passed**, 10 skipped, 1 xfailed (no regressions); the one test that asserted on the literal timeout string was updated
- [x] Grepped `scripts/` and `tests/` for other `timeout`, `300`, `30 seconds`, `60 seconds` references — no other stale values

Ready for review. The next full pipeline run (not in this PR) will validate whether any of the borderline timeout models actually recover under the new budgets.