### PR TITLE
Sprint 25 Day 1: Land #1283 Option D grammar fix + PR12 determinism test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Run full test suite with coverage (parallel)
         run: |
           pip install pytest-cov
-          pytest tests/ -n auto --cov=src --cov-report=term-missing --tb=short
+          # Exclude `slow` — TestDeterminismFull sweeps the 143-model convex
+          # corpus and only runs in the nightly workflow (which populates the
+          # full raw/ dir). The per-PR coverage run uses the 5 fast fixtures
+          # already downloaded above.
+          pytest tests/ -m "not slow" -n auto --cov=src --cov-report=term-missing --tb=short
         timeout-minutes: 10
 
       - name: Generate JSON diagnostics for tier 1 models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
           pip install -e ".[dev]"
           pip install -r requirements.txt
 
+      - name: Download fast-suite determinism fixtures
+        run: |
+          # Populate data/gamslib/raw/ with the 5 models referenced by
+          # tests/integration/test_pipeline_determinism.py::TestDeterminismFast.
+          # Without this step those tests skip (raw/ is gitignored), and the
+          # #1283 regression signal is lost on per-PR CI.
+          ./scripts/download_gamslib_raw.sh --fast
+
       - name: Run fast test suite (parallel)
         run: |
           pytest -m "not slow" -n auto -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,30 +30,46 @@ jobs:
 
       - name: Restore fast-suite determinism fixture cache
         id: gamslib-raw-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: data/gamslib/raw/
-          # Key on the download script (which pins the fast fixture list) and
-          # the status JSON (which provides source URLs). Either change should
-          # invalidate the cache.
-          key: ${{ runner.os }}-gamslib-raw-fast-${{ hashFiles('scripts/download_gamslib_raw.sh', 'data/gamslib/gamslib_status.json') }}
+          # Key on the download script (which pins the fast fixture list),
+          # the shared manifest file (the actual list of fixture names), and
+          # the status JSON (which provides source URLs). Any of these changes
+          # should invalidate the cache.
+          key: ${{ runner.os }}-gamslib-raw-fast-${{ hashFiles('scripts/download_gamslib_raw.sh', 'tests/integration/determinism_fast_fixtures.txt', 'data/gamslib/gamslib_status.json') }}
 
       - name: Download fast-suite determinism fixtures
+        id: download-gamslib-raw
         if: steps.gamslib-raw-cache.outputs.cache-hit != 'true'
         run: |
-          # Populate data/gamslib/raw/ with the 5 models referenced by
-          # tests/integration/test_pipeline_determinism.py::TestDeterminismFast.
-          # On a cache miss we try to fetch from gams.com. If that fails
-          # (transient network/gams.com hiccup), emit a GitHub warning and
-          # set SKIP_DETERMINISM=1 — the next step filters the determinism
+          # Populate data/gamslib/raw/ with the fixtures from
+          # tests/integration/determinism_fast_fixtures.txt. On a cache miss
+          # we try to fetch from gams.com. If that fails (transient
+          # network/gams.com hiccup), emit a GitHub warning and set
+          # SKIP_DETERMINISM=1 — the next step filters the determinism
           # marker out so the job still passes. The signal we care about is
           # repo regressions, not external availability.
           if ./scripts/download_gamslib_raw.sh --fast; then
             echo "Downloaded fast-suite determinism fixtures."
+            echo "download-ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Failed to download fast-suite determinism fixtures from gams.com; skipping determinism tests in PR CI for this run."
             echo "SKIP_DETERMINISM=1" >> "$GITHUB_ENV"
+            echo "download-ok=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Save fast-suite determinism fixture cache
+        # Only save on a successful fresh download — don't poison the cache
+        # with a partially-downloaded fixture set that a future run would
+        # silently hit. Skipped entirely on cache-hit (nothing new to save).
+        if: |
+          steps.gamslib-raw-cache.outputs.cache-hit != 'true'
+          && steps.download-gamslib-raw.outputs.download-ok == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: data/gamslib/raw/
+          key: ${{ steps.gamslib-raw-cache.outputs.cache-primary-key }}
 
       - name: Run fast test suite (parallel)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,40 @@ jobs:
           pip install -e ".[dev]"
           pip install -r requirements.txt
 
+      - name: Restore fast-suite determinism fixture cache
+        id: gamslib-raw-cache
+        uses: actions/cache@v4
+        with:
+          path: data/gamslib/raw/
+          # Key on the download script (which pins the fast fixture list) and
+          # the status JSON (which provides source URLs). Either change should
+          # invalidate the cache.
+          key: ${{ runner.os }}-gamslib-raw-fast-${{ hashFiles('scripts/download_gamslib_raw.sh', 'data/gamslib/gamslib_status.json') }}
+
       - name: Download fast-suite determinism fixtures
+        if: steps.gamslib-raw-cache.outputs.cache-hit != 'true'
         run: |
           # Populate data/gamslib/raw/ with the 5 models referenced by
           # tests/integration/test_pipeline_determinism.py::TestDeterminismFast.
-          # Without this step those tests skip (raw/ is gitignored), and the
-          # #1283 regression signal is lost on per-PR CI.
-          ./scripts/download_gamslib_raw.sh --fast
+          # On a cache miss we try to fetch from gams.com. If that fails
+          # (transient network/gams.com hiccup), emit a GitHub warning and
+          # set SKIP_DETERMINISM=1 — the next step filters the determinism
+          # marker out so the job still passes. The signal we care about is
+          # repo regressions, not external availability.
+          if ./scripts/download_gamslib_raw.sh --fast; then
+            echo "Downloaded fast-suite determinism fixtures."
+          else
+            echo "::warning::Failed to download fast-suite determinism fixtures from gams.com; skipping determinism tests in PR CI for this run."
+            echo "SKIP_DETERMINISM=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Run fast test suite (parallel)
         run: |
-          pytest -m "not slow" -n auto -v --tb=short
+          if [ "${SKIP_DETERMINISM:-0}" = "1" ]; then
+            pytest -m "not slow and not determinism" -n auto -v --tb=short
+          else
+            pytest -m "not slow" -n auto -v --tb=short
+          fi
         timeout-minutes: 5
 
       - name: Run full test suite with coverage (parallel)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,12 @@ jobs:
       - name: Run full test suite with coverage (parallel)
         run: |
           pip install pytest-cov
-          # Exclude `slow` — TestDeterminismFull sweeps the 143-model convex
-          # corpus and only runs in the nightly workflow (which populates the
-          # full raw/ dir). The per-PR coverage run uses the 5 fast fixtures
-          # already downloaded above.
-          pytest tests/ -m "not slow" -n auto --cov=src --cov-report=term-missing --tb=short
+          # Exclude `slow` — TestDeterminismFull sweeps the full convex corpus
+          # and only runs in the nightly workflow.
+          # Exclude `determinism` — TestDeterminismFast already ran in the
+          # fast-suite step above; re-running here would double 25 CLI
+          # subprocesses against the 10-min timeout budget for no extra signal.
+          pytest tests/ -m "not slow and not determinism" -n auto --cov=src --cov-report=term-missing --tb=short
         timeout-minutes: 10
 
       - name: Generate JSON diagnostics for tier 1 models

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,13 @@ jobs:
           pip install -e ".[dev]"
           pip install -r requirements.txt
 
+      - name: Download convex in-scope GAMSLIB raw sources
+        run: |
+          # Populate data/gamslib/raw/ from gams.com (the dir is gitignored).
+          # Required by tests/integration/test_pipeline_determinism.py —
+          # without this step the sweep would no-op (all fixtures missing).
+          ./scripts/download_gamslib_raw.sh
+
       - name: Run full-corpus determinism sweep
         run: |
           pytest -m "slow and determinism" -v --tb=short \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,15 @@ jobs:
           # Populate data/gamslib/raw/ from gams.com (the dir is gitignored).
           # Required by tests/integration/test_pipeline_determinism.py —
           # without this step the sweep would no-op (all fixtures missing).
-          ./scripts/download_gamslib_raw.sh
+          #
+          # Don't fail the whole job on partial download failures: transient
+          # gams.com/network hiccups are not determinism regressions, and the
+          # test harness already treats missing fixtures as translate noise
+          # (FileNotFoundError → logged, doesn't fail the test). Surface the
+          # count via a GitHub warning so nightly review can see it.
+          if ! ./scripts/download_gamslib_raw.sh; then
+            echo "::warning::download_gamslib_raw.sh reported one or more download failures; continuing nightly sweep with any fixtures that were fetched."
+          fi
 
       - name: Run full-corpus determinism sweep
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,41 @@
+name: Nightly determinism sweep
+
+on:
+  schedule:
+    - cron: "17 7 * * *"  # 07:17 UTC daily
+  workflow_dispatch:      # manual trigger
+
+jobs:
+  determinism-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install -r requirements.txt
+
+      - name: Run full-corpus determinism sweep
+        run: |
+          pytest -m "slow and determinism" -v --tb=short \
+            tests/integration/test_pipeline_determinism.py
+
+      - name: Upload diff artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: determinism-diffs
+          path: tests/artifacts/determinism/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .tox/
 .mypy_cache/
 .ruff_cache/
+tests/artifacts/
 
 # Build tools
 *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ markers = [
     "e2e: End-to-end pipeline tests (deselect with '-m \"not e2e\"')",
     "validation: Mathematical validation tests (slower) (deselect with '-m \"not validation\"')",
     "slow: Slow tests that take significant time (deselect with '-m \"not slow\"')",
+    "determinism: Byte-stability regression tests across PYTHONHASHSEED values (PR12)",
 ]
 
 [tool.nlp2mcp]

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -70,7 +70,20 @@ if [ "$MODE" = "fast" ]; then
         echo "ERROR: fast-fixture manifest not found at $FAST_FIXTURES_MANIFEST" >&2
         exit 1
     fi
-    FAST_LIST="$(grep -v '^#' "$FAST_FIXTURES_MANIFEST" | tr '\n' ' ')"
+    # Mirror _load_fast_fixtures() in test_pipeline_determinism.py: strip
+    # leading/trailing whitespace, then skip blank lines and `#` comments
+    # (including indented ones). Using awk keeps both sides in true lockstep.
+    FAST_LIST="$(awk '
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            if (line == "" || line ~ /^#/) {
+                next
+            }
+            printf "%s ", line
+        }
+    ' "$FAST_FIXTURES_MANIFEST")"
 else
     FAST_LIST=""
 fi

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -22,9 +22,10 @@ BASE_URL="https://www.gams.com/latest/gamslib_ml"
 
 MODE="convex"
 
-# Fast-suite fixtures — must stay in sync with FAST_FIXTURES in
-# tests/integration/test_pipeline_determinism.py.
-FAST_FIXTURES=("chenery" "abel" "partssupply" "ps2_f" "himmel11")
+# Fast-suite fixtures — loaded from the shared manifest file so the shell
+# script and Python test can't drift out of sync. One model_id per line;
+# blanks and `#` comments are ignored.
+FAST_FIXTURES_MANIFEST="${REPO_ROOT}/tests/integration/determinism_fast_fixtures.txt"
 
 show_help() {
     cat << EOF
@@ -35,8 +36,9 @@ Download GAMSLIB raw .gms sources into data/gamslib/raw/.
 OPTIONS:
     --help          Show this help message
     --all           Download every model in the status JSON
-    --fast          Download only the 5 fixtures used by TestDeterminismFast
-                    (chenery, abel, partssupply, ps2_f, himmel11)
+    --fast          Download only the fixtures listed in
+                    tests/integration/determinism_fast_fixtures.txt
+                    (the same list TestDeterminismFast parametrizes over)
 
 Default: convex in-scope models (likely_convex + verified_convex) that are
 not skipped by pipeline_status and have nlp2mcp_translate.status == success;
@@ -60,8 +62,18 @@ fi
 
 mkdir -p "$TARGET_DIR"
 
-# Select model_ids by mode.
-FAST_LIST="${FAST_FIXTURES[*]}"
+# Select model_ids by mode. For --fast mode, load fixtures from the shared
+# manifest file so the shell script and the Python test read from the same
+# source of truth.
+if [ "$MODE" = "fast" ]; then
+    if [ ! -f "$FAST_FIXTURES_MANIFEST" ]; then
+        echo "ERROR: fast-fixture manifest not found at $FAST_FIXTURES_MANIFEST" >&2
+        exit 1
+    fi
+    FAST_LIST="$(grep -v '^#' "$FAST_FIXTURES_MANIFEST" | tr '\n' ' ')"
+else
+    FAST_LIST=""
+fi
 MODEL_IDS="$(FAST_LIST="$FAST_LIST" python3 - "$STATUS_JSON" "$MODE" <<'PYEOF'
 import json, os, sys
 status_path, mode = sys.argv[1], sys.argv[2]

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -68,8 +68,17 @@ fast_set = set(os.environ.get("FAST_LIST", "").split())
 data = json.loads(open(status_path).read())
 for e in data["models"]:
     if mode == "convex":
-        status = (e.get("convexity") or {}).get("status")
-        if status not in ("likely_convex", "verified_convex"):
+        # Must match TestDeterminismFull._convex_models(): convex AND not
+        # explicitly skipped AND baseline translate succeeded. Downloading
+        # additional models would just waste the runner's bandwidth since
+        # they'd be filtered out of the sweep anyway.
+        if (e.get("convexity") or {}).get("status") not in (
+            "likely_convex", "verified_convex",
+        ):
+            continue
+        if (e.get("pipeline_status") or {}).get("status") == "skipped":
+            continue
+        if (e.get("nlp2mcp_translate") or {}).get("status") != "success":
             continue
     elif mode == "fast":
         if e["model_id"] not in fast_set:

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -88,14 +88,24 @@ echo "Downloading $TOTAL models (mode=$MODE) → $TARGET_DIR"
 
 # Resolve the real download URL for a given model by scraping the model's
 # landing page. Echoes "<url>" on success, empty on failure.
+#
+# The pipeline is wrapped in `|| true` so a `grep` no-match (exit 1) does not
+# trip `set -e` — we want per-model failures to be reported and skipped, not
+# to abort the entire download run.
 resolve_url() {
     local name="$1"
-    curl -fsS --max-time 15 --retry 2 \
-        "${BASE_URL}/libhtml/gamslib_${name}.html" 2>/dev/null \
-        | grep -oE 'Main file.*</p>' \
-        | grep -oE 'href="[^"]+"' \
-        | head -1 \
-        | sed "s/^href=\"\.\.\///; s/\"$//; s|^|${BASE_URL}/|"
+    local url
+    url="$(
+        curl -fsS --max-time 15 --retry 2 \
+            "${BASE_URL}/libhtml/gamslib_${name}.html" 2>/dev/null \
+            | grep -oE 'Main file.*</p>' \
+            | grep -oE 'href="[^"]+"' \
+            | head -1 \
+            | sed "s/^href=\"\.\.\///; s/\"$//; s|^|${BASE_URL}/|" \
+            || true
+    )"
+    printf '%s\n' "$url"
+    return 0
 }
 
 SUCCESS=0

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -38,8 +38,9 @@ OPTIONS:
     --fast          Download only the 5 fixtures used by TestDeterminismFast
                     (chenery, abel, partssupply, ps2_f, himmel11)
 
-Default: convex in-scope models (likely_convex + verified_convex), the set
-targeted by TestDeterminismFull.
+Default: convex in-scope models (likely_convex + verified_convex) that are
+not skipped by pipeline_status and have nlp2mcp_translate.status == success;
+this is the set targeted by TestDeterminismFull.
 EOF
 }
 

--- a/scripts/download_gamslib_raw.sh
+++ b/scripts/download_gamslib_raw.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Download GAMSLIB raw `.gms` sources into `data/gamslib/raw/` for CI.
+#
+# For each model selected by mode, fetch the model's HTML landing page and
+# extract the real download URL from the "Main file" link (the seq number in
+# `gamslib_status.json::source_url` does NOT match the download URL — the
+# status JSON field is stale/wrong, so we scrape the live page instead).
+#
+# Usage:
+#   ./scripts/download_gamslib_raw.sh              # Convex in-scope models (nightly)
+#   ./scripts/download_gamslib_raw.sh --fast       # 5 TestDeterminismFast fixtures
+#   ./scripts/download_gamslib_raw.sh --all        # Every model in the status JSON
+#   ./scripts/download_gamslib_raw.sh --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATUS_JSON="${REPO_ROOT}/data/gamslib/gamslib_status.json"
+TARGET_DIR="${REPO_ROOT}/data/gamslib/raw"
+BASE_URL="https://www.gams.com/latest/gamslib_ml"
+
+MODE="convex"
+
+# Fast-suite fixtures — must stay in sync with FAST_FIXTURES in
+# tests/integration/test_pipeline_determinism.py.
+FAST_FIXTURES=("chenery" "abel" "partssupply" "ps2_f" "himmel11")
+
+show_help() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Download GAMSLIB raw .gms sources into data/gamslib/raw/.
+
+OPTIONS:
+    --help          Show this help message
+    --all           Download every model in the status JSON
+    --fast          Download only the 5 fixtures used by TestDeterminismFast
+                    (chenery, abel, partssupply, ps2_f, himmel11)
+
+Default: convex in-scope models (likely_convex + verified_convex), the set
+targeted by TestDeterminismFull.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --help) show_help; exit 0 ;;
+        --all)  MODE="all"; shift ;;
+        --fast) MODE="fast"; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ ! -f "$STATUS_JSON" ]; then
+    echo "ERROR: status JSON not found at $STATUS_JSON" >&2
+    exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+# Select model_ids by mode.
+FAST_LIST="${FAST_FIXTURES[*]}"
+MODEL_IDS="$(FAST_LIST="$FAST_LIST" python3 - "$STATUS_JSON" "$MODE" <<'PYEOF'
+import json, os, sys
+status_path, mode = sys.argv[1], sys.argv[2]
+fast_set = set(os.environ.get("FAST_LIST", "").split())
+data = json.loads(open(status_path).read())
+for e in data["models"]:
+    if mode == "convex":
+        status = (e.get("convexity") or {}).get("status")
+        if status not in ("likely_convex", "verified_convex"):
+            continue
+    elif mode == "fast":
+        if e["model_id"] not in fast_set:
+            continue
+    print(e["model_id"])
+PYEOF
+)"
+
+if [ -z "$MODEL_IDS" ]; then
+    echo "No models to download (mode=$MODE)" >&2
+    exit 0
+fi
+
+TOTAL=$(echo "$MODEL_IDS" | wc -l | tr -d ' ')
+echo "Downloading $TOTAL models (mode=$MODE) → $TARGET_DIR"
+
+# Resolve the real download URL for a given model by scraping the model's
+# landing page. Echoes "<url>" on success, empty on failure.
+resolve_url() {
+    local name="$1"
+    curl -fsS --max-time 15 --retry 2 \
+        "${BASE_URL}/libhtml/gamslib_${name}.html" 2>/dev/null \
+        | grep -oE 'Main file.*</p>' \
+        | grep -oE 'href="[^"]+"' \
+        | head -1 \
+        | sed "s/^href=\"\.\.\///; s/\"$//; s|^|${BASE_URL}/|"
+}
+
+SUCCESS=0
+SKIPPED=0
+FAILED=0
+while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    target="${TARGET_DIR}/${name}.gms"
+
+    if [ -s "$target" ]; then
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    url="$(resolve_url "$name")"
+    if [ -z "$url" ]; then
+        echo "FAILED: $name (could not resolve download URL)" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    if curl -fsS --retry 2 --max-time 30 -o "$target" "$url"; then
+        SUCCESS=$((SUCCESS + 1))
+    else
+        echo "FAILED: $name ($url)" >&2
+        rm -f "$target"
+        FAILED=$((FAILED + 1))
+    fi
+done <<< "$MODEL_IDS"
+
+echo "Summary: $SUCCESS downloaded, $SKIPPED already present, $FAILED failed (total $TOTAL)"
+[ "$FAILED" -eq 0 ]

--- a/src/ir/parser.py
+++ b/src/ir/parser.py
@@ -332,16 +332,14 @@ def _normalize_parsed_tables(node: Tree | Token) -> Tree | Token:
 
     # Post-order iterative traversal: visit each Tree twice (first to push
     # children, then to assemble). normalized[id(x)] holds the normalized
-    # replacement for x (or x itself if unchanged).
-    normalized: dict[int, Tree | Token] = {}
-    stack: list[tuple[Tree | Token, bool]] = [(node, False)]
+    # replacement for x (or x itself if unchanged). Only Tree children are
+    # pushed; Token children are read directly off `current.children` during
+    # assembly without needing a normalized entry.
+    normalized: dict[int, Tree] = {}
+    stack: list[tuple[Tree, bool]] = [(node, False)]
 
     while stack:
         current, is_return = stack.pop()
-
-        if isinstance(current, Token):
-            normalized[id(current)] = current
-            continue
 
         if not is_return:
             # First visit: schedule assembly, then push children.

--- a/src/ir/parser.py
+++ b/src/ir/parser.py
@@ -164,12 +164,196 @@ def _build_lark() -> Lark:
     )
 
 
-def _resolve_ambiguities(node: Tree | Token) -> Tree | Token:
-    """Collapse Earley ambiguity nodes by picking the first alternative.
+def _is_bare_number_row(row: Tree) -> Token | None:
+    """Detect a `table_row` that is the #1283 corruption artifact.
 
-    With ambiguity="resolve" in the parser, ambiguity nodes are rare, but this
-    function handles any that do appear by consistently picking the first alternative.
-    This avoids exponential blowup in pathological grammar cases.
+    Returns the NUMBER token if the row matches the corruption pattern
+    (a single-NUMBER row label with zero `table_value` children) — i.e., a
+    numeric table value that Lark's Earley resolver mis-parsed as a new row
+    label. Returns None otherwise.
+
+    A legitimate bare-NUMBER row label (e.g., `9000011` from issue #863) is
+    distinguished by having one-or-more `table_value` children following the
+    label; corrupted rows have none.
+    """
+    if not isinstance(row, Tree) or row.data != "table_row":
+        return None
+    if len(row.children) != 1:
+        return None
+    label = row.children[0]
+    if not isinstance(label, Tree) or label.data != "simple_label":
+        return None
+    if len(label.children) != 1:
+        return None
+    dotted = label.children[0]
+    if not isinstance(dotted, Tree) or dotted.data != "dotted_label":
+        return None
+    if len(dotted.children) != 1:
+        return None
+    tok = dotted.children[0]
+    if not isinstance(tok, Token) or tok.type != "NUMBER":
+        return None
+    return tok
+
+
+def _collapse_corrupted_table_rows(contents: list[Tree | Token]) -> list[Tree | Token]:
+    """Collapse #1283 corrupted rows within a `table_block`'s `table_content` list.
+
+    Scans for `table_content → table_row` children where the row is a bare-NUMBER
+    orphan (per `_is_bare_number_row`) and merges those rows' NUMBER tokens into
+    the preceding real row as `table_value` children. If a bare-NUMBER orphan
+    has no preceding real row (i.e., it's the first content of the table), it is
+    left as-is — that leaves the original error intact for downstream reporting
+    rather than silently losing data.
+    """
+    result: list[Tree | Token] = []
+    for content in contents:
+        if not isinstance(content, Tree) or content.data != "table_content":
+            result.append(content)
+            continue
+        if not content.children or not isinstance(content.children[0], Tree):
+            result.append(content)
+            continue
+
+        inner = content.children[0]
+        tok = _is_bare_number_row(inner) if inner.data == "table_row" else None
+        if tok is None:
+            result.append(content)
+            continue
+
+        # Bare-NUMBER orphan: try to attach to previous real row.
+        prev_idx: int | None = None
+        if result:
+            prev_content = result[-1]
+            if (
+                isinstance(prev_content, Tree)
+                and prev_content.data == "table_content"
+                and prev_content.children
+                and isinstance(prev_content.children[0], Tree)
+                and prev_content.children[0].data == "table_row"
+                and _is_bare_number_row(prev_content.children[0]) is None
+            ):
+                prev_idx = len(result) - 1
+
+        if prev_idx is None:
+            # Orphan with no preceding real row; preserve as-is.
+            result.append(content)
+            continue
+
+        # Rebuild the previous table_content with an extra table_value child on its row.
+        prev_content = result[prev_idx]
+        assert isinstance(prev_content, Tree)
+        prev_row = prev_content.children[0]
+        assert isinstance(prev_row, Tree)
+        new_row = Tree("table_row", [*prev_row.children, Tree("table_value", [tok])])
+        result[prev_idx] = Tree("table_content", [new_row, *prev_content.children[1:]])
+    return result
+
+
+def _normalize_parsed_tables(node: Tree | Token) -> Tree | Token:
+    """Post-parse repair of #1283-corrupted table rows.
+
+    Lark's Earley parser with `ambiguity="resolve"` picks a parse forest leaf
+    with a hash-seed-dependent tiebreak. When the `table_row` / `simple_label`
+    / `dotted_label` rule chain produces a forest entry where row values are
+    reparsed as bare-NUMBER row labels (a 65% corruption rate on chenery per
+    Task 3's 20-seed sweep), this function walks the resolved tree and
+    reconstructs the intended `table_row` → `table_value*` structure inside
+    each `table_block`.
+
+    This post-parse approach is required because `ambiguity="resolve"` does
+    not emit `_ambig` nodes (Lark's internal resolver picks one alternative
+    directly). `ambiguity="explicit"` was considered and rejected: the
+    corpus has enough latent ambiguities that even a trivial model like
+    `abel` expands to 12,513 `_ambig` nodes.
+    """
+    if isinstance(node, Token):
+        return node
+
+    # Walk bottom-up: children first, then rewrite table_block if applicable.
+    new_children: list[Tree | Token] = [
+        _normalize_parsed_tables(c) if isinstance(c, Tree) else c for c in node.children
+    ]
+    if node.data == "table_block":
+        new_children = _collapse_corrupted_table_rows(new_children)
+    return Tree(node.data, new_children)
+
+
+def _score_table_row_alternative(alt: Tree | Token) -> tuple[int, int]:
+    """Score an _ambig alternative by its table_row packing density.
+
+    Returns (table_value_children_count, -table_row_node_count). The tuple is
+    designed for use as a max() key: the alternative packing the most
+    `table_value` children into the fewest `table_row` nodes wins.
+
+    This resolves issue #1283: under Earley ambiguity, `table_row_label` →
+    `simple_label` → `dotted_label` → bare `NUMBER` lets a row like `low.a 1 2 3`
+    parse as either 1 row with 3 values OR 4 rows with 0 values. The correct
+    parse (1 row) has score (3, -1); the corrupted parse has score (0, -4);
+    the first wins under max().
+
+    Alternatives containing zero table_row nodes score (0, 0) and tie; this
+    preserves the existing "pick first" behavior for non-table ambiguities.
+    """
+    if not isinstance(alt, Tree):
+        return (0, 0)
+
+    values = 0
+    rows = 0
+    for sub in alt.iter_subtrees():
+        if sub.data == "table_row":
+            rows += 1
+            values += sum(
+                1 for c in sub.children if isinstance(c, Tree) and c.data == "table_value"
+            )
+    return (values, -rows)
+
+
+def _pick_ambig_alternative(ambig: Tree) -> Tree | Token:
+    """Pick the best alternative from an `_ambig` node.
+
+    Uses the greediest-value heuristic (`_score_table_row_alternative`) when
+    any alternative contains `table_row` children; otherwise falls back to
+    the first alternative (the historical behavior).
+
+    This scope gating keeps the fix narrow: Option D for issue #1283 only
+    affects `_ambig` subtrees that contain `table_row` nodes. All other
+    ambiguity sites retain their prior first-child-wins resolution.
+    """
+    if not ambig.children:
+        return ambig
+
+    # Check whether any alternative contains a table_row — if not, keep the
+    # historical first-alternative behavior.
+    has_table_row = False
+    for alt in ambig.children:
+        if not isinstance(alt, Tree):
+            continue
+        for sub in alt.iter_subtrees():
+            if sub.data == "table_row":
+                has_table_row = True
+                break
+        if has_table_row:
+            break
+
+    if not has_table_row:
+        return ambig.children[0]
+
+    # Greediest-value: pack most table_value children into fewest table_row nodes.
+    return max(ambig.children, key=_score_table_row_alternative)
+
+
+def _resolve_ambiguities(node: Tree | Token) -> Tree | Token:
+    """Collapse Earley ambiguity nodes by picking a defensible alternative.
+
+    For non-`table_row` ambiguity sites, picks the first alternative (historical
+    behavior; avoids exponential blowup in pathological grammar cases).
+
+    For `_ambig` subtrees containing `table_row` nodes (issue #1283),
+    uses the greediest-value heuristic via `_pick_ambig_alternative`: prefer
+    the alternative packing the most `table_value` children into the fewest
+    `table_row` nodes. This eliminates the `PYTHONHASHSEED`-dependent
+    corruption observed at 65% of runs on chenery.
 
     Uses iterative approach with explicit stack to avoid Python recursion limits
     for large parse trees (e.g., models with 1000+ variables).
@@ -187,8 +371,12 @@ def _resolve_ambiguities(node: Tree | Token) -> Tree | Token:
     # Memory trade-off: Holds references to all nodes during traversal
     resolved = {}
 
+    # Map from _ambig node id to the pre-selected winning alternative. Computed on
+    # the first visit; read on the return visit to wire up the resolved tree.
+    ambig_winners: dict[int, Tree | Token] = {}
+
     # Stack for post-order traversal: (node, is_return_visit)
-    stack = [(node, False)]
+    stack: list[tuple[Tree | Token, bool]] = [(node, False)]
 
     while stack:
         current, is_return = stack.pop()
@@ -203,8 +391,8 @@ def _resolve_ambiguities(node: Tree | Token) -> Tree | Token:
                 if not current.children:
                     resolved[id(current)] = current
                 else:
-                    # Pick first alternative
-                    resolved[id(current)] = resolved[id(current.children[0])]
+                    winner = ambig_winners[id(current)]
+                    resolved[id(current)] = resolved[id(winner)]
             else:
                 # Reconstruct tree with resolved children
                 resolved_children = [resolved[id(child)] for child in current.children]
@@ -215,8 +403,11 @@ def _resolve_ambiguities(node: Tree | Token) -> Tree | Token:
 
             # Push children to stack
             if current.data == "_ambig" and current.children:
-                # Only process first child for ambiguity nodes
-                stack.append((current.children[0], False))
+                # Pick the best alternative now; only push the winner onto the stack
+                # to preserve the existing no-exponential-blowup invariant.
+                winner = _pick_ambig_alternative(current)
+                ambig_winners[id(current)] = winner
+                stack.append((winner, False))
             else:
                 # Process all children in reverse order (for left-to-right processing)
                 for child in reversed(current.children):
@@ -320,7 +511,8 @@ def parse_text(source: str) -> Tree:
     parser = _build_lark()
     try:
         raw = parser.parse(source)
-        return _resolve_ambiguities(raw)
+        resolved = _resolve_ambiguities(raw)
+        return _normalize_parsed_tables(resolved)
     except UnexpectedToken as e:
         # Extract source line and adjust column
         source_line, column = _extract_source_line_with_adjusted_column(source, e.line, e.column)

--- a/src/ir/parser.py
+++ b/src/ir/parser.py
@@ -271,12 +271,33 @@ def _normalize_parsed_tables(node: Tree | Token) -> Tree | Token:
         return node
 
     # Walk bottom-up: children first, then rewrite table_block if applicable.
-    new_children: list[Tree | Token] = [
-        _normalize_parsed_tables(c) if isinstance(c, Tree) else c for c in node.children
-    ]
+    # Short-circuit to avoid reconstructing every Tree on parses that don't
+    # contain a corrupted table_block (i.e., the common case).
+    new_children: list[Tree | Token] = []
+    children_changed = False
+    for child in node.children:
+        if isinstance(child, Tree):
+            normalized_child = _normalize_parsed_tables(child)
+            if normalized_child is not child:
+                children_changed = True
+            new_children.append(normalized_child)
+        else:
+            new_children.append(child)
+
     if node.data == "table_block":
-        new_children = _collapse_corrupted_table_rows(new_children)
-    return Tree(node.data, new_children)
+        collapsed_children = _collapse_corrupted_table_rows(new_children)
+        if len(collapsed_children) != len(new_children) or any(
+            collapsed is not original
+            for collapsed, original in zip(collapsed_children, new_children, strict=True)
+        ):
+            return Tree(node.data, collapsed_children)
+        if children_changed:
+            return Tree(node.data, new_children)
+        return node
+
+    if children_changed:
+        return Tree(node.data, new_children)
+    return node
 
 
 def _score_table_row_alternative(alt: Tree | Token) -> tuple[int, int]:

--- a/src/ir/parser.py
+++ b/src/ir/parser.py
@@ -196,18 +196,54 @@ def _is_bare_number_row(row: Tree) -> Token | None:
     return tok
 
 
+def _last_token_line(node: Tree | Token) -> int | None:
+    """Return the source line of the last `Token` reachable from `node`, or None.
+
+    Used to distinguish #1283 corruption (bare-NUMBER row on the same physical
+    line as the previous real row) from legitimate bare-NUMBER row labels
+    (alone on their own line, possibly with values on a subsequent
+    `table_continuation`).
+    """
+    if isinstance(node, Token):
+        return getattr(node, "line", None)
+    if not isinstance(node, Tree):
+        return None
+    for child in reversed(node.children):
+        line = _last_token_line(child)
+        if line is not None:
+            return line
+    return None
+
+
+def _is_table_continuation_content(content: Tree | Token) -> bool:
+    """Return True iff `content` is a `table_content[table_continuation[...]]`."""
+    if not isinstance(content, Tree) or content.data != "table_content":
+        return False
+    if not content.children:
+        return False
+    first = content.children[0]
+    return isinstance(first, Tree) and first.data == "table_continuation"
+
+
 def _collapse_corrupted_table_rows(contents: list[Tree | Token]) -> list[Tree | Token]:
     """Collapse #1283 corrupted rows within a `table_block`'s `table_content` list.
 
     Scans for `table_content → table_row` children where the row is a bare-NUMBER
     orphan (per `_is_bare_number_row`) and merges those rows' NUMBER tokens into
-    the preceding real row as `table_value` children. If a bare-NUMBER orphan
-    has no preceding real row (i.e., it's the first content of the table), it is
-    left as-is — that leaves the original error intact for downstream reporting
-    rather than silently losing data.
+    the preceding real row as `table_value` children. Only collapses when the
+    bare-NUMBER token is on the **same physical line** as the previous real
+    row's last token AND the next `table_content` is not a `table_continuation`.
+    Both gates distinguish real #1283 corruption (orphan NUMBERs on the same
+    line as the row they were originally attached to) from legitimate patterns
+    like a numeric row label alone on its own line whose values arrive on the
+    next `+` continuation line.
+
+    If a bare-NUMBER orphan has no preceding real row (i.e., it's the first
+    content of the table), or fails either of the gates above, it is left as-is
+    — the original parse is preserved for downstream handling.
     """
     result: list[Tree | Token] = []
-    for content in contents:
+    for i, content in enumerate(contents):
         if not isinstance(content, Tree) or content.data != "table_content":
             result.append(content)
             continue
@@ -221,7 +257,15 @@ def _collapse_corrupted_table_rows(contents: list[Tree | Token]) -> list[Tree | 
             result.append(content)
             continue
 
-        # Bare-NUMBER orphan: try to attach to previous real row.
+        # Gate: the NEXT content must not be a `table_continuation`. If it is,
+        # the bare-NUMBER is likely a legitimate standalone row label whose
+        # values come on the continuation line — collapsing would wrongly
+        # attach the label to the previous row AND misroute the continuation.
+        if i + 1 < len(contents) and _is_table_continuation_content(contents[i + 1]):
+            result.append(content)
+            continue
+
+        # Locate the previous real (non-corrupted) row.
         prev_idx: int | None = None
         if result:
             prev_content = result[-1]
@@ -240,10 +284,20 @@ def _collapse_corrupted_table_rows(contents: list[Tree | Token]) -> list[Tree | 
             result.append(content)
             continue
 
-        # Rebuild the previous table_content with an extra table_value child on its row.
+        # Gate: the bare-NUMBER token must be on the same physical line as
+        # the previous row's last token. #1283 corruption produces orphans
+        # on the same line as the row they were meant to be values of;
+        # legitimate bare-NUMBER row labels are on their own separate line.
         prev_content = result[prev_idx]
         assert isinstance(prev_content, Tree)
         prev_row = prev_content.children[0]
+        prev_line = _last_token_line(prev_row)
+        tok_line = getattr(tok, "line", None)
+        if prev_line is None or tok_line is None or prev_line != tok_line:
+            result.append(content)
+            continue
+
+        # Rebuild the previous table_content with an extra table_value child on its row.
         assert isinstance(prev_row, Tree)
         new_row = Tree("table_row", [*prev_row.children, Tree("table_value", [tok])])
         result[prev_idx] = Tree("table_content", [new_row, *prev_content.children[1:]])

--- a/src/ir/parser.py
+++ b/src/ir/parser.py
@@ -266,38 +266,70 @@ def _normalize_parsed_tables(node: Tree | Token) -> Tree | Token:
     directly). `ambiguity="explicit"` was considered and rejected: the
     corpus has enough latent ambiguities that even a trivial model like
     `abel` expands to 12,513 `_ambig` nodes.
+
+    Uses iterative post-order traversal with an explicit stack so callers
+    without an elevated `sys.setrecursionlimit()` don't hit `RecursionError`
+    on deep parse trees (mirrors `_resolve_ambiguities`). Short-circuits by
+    returning the original node when no child subtree was modified, so
+    table-free parses allocate no new `Tree` objects.
     """
     if isinstance(node, Token):
         return node
 
-    # Walk bottom-up: children first, then rewrite table_block if applicable.
-    # Short-circuit to avoid reconstructing every Tree on parses that don't
-    # contain a corrupted table_block (i.e., the common case).
-    new_children: list[Tree | Token] = []
-    children_changed = False
-    for child in node.children:
-        if isinstance(child, Tree):
-            normalized_child = _normalize_parsed_tables(child)
-            if normalized_child is not child:
-                children_changed = True
-            new_children.append(normalized_child)
-        else:
-            new_children.append(child)
+    # Post-order iterative traversal: visit each Tree twice (first to push
+    # children, then to assemble). normalized[id(x)] holds the normalized
+    # replacement for x (or x itself if unchanged).
+    normalized: dict[int, Tree | Token] = {}
+    stack: list[tuple[Tree | Token, bool]] = [(node, False)]
 
-    if node.data == "table_block":
-        collapsed_children = _collapse_corrupted_table_rows(new_children)
-        if len(collapsed_children) != len(new_children) or any(
-            collapsed is not original
-            for collapsed, original in zip(collapsed_children, new_children, strict=True)
-        ):
-            return Tree(node.data, collapsed_children)
+    while stack:
+        current, is_return = stack.pop()
+
+        if isinstance(current, Token):
+            normalized[id(current)] = current
+            continue
+
+        if not is_return:
+            # First visit: schedule assembly, then push children.
+            stack.append((current, True))
+            for child in reversed(current.children):
+                if isinstance(child, Tree):
+                    stack.append((child, False))
+            continue
+
+        # Assembly visit: build normalized children list, tracking whether
+        # anything changed so we can skip rebuilding on unchanged subtrees.
+        children_changed = False
+        new_children: list[Tree | Token] = []
+        for child in current.children:
+            if isinstance(child, Tree):
+                replacement = normalized[id(child)]
+                if replacement is not child:
+                    children_changed = True
+                new_children.append(replacement)
+            else:
+                new_children.append(child)
+
+        if current.data == "table_block":
+            collapsed = _collapse_corrupted_table_rows(new_children)
+            collapse_changed = len(collapsed) != len(new_children) or any(
+                c is not o for c, o in zip(collapsed, new_children, strict=True)
+            )
+            if collapse_changed:
+                normalized[id(current)] = Tree(current.data, collapsed)
+                continue
+            if children_changed:
+                normalized[id(current)] = Tree(current.data, new_children)
+                continue
+            normalized[id(current)] = current
+            continue
+
         if children_changed:
-            return Tree(node.data, new_children)
-        return node
+            normalized[id(current)] = Tree(current.data, new_children)
+        else:
+            normalized[id(current)] = current
 
-    if children_changed:
-        return Tree(node.data, new_children)
-    return node
+    return normalized[id(node)]
 
 
 def _score_table_row_alternative(alt: Tree | Token) -> tuple[int, int]:

--- a/tests/integration/determinism_fast_fixtures.txt
+++ b/tests/integration/determinism_fast_fixtures.txt
@@ -1,0 +1,10 @@
+# Per-commit fast-suite fixtures for TestDeterminismFast (PR12 / issue #1283).
+# One model_id per line. Both `tests/integration/test_pipeline_determinism.py`
+# (FAST_FIXTURES) and `scripts/download_gamslib_raw.sh --fast` read from here
+# so the CI download set and the pytest parametrize stay in lockstep.
+# Lines starting with `#` and blank lines are ignored.
+chenery
+abel
+partssupply
+ps2_f
+himmel11

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -33,6 +33,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RAW_DIR = REPO_ROOT / "data" / "gamslib" / "raw"
+# Mismatch artifacts land here on failure (reference + failing seed dumps).
+# `tests/artifacts/` is gitignored so local failing runs don't leak .gms files
+# into commits.
 ARTIFACT_DIR = REPO_ROOT / "tests" / "artifacts" / "determinism"
 
 # Per-commit fixtures — all with baseline translate time <10s so the

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -53,8 +53,17 @@ FAST_SEEDS: tuple[int, ...] = (0, 1, 42, 12345, 99999)
 
 NIGHTLY_SEEDS: tuple[int, ...] = (0, 99999)
 
+# Per-subprocess translate timeouts. Fast fixtures have baseline translate
+# times <10s, so a 60s budget is ~6× the expected worst case and still well
+# below the 5-min CI fast-suite step timeout — if a fast fixture hangs, the
+# subprocess raises TimeoutExpired first and pytest reports a clean failure
+# instead of GitHub Actions killing the whole step. Nightly uses a larger
+# budget because the full convex corpus includes models at 60-300s.
+FAST_TRANSLATE_TIMEOUT_SEC: int = 60
+NIGHTLY_TRANSLATE_TIMEOUT_SEC: int = 300
 
-def _translate_to_bytes(model: str, seed: int) -> bytes:
+
+def _translate_to_bytes(model: str, seed: int, *, timeout: int) -> bytes:
     """Run `python -m src.cli <model>.gms -o <tmp>` under PYTHONHASHSEED=seed.
 
     Returns the raw bytes of the emitted MCP file (via `Path.read_bytes()`) —
@@ -87,7 +96,7 @@ def _translate_to_bytes(model: str, seed: int) -> bytes:
             capture_output=True,
             text=True,
             check=True,
-            timeout=300,
+            timeout=timeout,
         )
         return output_path.read_bytes()
 
@@ -167,7 +176,10 @@ class TestDeterminismFast:
             outputs: dict[int, bytes] = dict(
                 zip(
                     FAST_SEEDS,
-                    pool.map(lambda s: _translate_to_bytes(model, s), FAST_SEEDS),
+                    pool.map(
+                        lambda s: _translate_to_bytes(model, s, timeout=FAST_TRANSLATE_TIMEOUT_SEC),
+                        FAST_SEEDS,
+                    ),
                     strict=True,
                 )
             )
@@ -230,12 +242,12 @@ class TestDeterminismFull:
             pytest.skip("no convex in-scope models found in status JSON")
 
         # `FileNotFoundError` covers missing raw fixtures (an incomplete corpus
-        # on the runner); `TimeoutExpired` covers models exceeding the 300s
-        # per-seed translate budget; `CalledProcessError` is a CLI exit != 0.
-        # All three are treated as "translate noise" — NOT determinism bugs.
-        # We log them for visibility but only `pytest.fail()` on actual byte
-        # mismatches, so the nightly job's red/green signal reflects
-        # determinism regressions alone.
+        # on the runner); `TimeoutExpired` covers models exceeding the per-seed
+        # translate budget (NIGHTLY_TRANSLATE_TIMEOUT_SEC); `CalledProcessError`
+        # is a CLI exit != 0. All three are treated as "translate noise" — NOT
+        # determinism bugs. We log them for visibility but only `pytest.fail()`
+        # on actual byte mismatches, so the nightly job's red/green signal
+        # reflects determinism regressions alone.
         translate_exceptions = (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
@@ -245,7 +257,9 @@ class TestDeterminismFull:
         translate_failures: list[tuple[str, str]] = []
         for model in models:
             try:
-                ref = _translate_to_bytes(model, NIGHTLY_SEEDS[0])
+                ref = _translate_to_bytes(
+                    model, NIGHTLY_SEEDS[0], timeout=NIGHTLY_TRANSLATE_TIMEOUT_SEC
+                )
             except translate_exceptions as e:
                 translate_failures.append(
                     (model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}")
@@ -253,7 +267,7 @@ class TestDeterminismFull:
                 continue
             for seed in NIGHTLY_SEEDS[1:]:
                 try:
-                    other = _translate_to_bytes(model, seed)
+                    other = _translate_to_bytes(model, seed, timeout=NIGHTLY_TRANSLATE_TIMEOUT_SEC)
                 except translate_exceptions as e:
                     translate_failures.append((model, f"seed {seed} translate failed: {e}"))
                     continue

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -9,7 +9,9 @@ Usage:
 - Per-commit (fast): `pytest -m "integration and determinism"`
   Runs `TestDeterminismFast` — 5 fixture models × 5 fixed seeds.
 - Nightly (slow): `pytest -m "slow and determinism"`
-  Runs `TestDeterminismFull` — the full 143-model convex corpus × 2 seeds.
+  Runs `TestDeterminismFull` — every convex in-scope translate-success
+  model (the filter intersection in `_convex_models()`, currently ~135)
+  × 2 seeds. Exact count drifts as the baseline status JSON is refreshed.
 
 See `docs/planning/EPIC_4/SPRINT_25/DESIGN_DETERMINISM_TESTS.md` for the full
 scope / fixture / seed-set rationale.

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -59,10 +59,15 @@ def _translate_to_bytes(model: str, seed: int) -> bytes:
 
     Returns the raw bytes of the emitted MCP file (via `Path.read_bytes()`) —
     no decoding, no text normalization.
+
+    Raises `FileNotFoundError` when the raw model is absent. Callers invoking
+    this from a worker thread must convert that to a pytest skip/fail in the
+    main thread — `pytest.skip()` raised from a worker thread propagates as a
+    regular exception and errors the test instead of skipping cleanly.
     """
     raw_path = RAW_DIR / f"{model}.gms"
     if not raw_path.is_file():
-        pytest.skip(f"raw/{model}.gms not present (data/gamslib/raw/ is gitignored)")
+        raise FileNotFoundError(f"raw/{model}.gms not present (data/gamslib/raw/ is gitignored)")
 
     env = os.environ.copy()
     env["PYTHONHASHSEED"] = str(seed)
@@ -147,6 +152,13 @@ class TestDeterminismFast:
 
     @pytest.mark.parametrize("model", FAST_FIXTURES)
     def test_byte_stability_across_hash_seeds(self, model: str) -> None:
+        # Precheck fixture presence on the main thread — `pytest.skip()` raised
+        # from a ThreadPoolExecutor worker propagates as a regular exception and
+        # errors the test instead of cleanly skipping.
+        raw_path = RAW_DIR / f"{model}.gms"
+        if not raw_path.is_file():
+            pytest.skip(f"raw/{model}.gms not present (data/gamslib/raw/ is gitignored)")
+
         # Run seeds in parallel threads so the CLI-startup overhead (~15s of
         # module imports + parser construction per subprocess) amortizes across
         # cores. Combined with pytest-xdist fanout across models, 5 fixtures ×
@@ -196,20 +208,27 @@ class TestDeterminismFull:
         if not models:
             pytest.skip("no convex in-scope models found in status JSON")
 
+        # Translate failures are out-of-scope for determinism — only compare
+        # models that successfully translate. Record and skip. `FileNotFoundError`
+        # covers missing raw fixtures (e.g., a runner with an incomplete corpus);
+        # `TimeoutExpired` covers models that exceed the 300s per-seed timeout
+        # on slower runners (both raised by `_translate_to_bytes`).
+        translate_failures = (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        )
         failures: list[tuple[str, str]] = []
         for model in models:
             try:
                 ref = _translate_to_bytes(model, NIGHTLY_SEEDS[0])
-            except subprocess.CalledProcessError as e:
-                # Translate failures are out-of-scope for determinism — only
-                # compare models that successfully translate under the reference
-                # seed. Record and skip.
+            except translate_failures as e:
                 failures.append((model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}"))
                 continue
             for seed in NIGHTLY_SEEDS[1:]:
                 try:
                     other = _translate_to_bytes(model, seed)
-                except subprocess.CalledProcessError as e:
+                except translate_failures as e:
                     failures.append((model, f"seed {seed} translate failed: {e}"))
                     continue
                 if other != ref:

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -38,8 +38,10 @@ RAW_DIR = REPO_ROOT / "data" / "gamslib" / "raw"
 # into commits.
 ARTIFACT_DIR = REPO_ROOT / "tests" / "artifacts" / "determinism"
 
-# Per-commit fixtures — all with baseline translate time <10s so the
-# parametrized 5-seed sweep stays within the ~60s fast-suite budget.
+# Per-commit fixture manifest — one model_id per line, shared with
+# `scripts/download_gamslib_raw.sh --fast` so CI download set and pytest
+# parametrize can't drift. Fixtures are all baseline translate time <10s, so
+# the parametrized 5-seed sweep stays within the ~60s fast-suite budget.
 #
 # `DESIGN_DETERMINISM_TESTS.md` §4 originally proposed `indus89` as the
 # "silent-corruption guard" (second most likely to trigger the #1283
@@ -51,10 +53,28 @@ ARTIFACT_DIR = REPO_ROOT / "tests" / "artifacts" / "determinism"
 #     the per-commit budget. Same for `clearlak` at 323s.
 #
 # Silent-corruption coverage is therefore deferred to `TestDeterminismFull`'s
-# nightly full-corpus sweep (2 seeds × 135 translating models) which catches
-# any #1283-class regression on `indus`, `clearlak`, or `indus89` (when
-# upstream convexity status changes).
-FAST_FIXTURES: tuple[str, ...] = ("chenery", "abel", "partssupply", "ps2_f", "himmel11")
+# nightly full-corpus sweep which catches any #1283-class regression on
+# `indus`, `clearlak`, or `indus89` (when upstream convexity status changes).
+_FAST_FIXTURES_MANIFEST = Path(__file__).with_name("determinism_fast_fixtures.txt")
+
+
+def _load_fast_fixtures() -> tuple[str, ...]:
+    """Read fixture model_ids from the shared manifest file.
+
+    Strips blank lines and `#`-prefixed comments. Same file is consumed by
+    `scripts/download_gamslib_raw.sh --fast`, so edits here automatically
+    flow to CI download selection.
+    """
+    names: list[str] = []
+    for raw in _FAST_FIXTURES_MANIFEST.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        names.append(line)
+    return tuple(names)
+
+
+FAST_FIXTURES: tuple[str, ...] = _load_fast_fixtures()
 FAST_SEEDS: tuple[int, ...] = (0, 1, 42, 12345, 99999)
 
 NIGHTLY_SEEDS: tuple[int, ...] = (0, 99999)

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -1,0 +1,226 @@
+"""Byte-stability regression tests (PR12 / issue #1283).
+
+Runs the nlp2mcp CLI under multiple `PYTHONHASHSEED` values for a fixed set of
+fixture models, and asserts that every seed produces byte-identical `.gms`
+output. Catches `#1283`-class parser / emission non-determinism in CI instead
+of via manual reviewer inspection.
+
+Usage:
+- Per-commit (fast): `pytest -m "integration and determinism"`
+  Runs `TestDeterminismFast` — 5 fixture models × 5 fixed seeds.
+- Nightly (slow): `pytest -m "slow and determinism"`
+  Runs `TestDeterminismFull` — the full 143-model convex corpus × 2 seeds.
+
+See `docs/planning/EPIC_4/SPRINT_25/DESIGN_DETERMINISM_TESTS.md` for the full
+scope / fixture / seed-set rationale.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAW_DIR = REPO_ROOT / "data" / "gamslib" / "raw"
+ARTIFACT_DIR = REPO_ROOT / "tests" / "artifacts" / "determinism"
+
+# Per-commit fixtures — all with baseline translate time <10s so the
+# parametrized 5-seed sweep stays within the ~60s fast-suite budget.
+#
+# `DESIGN_DETERMINISM_TESTS.md` §4 originally proposed `indus89` as the
+# "silent-corruption guard" (second most likely to trigger the #1283
+# `table_row` / `simple_label` / `dotted_label` ambiguity), but:
+#
+#   - `indus89` is out-of-scope (`convexity.status = error`) — CLI exits
+#     nonzero, so we can't compare bytes across seeds.
+#   - `indus` is in-scope but baseline translate time is 101s, far above
+#     the per-commit budget. Same for `clearlak` at 323s.
+#
+# Silent-corruption coverage is therefore deferred to `TestDeterminismFull`'s
+# nightly full-corpus sweep (2 seeds × 135 translating models) which catches
+# any #1283-class regression on `indus`, `clearlak`, or `indus89` (when
+# upstream convexity status changes).
+FAST_FIXTURES: tuple[str, ...] = ("chenery", "abel", "partssupply", "ps2_f", "himmel11")
+FAST_SEEDS: tuple[int, ...] = (0, 1, 42, 12345, 99999)
+
+NIGHTLY_SEEDS: tuple[int, ...] = (0, 99999)
+
+
+def _translate_to_bytes(model: str, seed: int) -> bytes:
+    """Run `python -m src.cli <model>.gms -o <tmp>` under PYTHONHASHSEED=seed.
+
+    Returns the raw bytes of the emitted MCP file (via `Path.read_bytes()`) —
+    no decoding, no text normalization.
+    """
+    raw_path = RAW_DIR / f"{model}.gms"
+    if not raw_path.is_file():
+        pytest.skip(f"raw/{model}.gms not present (data/gamslib/raw/ is gitignored)")
+
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = str(seed)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / f"{model}_mcp.gms"
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "src.cli",
+                str(raw_path),
+                "-o",
+                str(output_path),
+                "--skip-convexity-check",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=300,
+        )
+        return output_path.read_bytes()
+
+
+def _format_determinism_failure(
+    model: str,
+    reference_seed: int,
+    failing_seed: int,
+    reference: bytes,
+    failing: bytes,
+) -> str:
+    """Human-readable diff + artifact dump for a byte mismatch.
+
+    Dumps:
+    - model name + both seeds
+    - line-count comparison
+    - first 40 lines of `difflib.unified_diff` on the decoded text
+    - the commit SHA (for bisect)
+    - full raw bytes to `tests/artifacts/determinism/<model>_seed<N>.gms`
+    """
+    ref_text = reference.decode("utf-8", errors="replace")
+    fail_text = failing.decode("utf-8", errors="replace")
+    ref_lines = ref_text.splitlines(keepends=True)
+    fail_lines = fail_text.splitlines(keepends=True)
+
+    diff_iter = difflib.unified_diff(
+        ref_lines,
+        fail_lines,
+        fromfile=f"{model} seed={reference_seed}",
+        tofile=f"{model} seed={failing_seed}",
+        n=3,
+    )
+    diff_lines = list(diff_iter)[:40]
+
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    ref_path = ARTIFACT_DIR / f"{model}_seed{reference_seed}.gms"
+    fail_path = ARTIFACT_DIR / f"{model}_seed{failing_seed}.gms"
+    ref_path.write_bytes(reference)
+    fail_path.write_bytes(failing)
+
+    commit_sha = os.environ.get("GITHUB_SHA", "local")
+
+    return (
+        f"\nDeterminism regression on {model} at commit {commit_sha}\n"
+        f"  reference seed: {reference_seed} ({len(ref_lines)} lines, {len(reference)} bytes)\n"
+        f"  failing seed:   {failing_seed} ({len(fail_lines)} lines, {len(failing)} bytes)\n"
+        f"  artifacts:      {ref_path} vs {fail_path}\n"
+        f"\n" + "".join(diff_lines)
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.determinism
+class TestDeterminismFast:
+    """Per-commit byte-stability sweep: 5 fixtures × 5 seeds ≈ 60s wall-clock.
+
+    Each fixture model is translated under `FAST_SEEDS` and every output is
+    asserted byte-identical to the `FAST_SEEDS[0]` output. A single failing
+    (model, seed) pair dumps the first-differing diff plus raw-bytes artifacts
+    and reports the commit SHA for bisecting.
+    """
+
+    @pytest.mark.parametrize("model", FAST_FIXTURES)
+    def test_byte_stability_across_hash_seeds(self, model: str) -> None:
+        # Run seeds in parallel threads so the CLI-startup overhead (~15s of
+        # module imports + parser construction per subprocess) amortizes across
+        # cores. Combined with pytest-xdist fanout across models, 5 fixtures ×
+        # 5 seeds = 25 concurrent subprocesses.
+        with ThreadPoolExecutor(max_workers=len(FAST_SEEDS)) as pool:
+            outputs: dict[int, bytes] = dict(
+                zip(
+                    FAST_SEEDS,
+                    pool.map(lambda s: _translate_to_bytes(model, s), FAST_SEEDS),
+                    strict=True,
+                )
+            )
+        reference = outputs[FAST_SEEDS[0]]
+        for seed, out in outputs.items():
+            if seed == FAST_SEEDS[0]:
+                continue
+            assert out == reference, _format_determinism_failure(
+                model, FAST_SEEDS[0], seed, reference, out
+            )
+
+
+@pytest.mark.slow
+@pytest.mark.determinism
+class TestDeterminismFull:
+    """Nightly full-corpus byte-stability sweep: 143-model × 2 seeds ≈ 4h30m.
+
+    Scheduled via `.github/workflows/nightly.yml` (cron "17 7 * * *"). Excluded
+    from the fast suite because the 143-model cross-product exceeds the 5-minute
+    per-commit CI budget.
+    """
+
+    @staticmethod
+    def _convex_models() -> list[str]:
+        """Enumerate the 143 convex in-scope models from the frozen baseline status."""
+        status_path = REPO_ROOT / "data" / "gamslib" / "gamslib_status.json"
+        if not status_path.is_file():
+            pytest.skip("data/gamslib/gamslib_status.json not present")
+        data = json.loads(status_path.read_text())
+        return sorted(
+            e["model_id"]
+            for e in data["models"]
+            if (e.get("convexity") or {}).get("status") in ("likely_convex", "verified_convex")
+        )
+
+    def test_full_corpus_byte_stability(self) -> None:
+        models = self._convex_models()
+        if not models:
+            pytest.skip("no convex in-scope models found in status JSON")
+
+        failures: list[tuple[str, str]] = []
+        for model in models:
+            try:
+                ref = _translate_to_bytes(model, NIGHTLY_SEEDS[0])
+            except subprocess.CalledProcessError as e:
+                # Translate failures are out-of-scope for determinism — only
+                # compare models that successfully translate under the reference
+                # seed. Record and skip.
+                failures.append((model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}"))
+                continue
+            for seed in NIGHTLY_SEEDS[1:]:
+                try:
+                    other = _translate_to_bytes(model, seed)
+                except subprocess.CalledProcessError as e:
+                    failures.append((model, f"seed {seed} translate failed: {e}"))
+                    continue
+                if other != ref:
+                    failures.append(
+                        (
+                            model,
+                            _format_determinism_failure(model, NIGHTLY_SEEDS[0], seed, ref, other),
+                        )
+                    )
+
+        if failures:
+            header = f"\n{len(failures)} determinism failures across {len(models)} models:\n\n"
+            body = "\n\n---\n\n".join(f"## {m}\n{detail}" for m, detail in failures)
+            pytest.fail(header + body)

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -183,63 +183,103 @@ class TestDeterminismFast:
 @pytest.mark.slow
 @pytest.mark.determinism
 class TestDeterminismFull:
-    """Nightly full-corpus byte-stability sweep: 143-model × 2 seeds ≈ 4h30m.
+    """Nightly full-corpus byte-stability sweep: ~135 models × 2 seeds ≈ 4h.
 
     Scheduled via `.github/workflows/nightly.yml` (cron "17 7 * * *"). Excluded
-    from the fast suite because the 143-model cross-product exceeds the 5-minute
-    per-commit CI budget.
+    from the fast suite because the 135-model cross-product exceeds the 5-minute
+    per-commit CI budget. Model count drifts over time as the baseline status
+    JSON is refreshed (convex ∩ not-skipped ∩ translate-success).
     """
 
     @staticmethod
     def _convex_models() -> list[str]:
-        """Enumerate the 143 convex in-scope models from the frozen baseline status."""
+        """Enumerate convex in-scope models whose baseline translate succeeded.
+
+        Filters applied (intersection):
+          1. `convexity.status` ∈ {likely_convex, verified_convex}
+          2. `pipeline_status.status != "skipped"` — excludes models explicitly
+             marked out-of-scope (e.g., multi-solve driver scripts like
+             `danwolfe`, minlp-out-of-scope, etc.) even if the solver landed on
+             a convex point.
+          3. `nlp2mcp_translate.status == "success"` — only test models that
+             actually translate under the baseline. A translate regression
+             shows up as a separate CI signal (e.g., gamslib-regression.yml)
+             and doesn't belong in the determinism harness.
+        """
         status_path = REPO_ROOT / "data" / "gamslib" / "gamslib_status.json"
         if not status_path.is_file():
             pytest.skip("data/gamslib/gamslib_status.json not present")
         data = json.loads(status_path.read_text())
-        return sorted(
-            e["model_id"]
-            for e in data["models"]
-            if (e.get("convexity") or {}).get("status") in ("likely_convex", "verified_convex")
-        )
+        selected: list[str] = []
+        for e in data["models"]:
+            if (e.get("convexity") or {}).get("status") not in (
+                "likely_convex",
+                "verified_convex",
+            ):
+                continue
+            if (e.get("pipeline_status") or {}).get("status") == "skipped":
+                continue
+            if (e.get("nlp2mcp_translate") or {}).get("status") != "success":
+                continue
+            selected.append(e["model_id"])
+        return sorted(selected)
 
     def test_full_corpus_byte_stability(self) -> None:
         models = self._convex_models()
         if not models:
             pytest.skip("no convex in-scope models found in status JSON")
 
-        # Translate failures are out-of-scope for determinism — only compare
-        # models that successfully translate. Record and skip. `FileNotFoundError`
-        # covers missing raw fixtures (e.g., a runner with an incomplete corpus);
-        # `TimeoutExpired` covers models that exceed the 300s per-seed timeout
-        # on slower runners (both raised by `_translate_to_bytes`).
-        translate_failures = (
+        # `FileNotFoundError` covers missing raw fixtures (an incomplete corpus
+        # on the runner); `TimeoutExpired` covers models exceeding the 300s
+        # per-seed translate budget; `CalledProcessError` is a CLI exit != 0.
+        # All three are treated as "translate noise" — NOT determinism bugs.
+        # We log them for visibility but only `pytest.fail()` on actual byte
+        # mismatches, so the nightly job's red/green signal reflects
+        # determinism regressions alone.
+        translate_exceptions = (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
             FileNotFoundError,
         )
-        failures: list[tuple[str, str]] = []
+        determinism_failures: list[tuple[str, str]] = []
+        translate_failures: list[tuple[str, str]] = []
         for model in models:
             try:
                 ref = _translate_to_bytes(model, NIGHTLY_SEEDS[0])
-            except translate_failures as e:
-                failures.append((model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}"))
+            except translate_exceptions as e:
+                translate_failures.append(
+                    (model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}")
+                )
                 continue
             for seed in NIGHTLY_SEEDS[1:]:
                 try:
                     other = _translate_to_bytes(model, seed)
-                except translate_failures as e:
-                    failures.append((model, f"seed {seed} translate failed: {e}"))
+                except translate_exceptions as e:
+                    translate_failures.append((model, f"seed {seed} translate failed: {e}"))
                     continue
                 if other != ref:
-                    failures.append(
+                    determinism_failures.append(
                         (
                             model,
                             _format_determinism_failure(model, NIGHTLY_SEEDS[0], seed, ref, other),
                         )
                     )
 
-        if failures:
-            header = f"\n{len(failures)} determinism failures across {len(models)} models:\n\n"
-            body = "\n\n---\n\n".join(f"## {m}\n{detail}" for m, detail in failures)
+        # Surface translate failures in captured stdout for nightly log review,
+        # but don't fail the test — they indicate translate regressions, not
+        # determinism bugs, and belong to a different signal.
+        if translate_failures:
+            print(
+                f"\n[determinism] {len(translate_failures)} translate failure(s) "
+                f"across {len(models)} models (informational — not determinism regressions):"
+            )
+            for model, detail in translate_failures:
+                print(f"  - {model}: {detail}")
+
+        if determinism_failures:
+            header = (
+                f"\n{len(determinism_failures)} determinism failures "
+                f"across {len(models)} models:\n\n"
+            )
+            body = "\n\n---\n\n".join(f"## {m}\n{detail}" for m, detail in determinism_failures)
             pytest.fail(header + body)

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -97,6 +97,7 @@ def _translate_to_bytes(model: str, seed: int, *, timeout: int) -> bytes:
                 "-o",
                 str(output_path),
                 "--skip-convexity-check",
+                "--quiet",
             ],
             env=env,
             capture_output=True,
@@ -252,10 +253,19 @@ class TestDeterminismFull:
         # `FileNotFoundError` covers missing raw fixtures (an incomplete corpus
         # on the runner); `TimeoutExpired` covers models exceeding the per-seed
         # translate budget (NIGHTLY_TRANSLATE_TIMEOUT_SEC); `CalledProcessError`
-        # is a CLI exit != 0. All three are treated as "translate noise" — NOT
-        # determinism bugs. We log them for visibility but only `pytest.fail()`
-        # on actual byte mismatches, so the nightly job's red/green signal
-        # reflects determinism regressions alone.
+        # is a CLI exit != 0.
+        #
+        # Failure categorization:
+        #   - ALL seeds fail     → translate noise (log only, don't fail test;
+        #                           indicates a model-level translate regression
+        #                           that other CI signals cover).
+        #   - SOME seeds fail    → hash-seed-dependent non-determinism (fail
+        #                           the test — this is exactly what the harness
+        #                           exists to catch).
+        #   - ALL seeds succeed,
+        #     byte mismatch      → hash-seed-dependent non-determinism (fail).
+        #   - ALL seeds succeed,
+        #     byte match         → ok.
         translate_exceptions = (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
@@ -264,35 +274,64 @@ class TestDeterminismFull:
         determinism_failures: list[tuple[str, str]] = []
         translate_failures: list[tuple[str, str]] = []
         for model in models:
-            try:
-                ref = _translate_to_bytes(
-                    model, NIGHTLY_SEEDS[0], timeout=NIGHTLY_TRANSLATE_TIMEOUT_SEC
-                )
-            except translate_exceptions as e:
-                translate_failures.append(
-                    (model, f"ref seed {NIGHTLY_SEEDS[0]} translate failed: {e}")
-                )
-                continue
-            for seed in NIGHTLY_SEEDS[1:]:
+            # Run every seed independently, collect (seed → bytes | Exception).
+            seed_results: dict[int, bytes | BaseException] = {}
+            for seed in NIGHTLY_SEEDS:
                 try:
-                    other = _translate_to_bytes(model, seed, timeout=NIGHTLY_TRANSLATE_TIMEOUT_SEC)
+                    seed_results[seed] = _translate_to_bytes(
+                        model, seed, timeout=NIGHTLY_TRANSLATE_TIMEOUT_SEC
+                    )
                 except translate_exceptions as e:
-                    translate_failures.append((model, f"seed {seed} translate failed: {e}"))
-                    continue
-                if other != ref:
+                    seed_results[seed] = e
+
+            succeeded = {s: r for s, r in seed_results.items() if isinstance(r, bytes)}
+            failed = {s: r for s, r in seed_results.items() if not isinstance(r, bytes)}
+
+            if not succeeded:
+                # All seeds failed — log as translate noise, don't fail test.
+                for seed, err in failed.items():
+                    translate_failures.append((model, f"seed {seed} translate failed: {err}"))
+                continue
+
+            if failed:
+                # Seed-dependent translate failure: the CLI's ability to even
+                # translate this model depends on PYTHONHASHSEED. That IS a
+                # determinism regression — fail the test.
+                ok_seeds = sorted(succeeded.keys())
+                for seed, err in failed.items():
                     determinism_failures.append(
                         (
                             model,
-                            _format_determinism_failure(model, NIGHTLY_SEEDS[0], seed, ref, other),
+                            f"seed-dependent translate failure: seed {seed} raised "
+                            f"{type(err).__name__}: {err} "
+                            f"while seeds {ok_seeds} translated successfully",
+                        )
+                    )
+                # Don't compare bytes when some seeds failed — the comparison
+                # signal is already noisy.
+                continue
+
+            # All seeds succeeded — compare byte outputs against the reference.
+            ref_seed = NIGHTLY_SEEDS[0]
+            ref = succeeded[ref_seed]
+            assert isinstance(ref, bytes)
+            for seed, out in succeeded.items():
+                if seed == ref_seed:
+                    continue
+                assert isinstance(out, bytes)
+                if out != ref:
+                    determinism_failures.append(
+                        (
+                            model,
+                            _format_determinism_failure(model, ref_seed, seed, ref, out),
                         )
                     )
 
-        # Surface translate failures in captured stdout for nightly log review,
-        # but don't fail the test — they indicate translate regressions, not
-        # determinism bugs, and belong to a different signal.
+        # Surface all-seed-failed translate noise in captured stdout for nightly
+        # log review — they indicate translate regressions, not determinism bugs.
         if translate_failures:
             print(
-                f"\n[determinism] {len(translate_failures)} translate failure(s) "
+                f"\n[determinism] {len(translate_failures)} all-seed translate failure(s) "
                 f"across {len(models)} models (informational — not determinism regressions):"
             )
             for model, detail in translate_failures:

--- a/tests/integration/test_pipeline_determinism.py
+++ b/tests/integration/test_pipeline_determinism.py
@@ -20,6 +20,7 @@ scope / fixture / seed-set rationale.
 from __future__ import annotations
 
 import difflib
+import itertools
 import json
 import os
 import subprocess
@@ -131,7 +132,9 @@ def _format_determinism_failure(
         tofile=f"{model} seed={failing_seed}",
         n=3,
     )
-    diff_lines = list(diff_iter)[:40]
+    # Stream the diff and cap at 40 lines — on large mismatches the full diff
+    # can be huge, but we only show the first window.
+    diff_lines = list(itertools.islice(diff_iter, 40))
 
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
     ref_path = ARTIFACT_DIR / f"{model}_seed{reference_seed}.gms"

--- a/tests/unit/ir/test_resolve_ambiguities.py
+++ b/tests/unit/ir/test_resolve_ambiguities.py
@@ -35,12 +35,16 @@ from src.ir.parser import (
 )
 
 
-def _num(value: str) -> Token:
-    return Token("NUMBER", value)
+def _num(value: str, line: int = 1) -> Token:
+    tok = Token("NUMBER", value)
+    tok.line = line
+    return tok
 
 
-def _id(value: str) -> Token:
-    return Token("ID", value)
+def _id(value: str, line: int = 1) -> Token:
+    tok = Token("ID", value)
+    tok.line = line
+    return tok
 
 
 def _correct_row() -> Tree:
@@ -175,30 +179,30 @@ class TestResolveAmbiguitiesEndToEnd:
         assert result.children[0].value == "a"
 
 
-def _label_row(label_id: str) -> Tree:
+def _label_row(label_id: str, line: int = 1) -> Tree:
     """Build a `table_row` with a simple ID row label and zero values."""
     return Tree(
         "table_row",
-        [Tree("simple_label", [Tree("dotted_label", [_id(label_id)])])],
+        [Tree("simple_label", [Tree("dotted_label", [_id(label_id, line=line)])])],
     )
 
 
-def _labeled_row_with_values(label_id: str, values: list[str]) -> Tree:
+def _labeled_row_with_values(label_id: str, values: list[str], line: int = 1) -> Tree:
     """Build a `table_row` with a simple ID row label and N `table_value` children."""
     return Tree(
         "table_row",
         [
-            Tree("simple_label", [Tree("dotted_label", [_id(label_id)])]),
-            *[Tree("table_value", [_num(v)]) for v in values],
+            Tree("simple_label", [Tree("dotted_label", [_id(label_id, line=line)])]),
+            *[Tree("table_value", [_num(v, line=line)]) for v in values],
         ],
     )
 
 
-def _corrupted_number_row(value: str) -> Tree:
+def _corrupted_number_row(value: str, line: int = 1) -> Tree:
     """Build a #1283-corrupted bare-NUMBER `table_row` (single NUMBER label, no values)."""
     return Tree(
         "table_row",
-        [Tree("simple_label", [Tree("dotted_label", [_num(value)])])],
+        [Tree("simple_label", [Tree("dotted_label", [_num(value, line=line)])])],
     )
 
 
@@ -298,6 +302,47 @@ class TestCollapseCorruptedTableRows:
         assert len(result) == 1
         inner = result[0].children[0]
         assert _is_bare_number_row(inner) is not None
+
+    def test_bare_number_on_different_line_not_collapsed(self):
+        """A bare-NUMBER row on a line AFTER the previous row is a legitimate
+        numeric row label (the values likely come on a continuation line) —
+        do NOT collapse it onto the previous row.
+        """
+        contents = [
+            _content(_labeled_row_with_values("foo", ["1.0"], line=49)),
+            _content(_corrupted_number_row("9000011", line=50)),
+        ]
+        result = _collapse_corrupted_table_rows(contents)
+        # Both rows preserved — different lines means not #1283 corruption.
+        assert len(result) == 2
+        prev_row = result[0].children[0]
+        prev_values = [
+            c for c in prev_row.children if isinstance(c, Tree) and c.data == "table_value"
+        ]
+        assert len(prev_values) == 1  # unchanged
+        assert _is_bare_number_row(result[1].children[0]) is not None
+
+    def test_bare_number_followed_by_continuation_not_collapsed(self):
+        """Bare-NUMBER row followed by a `table_continuation` is a legitimate
+        numeric row label whose values arrive on the `+` line — don't collapse.
+        """
+        continuation = Tree(
+            "table_continuation",
+            [Token("PLUS", "+"), Tree("table_value", [_num("2.0")])],
+        )
+        contents = [
+            _content(_labeled_row_with_values("foo", ["1.0"], line=1)),
+            _content(_corrupted_number_row("9000011", line=1)),  # same line → gate A passes
+            Tree("table_content", [continuation]),
+        ]
+        result = _collapse_corrupted_table_rows(contents)
+        # Even on the same line, gate B (next is continuation) prevents collapse.
+        assert len(result) == 3
+        prev_row = result[0].children[0]
+        prev_values = [
+            c for c in prev_row.children if isinstance(c, Tree) and c.data == "table_value"
+        ]
+        assert len(prev_values) == 1  # unchanged
 
 
 class TestNormalizeParsedTables:

--- a/tests/unit/ir/test_resolve_ambiguities.py
+++ b/tests/unit/ir/test_resolve_ambiguities.py
@@ -1,0 +1,367 @@
+"""Tests for #1283 Option D fix (parser-layer table-row disambiguation).
+
+When Earley parses a table row like `low.a 1 2 3` with ambiguity="resolve",
+the `table_row` / `simple_label` / `dotted_label` rule chain allows a bare
+NUMBER to parse as either a `table_value` (intended) or as a `simple_label`
+row label (valid under the grammar but corrupting). Lark's Earley resolver
+picks between these with a `PYTHONHASHSEED`-dependent tiebreak; a 20-seed
+sweep on chenery produced corruption in 65% of runs.
+
+The Option D fix has two layers:
+
+1. **Defensive `_resolve_ambiguities` extension** (`_score_table_row_alternative`
+   + `_pick_ambig_alternative`): when `_ambig` nodes reach the tree (rare
+   under `ambiguity="resolve"`, but possible if the parser config changes),
+   score each alternative by `(table_value_children_count, -table_row_node_count)`
+   and pick the maximum.
+2. **Post-parse table-row normalizer** (`_normalize_parsed_tables` +
+   `_is_bare_number_row` + `_collapse_corrupted_table_rows`): walks the
+   resolved parse tree and detects the #1283 corruption signature — a
+   `table_row` consisting of a single bare-NUMBER label with zero
+   `table_value` children — then merges each such row into the preceding
+   real row as a `table_value`. This is the layer that actually fixes
+   chenery under the current `ambiguity="resolve"` config.
+"""
+
+from lark import Token, Tree
+
+from src.ir.parser import (
+    _collapse_corrupted_table_rows,
+    _is_bare_number_row,
+    _normalize_parsed_tables,
+    _pick_ambig_alternative,
+    _resolve_ambiguities,
+    _score_table_row_alternative,
+)
+
+
+def _num(value: str) -> Token:
+    return Token("NUMBER", value)
+
+
+def _id(value: str) -> Token:
+    return Token("ID", value)
+
+
+def _correct_row() -> Tree:
+    """`low.a 1 2 3` parsed correctly: 1 row with 3 table_value children."""
+    return Tree(
+        "table_row",
+        [
+            Tree("simple_label", [Tree("dotted_label", [_id("low"), _id("a")])]),
+            Tree("table_value", [_num("1")]),
+            Tree("table_value", [_num("2")]),
+            Tree("table_value", [_num("3")]),
+        ],
+    )
+
+
+def _corrupted_rows() -> Tree:
+    """`low.a 1 2 3` parsed corruptedly: 4 rows, each a bare-label parse."""
+    return Tree(
+        "table_section",
+        [
+            Tree(
+                "table_row",
+                [Tree("simple_label", [Tree("dotted_label", [_id("low"), _id("a")])])],
+            ),
+            Tree(
+                "table_row",
+                [Tree("simple_label", [Tree("dotted_label", [_num("1")])])],
+            ),
+            Tree(
+                "table_row",
+                [Tree("simple_label", [Tree("dotted_label", [_num("2")])])],
+            ),
+            Tree(
+                "table_row",
+                [Tree("simple_label", [Tree("dotted_label", [_num("3")])])],
+            ),
+        ],
+    )
+
+
+class TestScoreTableRowAlternative:
+    """Score = (table_value_count, -table_row_count)."""
+
+    def test_empty_tree_returns_zero(self):
+        assert _score_table_row_alternative(Tree("table_section", [])) == (0, 0)
+
+    def test_token_returns_zero(self):
+        assert _score_table_row_alternative(_num("42")) == (0, 0)
+
+    def test_correct_multi_row_label_parse_scores_3_minus_1(self):
+        assert _score_table_row_alternative(_correct_row()) == (3, -1)
+
+    def test_corrupted_multi_row_label_parse_scores_0_minus_4(self):
+        assert _score_table_row_alternative(_corrupted_rows()) == (0, -4)
+
+    def test_max_picks_correct_over_corrupted(self):
+        alternatives = [_corrupted_rows(), _correct_row()]
+        winner = max(alternatives, key=_score_table_row_alternative)
+        assert winner is alternatives[1]
+
+
+class TestPickAmbigAlternative:
+    """Dispatch: only use the greediest-value heuristic when table_row is present."""
+
+    def test_no_children_returns_self(self):
+        ambig = Tree("_ambig", [])
+        assert _pick_ambig_alternative(ambig) is ambig
+
+    def test_no_table_row_falls_back_to_first(self):
+        """Non-table ambiguities keep the historical first-alternative behavior."""
+        alt_a = Tree("expr", [_id("a")])
+        alt_b = Tree("expr", [_id("b")])
+        ambig = Tree("_ambig", [alt_a, alt_b])
+        assert _pick_ambig_alternative(ambig) is alt_a
+
+    def test_table_row_present_picks_greediest_value(self):
+        """Despite being first child, corrupted alternative must lose to correct."""
+        corrupted = _corrupted_rows()
+        correct = _correct_row()
+        ambig = Tree("_ambig", [corrupted, correct])
+
+        assert _score_table_row_alternative(corrupted) == (0, -4)
+        assert _score_table_row_alternative(correct) == (3, -1)
+        assert _pick_ambig_alternative(ambig) is correct
+
+
+class TestResolveAmbiguitiesEndToEnd:
+    """End-to-end: `_resolve_ambiguities` walks the tree and resolves _ambig nodes."""
+
+    def test_token_passthrough(self):
+        tok = _num("42")
+        assert _resolve_ambiguities(tok) is tok
+
+    def test_no_ambiguity_identity_reconstruction(self):
+        """Trees without _ambig nodes are reconstructed but structurally equal."""
+        tree = Tree(
+            "table_row",
+            [
+                Tree("simple_label", [Tree("dotted_label", [_id("low")])]),
+                Tree("table_value", [_num("1")]),
+            ],
+        )
+        result = _resolve_ambiguities(tree)
+        assert isinstance(result, Tree)
+        assert result.data == "table_row"
+        assert len(result.children) == 2
+
+    def test_table_row_ambig_resolves_to_greediest_value(self):
+        """The #1283 reproducer: _ambig with (corrupted, correct) must pick correct."""
+        # The corrupted alternative is listed FIRST — pre-fix behavior would
+        # pick it. Post-fix behavior picks the greediest-value alternative (correct).
+        ambig = Tree("_ambig", [_corrupted_rows(), _correct_row()])
+        result = _resolve_ambiguities(ambig)
+
+        assert isinstance(result, Tree)
+        assert result.data == "table_row"
+        # 1 simple_label + 3 table_value children = 4 children total
+        assert len(result.children) == 4
+        assert (
+            sum(1 for c in result.children if isinstance(c, Tree) and c.data == "table_value") == 3
+        )
+
+    def test_non_table_ambig_still_picks_first(self):
+        """Non-table ambiguities use the historical first-alternative fallback."""
+        alt_a = Tree("expr", [_id("a")])
+        alt_b = Tree("expr", [_id("b")])
+        ambig = Tree("_ambig", [alt_a, alt_b])
+        result = _resolve_ambiguities(ambig)
+        assert isinstance(result, Tree)
+        assert len(result.children) == 1
+        assert isinstance(result.children[0], Token)
+        assert result.children[0].value == "a"
+
+
+def _label_row(label_id: str) -> Tree:
+    """Build a `table_row` with a simple ID row label and zero values."""
+    return Tree(
+        "table_row",
+        [Tree("simple_label", [Tree("dotted_label", [_id(label_id)])])],
+    )
+
+
+def _labeled_row_with_values(label_id: str, values: list[str]) -> Tree:
+    """Build a `table_row` with a simple ID row label and N `table_value` children."""
+    return Tree(
+        "table_row",
+        [
+            Tree("simple_label", [Tree("dotted_label", [_id(label_id)])]),
+            *[Tree("table_value", [_num(v)]) for v in values],
+        ],
+    )
+
+
+def _corrupted_number_row(value: str) -> Tree:
+    """Build a #1283-corrupted bare-NUMBER `table_row` (single NUMBER label, no values)."""
+    return Tree(
+        "table_row",
+        [Tree("simple_label", [Tree("dotted_label", [_num(value)])])],
+    )
+
+
+def _content(row: Tree) -> Tree:
+    return Tree("table_content", [row])
+
+
+class TestIsBareNumberRow:
+    """Detect the #1283 corruption signature at the `table_row` level."""
+
+    def test_detects_corrupted_bare_number_row(self):
+        row = _corrupted_number_row("0.915")
+        tok = _is_bare_number_row(row)
+        assert isinstance(tok, Token)
+        assert tok.value == "0.915"
+
+    def test_rejects_row_with_values(self):
+        """Legit bare-NUMBER row label (issue #863) — has table_value children."""
+        row = Tree(
+            "table_row",
+            [
+                Tree("simple_label", [Tree("dotted_label", [_num("9000011")])]),
+                Tree("table_value", [_num("42")]),
+            ],
+        )
+        assert _is_bare_number_row(row) is None
+
+    def test_rejects_id_labeled_row(self):
+        assert _is_bare_number_row(_label_row("low")) is None
+
+    def test_rejects_multi_segment_dotted_label(self):
+        row = Tree(
+            "table_row",
+            [Tree("simple_label", [Tree("dotted_label", [_id("low"), _id("a")])])],
+        )
+        assert _is_bare_number_row(row) is None
+
+    def test_rejects_tuple_label_alternative(self):
+        """tuple_cross_label, tuple_label, etc. are not simple_label."""
+        row = Tree("table_row", [Tree("tuple_cross_label", [_id("dummy")])])
+        assert _is_bare_number_row(row) is None
+
+    def test_rejects_non_table_row(self):
+        assert _is_bare_number_row(Tree("expr", [_id("x")])) is None
+
+
+class TestCollapseCorruptedTableRows:
+    """Merge corrupted bare-NUMBER rows into the preceding real row."""
+
+    def test_collapse_single_corrupted_row(self):
+        """`low 1` + `[2]` corrupted → `low 1 2`."""
+        contents = [
+            _content(_labeled_row_with_values("low", ["1"])),
+            _content(_corrupted_number_row("2")),
+        ]
+        result = _collapse_corrupted_table_rows(contents)
+        assert len(result) == 1
+        row = result[0].children[0]
+        values = [c for c in row.children if isinstance(c, Tree) and c.data == "table_value"]
+        assert len(values) == 2
+        assert values[0].children[0].value == "1"
+        assert values[1].children[0].value == "2"
+
+    def test_collapse_chenery_pattern(self):
+        """Chenery-style: `low.a.distr` (no values) + [.915, .944, 2.60, .80] corrupted."""
+        contents = [
+            _content(_labeled_row_with_values("low", [])),
+            _content(_corrupted_number_row("0.915")),
+            _content(_corrupted_number_row("0.944")),
+            _content(_corrupted_number_row("2.60")),
+            _content(_corrupted_number_row("0.80")),
+        ]
+        result = _collapse_corrupted_table_rows(contents)
+        assert len(result) == 1
+        row = result[0].children[0]
+        values = [c for c in row.children if isinstance(c, Tree) and c.data == "table_value"]
+        assert len(values) == 4
+        assert [v.children[0].value for v in values] == ["0.915", "0.944", "2.60", "0.80"]
+
+    def test_legit_bare_number_row_preserved(self):
+        """A legit bare-NUMBER row label (issue #863) with table_value children is NOT merged."""
+        legit = Tree(
+            "table_row",
+            [
+                Tree("simple_label", [Tree("dotted_label", [_num("9000011")])]),
+                Tree("table_value", [_num("42")]),
+            ],
+        )
+        contents = [_content(_label_row("prev")), _content(legit)]
+        result = _collapse_corrupted_table_rows(contents)
+        assert len(result) == 2
+
+    def test_orphan_with_no_preceding_row_preserved(self):
+        """If the first row is a bare-NUMBER orphan, preserve it — don't drop data."""
+        contents = [_content(_corrupted_number_row("42"))]
+        result = _collapse_corrupted_table_rows(contents)
+        assert len(result) == 1
+        inner = result[0].children[0]
+        assert _is_bare_number_row(inner) is not None
+
+
+class TestNormalizeParsedTables:
+    """End-to-end post-parse normalizer for #1283."""
+
+    def test_token_passthrough(self):
+        tok = _num("42")
+        assert _normalize_parsed_tables(tok) is tok
+
+    def test_non_table_tree_structurally_unchanged(self):
+        tree = Tree("model_def", [_id("foo")])
+        result = _normalize_parsed_tables(tree)
+        assert isinstance(result, Tree)
+        assert result.data == "model_def"
+        assert len(result.children) == 1
+
+    def test_table_block_with_corruption_repaired(self):
+        """table_block wrapping corrupted rows: rewritten to 1 row with N values."""
+        contents = [
+            _content(_labeled_row_with_values("high", [])),
+            _content(_corrupted_number_row("1")),
+            _content(_corrupted_number_row("2")),
+            _content(_corrupted_number_row("3")),
+        ]
+        block = Tree(
+            "table_block",
+            [_id("pdat"), Tree("table_domain_list", []), *contents],
+        )
+        result = _normalize_parsed_tables(block)
+        assert isinstance(result, Tree)
+        assert result.data == "table_block"
+        # The first two preamble children are kept; the table_content tail is collapsed.
+        table_contents = [
+            c for c in result.children if isinstance(c, Tree) and c.data == "table_content"
+        ]
+        assert len(table_contents) == 1
+        row = table_contents[0].children[0]
+        values = [c for c in row.children if isinstance(c, Tree) and c.data == "table_value"]
+        assert len(values) == 3
+        assert [v.children[0].value for v in values] == ["1", "2", "3"]
+
+    def test_nested_table_blocks_all_normalized(self):
+        """Normalizer recurses: nested table_blocks are also repaired."""
+        corrupted_block = Tree(
+            "table_block",
+            [
+                _id("inner"),
+                _content(_labeled_row_with_values("a", [])),
+                _content(_corrupted_number_row("7")),
+            ],
+        )
+        outer = Tree("program", [corrupted_block])
+        result = _normalize_parsed_tables(outer)
+        inner = result.children[0]
+        assert isinstance(inner, Tree)
+        assert inner.data == "table_block"
+        table_contents = [
+            c for c in inner.children if isinstance(c, Tree) and c.data == "table_content"
+        ]
+        assert len(table_contents) == 1
+        values = [
+            c
+            for c in table_contents[0].children[0].children
+            if isinstance(c, Tree) and c.data == "table_value"
+        ]
+        assert len(values) == 1
+        assert values[0].children[0].value == "7"


### PR DESCRIPTION
## Summary

Sprint 25 Day 1: two deliverables landing together so CI stays green going forward.

1. **#1283 fix** — eliminates Lark Earley's PYTHONHASHSEED-dependent corruption on chenery (pre-fix: 13/20 seeds corrupt; post-fix: 20/20 identical).
2. **PR12 byte-stability test harness** — per-commit `@pytest.mark.integration @pytest.mark.determinism` sweep + nightly full-corpus sweep via new `.github/workflows/nightly.yml`.

## #1283 two-layer fix

Original Task 3 Option D design operated on `_ambig` tree nodes, but Lark's `ambiguity="resolve"` never emits them — the resolver picks internally before `_resolve_ambiguities` runs. Switching to `ambiguity="explicit"` is infeasible (abel alone expands to 12,513 `_ambig` nodes; chenery doesn't complete). Implemented a two-layer fix in `src/ir/parser.py`:

- **Layer 1 (defensive):** `_score_table_row_alternative` + `_pick_ambig_alternative` implement the greediest-value heuristic per Task 3 design — only active if `_ambig` nodes ever reach `_resolve_ambiguities` (i.e., if the parser is reconfigured to `"explicit"`).
- **Layer 2 (active fix):** `_normalize_parsed_tables` walks `table_block` subtrees and detects the #1283 corruption signature (a `table_row` with a single bare-NUMBER `simple_label` and zero `table_value` children), merging each such row into the preceding real row as a `table_value`. Preserves legitimate bare-NUMBER row labels (issue #863 — those have sibling `table_value` children).

## PR12 test harness

- **`TestDeterminismFast`:** 5 fixtures (`chenery`, `abel`, `partssupply`, `ps2_f`, `himmel11`) × 5 seeds (`[0, 1, 42, 12345, 99999]`). `ThreadPoolExecutor` parallelizes seeds within each test; with pytest-xdist `-n auto` and ~12 cores, 25 concurrent subprocesses amortize Python-startup overhead. Wall-clock **≈103s locally**; fits the 5-min fast-suite CI budget.
- **`TestDeterminismFull`:** 143-model convex corpus × 2 seeds `[0, 99999]`; enumerated from `gamslib_status.json`. Marked `@pytest.mark.slow` so per-commit suite skips it.
- Subprocess uses `-o <tempdir>/model.gms` + `Path.read_bytes()` — raw-byte comparison per DESIGN §7.
- On mismatch: dumps model name, seed pair, line-count diff, capped 40-line `difflib.unified_diff`, full raw-bytes artifacts to `tests/artifacts/determinism/`, and `GITHUB_SHA` for bisecting.

## Fixture deviations from DESIGN §4

Original per-commit fixture list included `indus89`. Replaced with `himmel11`:
- `indus89`: `convexity.status = error` (demo license limits) — CLI exits nonzero.
- `indus`, `clearlak`: in-scope but translate times (101s, 323s) exceed per-commit budget.

Silent-corruption coverage for those 3 models is deferred to the nightly full-corpus sweep; header comment in the test file documents the reasoning.

## Test plan

- [x] 12 unit tests for Layer 1 (`_score_table_row_alternative`, `_pick_ambig_alternative`, `_resolve_ambiguities`) — pass
- [x] 14 unit tests for Layer 2 (`_is_bare_number_row`, `_collapse_corrupted_table_rows`, `_normalize_parsed_tables`) — pass
- [x] 20-seed `PYTHONHASHSEED` sweep on chenery: 1 unique hash (pre-fix: 2)
- [x] Full fast test suite: 4,548 passed, 10 skipped, 1 xfailed, 0 failed
- [x] `make typecheck && make format && make lint` — clean
- [x] PR12 fast suite (5 fixtures × 5 seeds) — all pass in ~103s
- [x] Nightly workflow YAML mirrors `ci.yml` dependency install sequence