### PR TITLE
Sprint 25 Day 2: Fix #1275 presolve  portability + Phase 1 AD instrumentation

### DIFF
--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -73,13 +73,22 @@ from ..ir.ast import (
 # input/output of `_diff_varref` and `_partial_collapse_sum` at every call.
 #
 # Remove after Phase 1 prototype lands (Day 4 cleanup pass).
+#
+# IMPORTANT: every call site guards message construction with
+# `if _SPRINT25_DAY2_DEBUG:` before invoking `_sprint25_day2_log(...)`. These
+# helpers sit in the AD hot path (called hundreds of thousands of times on
+# qabel alone), so building `f"... {expr.body!r}"` unconditionally — even if
+# the helper drops the result — would be a real performance regression.
 _SPRINT25_DAY2_DEBUG = os.environ.get("SPRINT25_DAY2_DEBUG") == "1"
 
 
 def _sprint25_day2_log(tag: str, msg: str) -> None:
-    """Emit a `[SPRINT25_DAY2][<tag>]` trace line to stderr when the env var is set."""
-    if _SPRINT25_DAY2_DEBUG:
-        print(f"[SPRINT25_DAY2][{tag}] {msg}", file=sys.stderr, flush=True)
+    """Emit a `[SPRINT25_DAY2][<tag>]` trace line to stderr.
+
+    Callers MUST guard message construction with `if _SPRINT25_DAY2_DEBUG:`;
+    this helper does not re-check the flag so callers can't forget the guard.
+    """
+    print(f"[SPRINT25_DAY2][{tag}] {msg}", file=sys.stderr, flush=True)
 
 
 def differentiate_expr(
@@ -422,11 +431,13 @@ def _diff_varref(
 
     # SPRINT25_DAY2: Trace entry — only logs when the name already matches,
     # so the trace only shows candidate sites (not every VarRef in the model).
-    _sprint25_day2_log(
-        "diff_varref",
-        f"enter name={expr.name!r} expr.indices={expr.indices!r} "
-        f"wrt_indices={wrt_indices!r} bound_indices={sorted(bound_indices)}",
-    )
+    # Guards are at every call site so f-strings don't evaluate in production.
+    if _SPRINT25_DAY2_DEBUG:
+        _sprint25_day2_log(
+            "diff_varref",
+            f"enter name={expr.name!r} expr.indices={expr.indices!r} "
+            f"wrt_indices={wrt_indices!r} bound_indices={sorted(bound_indices)}",
+        )
 
     # Index matching
     if wrt_indices is None:
@@ -434,10 +445,12 @@ def _diff_varref(
         # d/dx x = 1 (scalar matches scalar)
         # d/dx x(i) = 0 (indexed doesn't match scalar)
         if expr.indices == ():
-            _sprint25_day2_log("diff_varref", "-> Const(1.0) [scalar match]")
+            if _SPRINT25_DAY2_DEBUG:
+                _sprint25_day2_log("diff_varref", "-> Const(1.0) [scalar match]")
             return Const(1.0)
         else:
-            _sprint25_day2_log("diff_varref", "-> Const(0.0) [indexed vs scalar mismatch]")
+            if _SPRINT25_DAY2_DEBUG:
+                _sprint25_day2_log("diff_varref", "-> Const(0.0) [indexed vs scalar mismatch]")
             return Const(0.0)
 
     # Indices specified: must match (with quote normalization)
@@ -445,7 +458,8 @@ def _diff_varref(
     # quotes (e.g., '"disrupted"') while instance indices from set enumeration
     # use unquoted form ('disrupted'). Normalize before comparison.
     if _indices_match(expr.indices, wrt_indices):
-        _sprint25_day2_log("diff_varref", "-> Const(1.0) [exact index match]")
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log("diff_varref", "-> Const(1.0) [exact index match]")
         return Const(1.0)
 
     # Issue #1111: Alias-aware matching — when exact match fails, check if
@@ -455,10 +469,12 @@ def _diff_varref(
         if aliases:
             guard = _alias_match(expr.indices, wrt_indices, aliases, bound_indices)
             if guard is not None:
-                _sprint25_day2_log("diff_varref", f"-> alias guard: {guard!r}")
+                if _SPRINT25_DAY2_DEBUG:
+                    _sprint25_day2_log("diff_varref", f"-> alias guard: {guard!r}")
                 return guard
 
-    _sprint25_day2_log("diff_varref", "-> Const(0.0) [no match]")
+    if _SPRINT25_DAY2_DEBUG:
+        _sprint25_day2_log("diff_varref", "-> Const(0.0) [no match]")
     return Const(0.0)
 
 
@@ -2240,12 +2256,13 @@ def _partial_collapse_sum(
     """
     sum_index_sets = expr.index_sets
 
-    _sprint25_day2_log(
-        "partial_collapse_sum",
-        f"enter wrt_var={wrt_var!r} wrt_indices={wrt_indices!r} "
-        f"sum_index_sets={sum_index_sets!r} bound_indices={sorted(bound_indices)} "
-        f"body={expr.body!r}",
-    )
+    if _SPRINT25_DAY2_DEBUG:
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"enter wrt_var={wrt_var!r} wrt_indices={wrt_indices!r} "
+            f"sum_index_sets={sum_index_sets!r} bound_indices={sorted(bound_indices)} "
+            f"body={expr.body!r}",
+        )
 
     # Build a list of candidate sum indices for each wrt index position.
     # Each wrt index may match multiple sum indices (e.g., both n and np
@@ -2259,17 +2276,19 @@ def _partial_collapse_sum(
                 cands.append(si)
         candidates_per_wrt.append(cands)
 
-    _sprint25_day2_log(
-        "partial_collapse_sum",
-        f"candidates_per_wrt={candidates_per_wrt} "
-        f"(positions map to sum_index_sets[i])",
-    )
+    if _SPRINT25_DAY2_DEBUG:
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"candidates_per_wrt={candidates_per_wrt} " f"(positions map to sum_index_sets[i])",
+        )
 
     # If any wrt index has no candidates, no valid matching exists
     if any(len(c) == 0 for c in candidates_per_wrt):
-        _sprint25_day2_log(
-            "partial_collapse_sum", "-> None [some wrt position has no candidate sum index]"
-        )
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log(
+                "partial_collapse_sum",
+                "-> None [some wrt position has no candidate sum index]",
+            )
         return None
 
     # Enumerate all valid matchings (each sum index used at most once).
@@ -2278,14 +2297,16 @@ def _partial_collapse_sum(
     # matchings whose derivatives must be summed for the correct gradient.
     all_matchings = _enumerate_matchings(candidates_per_wrt)
 
-    _sprint25_day2_log(
-        "partial_collapse_sum",
-        f"all_matchings={all_matchings} "
-        f"(each is a tuple of sum_index_sets-positions, one per wrt position)",
-    )
+    if _SPRINT25_DAY2_DEBUG:
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"all_matchings={all_matchings} "
+            f"(each is a tuple of sum_index_sets-positions, one per wrt position)",
+        )
 
     if not all_matchings:
-        _sprint25_day2_log("partial_collapse_sum", "-> None [no valid matching found]")
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log("partial_collapse_sum", "-> None [no valid matching found]")
         return None
 
     # Compute derivative for each valid matching and accumulate results
@@ -2304,11 +2325,13 @@ def _partial_collapse_sum(
         remaining_sum_indices = [
             sum_index_sets[si] for si in range(len(sum_index_sets)) if si not in matched_set
         ]
-        _sprint25_day2_log(
-            "partial_collapse_sum",
-            f"matching={matching} matched_sum_indices={matched_sum_indices} "
-            f"matched_concrete={matched_concrete} remaining_sum_indices={remaining_sum_indices}",
-        )
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log(
+                "partial_collapse_sum",
+                f"matching={matching} matched_sum_indices={matched_sum_indices} "
+                f"matched_concrete={matched_concrete} "
+                f"remaining_sum_indices={remaining_sum_indices}",
+            )
 
         # Issue #1111: Rename remaining sum indices that share an alias root
         # with any matched sum index. After substitution, the matched indices
@@ -2352,35 +2375,37 @@ def _partial_collapse_sum(
         symbolic_wrt: tuple[str | IndexOffset, ...] = tuple(wrt_to_symbolic)
         # Augment bound_indices with remaining (uncollapsed) sum indices
         new_bound = bound_indices | frozenset(final_remaining)
-        _sprint25_day2_log(
-            "partial_collapse_sum",
-            f"about to diff body with symbolic_wrt={symbolic_wrt!r} "
-            f"new_bound={sorted(new_bound)} final_remaining={final_remaining} "
-            f"working_body={working_body!r}",
-        )
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log(
+                "partial_collapse_sum",
+                f"about to diff body with symbolic_wrt={symbolic_wrt!r} "
+                f"new_bound={sorted(new_bound)} final_remaining={final_remaining} "
+                f"working_body={working_body!r}",
+            )
         body_derivative = differentiate_expr(
             working_body, wrt_var, symbolic_wrt, config, bound_indices=new_bound
         )
-        _sprint25_day2_log(
-            "partial_collapse_sum",
-            f"body_derivative={body_derivative!r}",
-        )
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log(
+                "partial_collapse_sum",
+                f"body_derivative={body_derivative!r}",
+            )
 
         # Skip zero derivatives (common for non-matching alias paths)
         if isinstance(body_derivative, Const) and body_derivative.value == 0.0:
-            _sprint25_day2_log(
-                "partial_collapse_sum", "skip: body_derivative is Const(0.0)"
-            )
+            if _SPRINT25_DAY2_DEBUG:
+                _sprint25_day2_log("partial_collapse_sum", "skip: body_derivative is Const(0.0)")
             continue
 
         # Substitute matched sum indices with their concrete values
         result_body = _substitute_sum_indices(
             body_derivative, tuple(matched_sum_indices), tuple(matched_concrete)
         )
-        _sprint25_day2_log(
-            "partial_collapse_sum",
-            f"after substitute matched→concrete: result_body={result_body!r}",
-        )
+        if _SPRINT25_DAY2_DEBUG:
+            _sprint25_day2_log(
+                "partial_collapse_sum",
+                f"after substitute matched→concrete: result_body={result_body!r}",
+            )
 
         # If there are remaining sum indices, wrap in a Sum (preserving condition)
         if final_remaining:

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -83,10 +83,16 @@ _SPRINT25_DAY2_DEBUG = os.environ.get("SPRINT25_DAY2_DEBUG") == "1"
 
 
 def _sprint25_day2_log(tag: str, msg: str) -> None:
-    """Emit a `[SPRINT25_DAY2][<tag>]` trace line to stderr.
+    """Emit a `[SPRINT25_DAY2][<tag>]` trace line to stderr unconditionally.
 
-    Callers MUST guard message construction with `if _SPRINT25_DAY2_DEBUG:`;
-    this helper does not re-check the flag so callers can't forget the guard.
+    This helper deliberately does NOT re-check `_SPRINT25_DAY2_DEBUG`: the
+    goal is zero cost when debug is off, which requires callers to short-
+    circuit message construction themselves. Every call site in this module
+    is therefore wrapped with `if _SPRINT25_DAY2_DEBUG:` — if a future
+    contributor adds a call without the guard, this helper WILL log
+    unconditionally (and the `f"... {expr.body!r}"` argument will also
+    evaluate unconditionally, defeating the zero-cost property). Keep the
+    guard at every call site.
     """
     print(f"[SPRINT25_DAY2][{tag}] {msg}", file=sys.stderr, flush=True)
 

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -43,6 +43,8 @@ Backward Compatibility:
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -63,6 +65,21 @@ from ..ir.ast import (
     Unary,
     VarRef,
 )
+
+# SPRINT25_DAY2: Debug instrumentation for the Phase 1 investigation into
+# `_partial_collapse_sum` multi-index concrete→symbolic gap (qabel / #1089).
+# Gated on env var so the trace costs nothing in production; flip it on with
+# `SPRINT25_DAY2_DEBUG=1` when reproducing the qabel trace to inspect the
+# input/output of `_diff_varref` and `_partial_collapse_sum` at every call.
+#
+# Remove after Phase 1 prototype lands (Day 4 cleanup pass).
+_SPRINT25_DAY2_DEBUG = os.environ.get("SPRINT25_DAY2_DEBUG") == "1"
+
+
+def _sprint25_day2_log(tag: str, msg: str) -> None:
+    """Emit a `[SPRINT25_DAY2][<tag>]` trace line to stderr when the env var is set."""
+    if _SPRINT25_DAY2_DEBUG:
+        print(f"[SPRINT25_DAY2][{tag}] {msg}", file=sys.stderr, flush=True)
 
 
 def differentiate_expr(
@@ -403,14 +420,24 @@ def _diff_varref(
     if expr.name != wrt_var:
         return Const(0.0)
 
+    # SPRINT25_DAY2: Trace entry — only logs when the name already matches,
+    # so the trace only shows candidate sites (not every VarRef in the model).
+    _sprint25_day2_log(
+        "diff_varref",
+        f"enter name={expr.name!r} expr.indices={expr.indices!r} "
+        f"wrt_indices={wrt_indices!r} bound_indices={sorted(bound_indices)}",
+    )
+
     # Index matching
     if wrt_indices is None:
         # No indices specified: only match if expr is also scalar (no indices)
         # d/dx x = 1 (scalar matches scalar)
         # d/dx x(i) = 0 (indexed doesn't match scalar)
         if expr.indices == ():
+            _sprint25_day2_log("diff_varref", "-> Const(1.0) [scalar match]")
             return Const(1.0)
         else:
+            _sprint25_day2_log("diff_varref", "-> Const(0.0) [indexed vs scalar mismatch]")
             return Const(0.0)
 
     # Indices specified: must match (with quote normalization)
@@ -418,6 +445,7 @@ def _diff_varref(
     # quotes (e.g., '"disrupted"') while instance indices from set enumeration
     # use unquoted form ('disrupted'). Normalize before comparison.
     if _indices_match(expr.indices, wrt_indices):
+        _sprint25_day2_log("diff_varref", "-> Const(1.0) [exact index match]")
         return Const(1.0)
 
     # Issue #1111: Alias-aware matching — when exact match fails, check if
@@ -427,8 +455,10 @@ def _diff_varref(
         if aliases:
             guard = _alias_match(expr.indices, wrt_indices, aliases, bound_indices)
             if guard is not None:
+                _sprint25_day2_log("diff_varref", f"-> alias guard: {guard!r}")
                 return guard
 
+    _sprint25_day2_log("diff_varref", "-> Const(0.0) [no match]")
     return Const(0.0)
 
 
@@ -2210,6 +2240,13 @@ def _partial_collapse_sum(
     """
     sum_index_sets = expr.index_sets
 
+    _sprint25_day2_log(
+        "partial_collapse_sum",
+        f"enter wrt_var={wrt_var!r} wrt_indices={wrt_indices!r} "
+        f"sum_index_sets={sum_index_sets!r} bound_indices={sorted(bound_indices)} "
+        f"body={expr.body!r}",
+    )
+
     # Build a list of candidate sum indices for each wrt index position.
     # Each wrt index may match multiple sum indices (e.g., both n and np
     # when Alias(n,np) and both are in the sum).
@@ -2222,8 +2259,17 @@ def _partial_collapse_sum(
                 cands.append(si)
         candidates_per_wrt.append(cands)
 
+    _sprint25_day2_log(
+        "partial_collapse_sum",
+        f"candidates_per_wrt={candidates_per_wrt} "
+        f"(positions map to sum_index_sets[i])",
+    )
+
     # If any wrt index has no candidates, no valid matching exists
     if any(len(c) == 0 for c in candidates_per_wrt):
+        _sprint25_day2_log(
+            "partial_collapse_sum", "-> None [some wrt position has no candidate sum index]"
+        )
         return None
 
     # Enumerate all valid matchings (each sum index used at most once).
@@ -2232,7 +2278,14 @@ def _partial_collapse_sum(
     # matchings whose derivatives must be summed for the correct gradient.
     all_matchings = _enumerate_matchings(candidates_per_wrt)
 
+    _sprint25_day2_log(
+        "partial_collapse_sum",
+        f"all_matchings={all_matchings} "
+        f"(each is a tuple of sum_index_sets-positions, one per wrt position)",
+    )
+
     if not all_matchings:
+        _sprint25_day2_log("partial_collapse_sum", "-> None [no valid matching found]")
         return None
 
     # Compute derivative for each valid matching and accumulate results
@@ -2251,6 +2304,11 @@ def _partial_collapse_sum(
         remaining_sum_indices = [
             sum_index_sets[si] for si in range(len(sum_index_sets)) if si not in matched_set
         ]
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"matching={matching} matched_sum_indices={matched_sum_indices} "
+            f"matched_concrete={matched_concrete} remaining_sum_indices={remaining_sum_indices}",
+        )
 
         # Issue #1111: Rename remaining sum indices that share an alias root
         # with any matched sum index. After substitution, the matched indices
@@ -2294,17 +2352,34 @@ def _partial_collapse_sum(
         symbolic_wrt: tuple[str | IndexOffset, ...] = tuple(wrt_to_symbolic)
         # Augment bound_indices with remaining (uncollapsed) sum indices
         new_bound = bound_indices | frozenset(final_remaining)
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"about to diff body with symbolic_wrt={symbolic_wrt!r} "
+            f"new_bound={sorted(new_bound)} final_remaining={final_remaining} "
+            f"working_body={working_body!r}",
+        )
         body_derivative = differentiate_expr(
             working_body, wrt_var, symbolic_wrt, config, bound_indices=new_bound
+        )
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"body_derivative={body_derivative!r}",
         )
 
         # Skip zero derivatives (common for non-matching alias paths)
         if isinstance(body_derivative, Const) and body_derivative.value == 0.0:
+            _sprint25_day2_log(
+                "partial_collapse_sum", "skip: body_derivative is Const(0.0)"
+            )
             continue
 
         # Substitute matched sum indices with their concrete values
         result_body = _substitute_sum_indices(
             body_derivative, tuple(matched_sum_indices), tuple(matched_concrete)
+        )
+        _sprint25_day2_log(
+            "partial_collapse_sum",
+            f"after substitute matched→concrete: result_body={result_body!r}",
         )
 
         # If there are remaining sum indices, wrap in a Sum (preserving condition)

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -5,8 +5,10 @@ GAMS MCP file from a KKT system.
 """
 
 import math
+import warnings
 from collections import deque
 from itertools import combinations
+from pathlib import Path
 from typing import cast
 
 from src.config import Config
@@ -69,6 +71,12 @@ from src.kkt.naming import (
     create_ineq_multiplier_name,
 )
 from src.kkt.objective import extract_objective_info
+
+# Repository root anchor for portable `$include` paths in emitted artifacts.
+# emit_gams.py lives at `<repo>/src/emit/emit_gams.py`, so parents[2] is the
+# repo root. Used by `_emit_nlp_presolve` to emit a repo-relative include
+# directive instead of a workstation-specific absolute path (#1275).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _merge_exclude_params(*sets: set[str] | None) -> set[str] | None:
@@ -928,12 +936,38 @@ def _emit_nlp_presolve(
     # solver uses the original equation forms (=L=/=G=) rather than the
     # MCP's comp_* (negated =G=) forms, which can confuse NLP solvers.
     # $onMultiR allows redefinition of symbols already declared in the MCP.
-    from pathlib import Path
+    #
+    # Emit a repo-relative include path when the source file lives under the
+    # repo root (#1275) so generated `_mcp_presolve.gms` artifacts remain
+    # portable across workstations and CI. Sources outside the repo root have
+    # no portable reference, so we emit a warning comment + commented-out
+    # absolute include — the artifact is then self-documenting about why it
+    # can't be re-run without manual edits.
+    src_path = Path(source_file).resolve()
+    try:
+        include_path = src_path.relative_to(_REPO_ROOT).as_posix()
+        include_is_portable = True
+    except ValueError:
+        include_path = src_path.as_posix()
+        include_is_portable = False
 
-    abs_path = Path(source_file).resolve().as_posix()
-    escaped_include_path = abs_path.replace('"', '""')
+    escaped_include_path = include_path.replace('"', '""')
     sections.append("$onMultiR")
-    sections.append(f'$include "{escaped_include_path}"')
+    if include_is_portable:
+        sections.append(f'$include "{escaped_include_path}"')
+    else:
+        warnings.warn(
+            f"nlp-presolve source {source_file!r} is outside the repo root "
+            f"({_REPO_ROOT}); emitting a commented-out absolute $include that "
+            f"will need manual replacement before the pre-solve wrapper can "
+            f"be re-run on another machine.",
+            stacklevel=3,
+        )
+        sections.append(
+            "* #1275: source file is outside the repo root; edit the line "
+            "below to a portable path before re-running."
+        )
+        sections.append(f'*$include "{escaped_include_path}"')
     sections.append("$offMulti")
     sections.append("")
 

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -945,6 +945,11 @@ def _emit_nlp_presolve(
             f"that contains it) to enable pre-solve.",
             stacklevel=3,
         )
+        # Emit the omission banner regardless of `add_comments` — without it,
+        # a consumer of a `--no-comments` artifact would have no in-file
+        # indication that the warm-start was dropped, and only the Python-
+        # time warning survives. The banner is four `*`-commented lines so
+        # GAMS ignores them at compile time.
         if add_comments:
             sections.append("* ============================================")
             sections.append("* NLP Pre-Solve omitted: source file is outside the repo root")
@@ -953,6 +958,13 @@ def _emit_nlp_presolve(
                 "under the repo root to enable warm-start)."
             )
             sections.append("* ============================================")
+            sections.append("")
+        else:
+            # Minimal single-line omission marker for --no-comments mode.
+            sections.append(
+                "* #1275: NLP pre-solve omitted — source file is outside the "
+                "repo root (no portable $include path)."
+            )
             sections.append("")
         return
 

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -928,8 +928,11 @@ def _emit_nlp_presolve(
     # it, AND the dual-transfer lines that follow would reference original
     # equation names that only come into scope via the $include — so skipping
     # only the include (keeping the transfers) would produce an un-runnable
-    # artifact. Emit a `UserWarning` and return, leaving the MCP itself
-    # runnable without the warm-start.
+    # artifact. Emit a `UserWarning` + a short commented banner in the GAMS
+    # output explaining why the pre-solve block was dropped, then return.
+    # The banner keeps the artifact self-documenting (reviewers / downstream
+    # readers see the explanation inline) without breaking its runnability —
+    # GAMS ignores `*` comment lines.
     src_path = Path(source_file).resolve()
     try:
         include_path = src_path.relative_to(_REPO_ROOT).as_posix()
@@ -942,6 +945,15 @@ def _emit_nlp_presolve(
             f"that contains it) to enable pre-solve.",
             stacklevel=3,
         )
+        if add_comments:
+            sections.append("* ============================================")
+            sections.append("* NLP Pre-Solve omitted: source file is outside the repo root")
+            sections.append(
+                "* (#1275 — no portable $include path; re-run with the source "
+                "under the repo root to enable warm-start)."
+            )
+            sections.append("* ============================================")
+            sections.append("")
         return
 
     # Build sets of equality/inequality names for sign handling

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -922,6 +922,28 @@ def _emit_nlp_presolve(
     if not nlp_eqs:
         return
 
+    # #1275: resolve the source path before committing any output to `sections`.
+    # If the source lives under the repo root we emit a portable
+    # `$include "<rel>"`. If it doesn't, there's no portable way to refer to
+    # it, AND the dual-transfer lines that follow would reference original
+    # equation names that only come into scope via the $include — so skipping
+    # only the include (keeping the transfers) would produce an un-runnable
+    # artifact. Emit a `UserWarning` and return, leaving the MCP itself
+    # runnable without the warm-start.
+    src_path = Path(source_file).resolve()
+    try:
+        include_path = src_path.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        warnings.warn(
+            f"nlp-presolve source {source_file!r} is outside the repo root "
+            f"({_REPO_ROOT}); there is no portable $include path, so the "
+            f"NLP pre-solve warm-start block is being omitted entirely. "
+            f"Move the source under the repo root (or run from a checkout "
+            f"that contains it) to enable pre-solve.",
+            stacklevel=3,
+        )
+        return
+
     # Build sets of equality/inequality names for sign handling
     eq_set = set(kkt.model_ir.equalities)
     ineq_set = set(kkt.model_ir.inequalities)
@@ -936,38 +958,9 @@ def _emit_nlp_presolve(
     # solver uses the original equation forms (=L=/=G=) rather than the
     # MCP's comp_* (negated =G=) forms, which can confuse NLP solvers.
     # $onMultiR allows redefinition of symbols already declared in the MCP.
-    #
-    # Emit a repo-relative include path when the source file lives under the
-    # repo root (#1275) so generated `_mcp_presolve.gms` artifacts remain
-    # portable across workstations and CI. Sources outside the repo root have
-    # no portable reference, so we emit a warning comment + commented-out
-    # absolute include — the artifact is then self-documenting about why it
-    # can't be re-run without manual edits.
-    src_path = Path(source_file).resolve()
-    try:
-        include_path = src_path.relative_to(_REPO_ROOT).as_posix()
-        include_is_portable = True
-    except ValueError:
-        include_path = src_path.as_posix()
-        include_is_portable = False
-
     escaped_include_path = include_path.replace('"', '""')
     sections.append("$onMultiR")
-    if include_is_portable:
-        sections.append(f'$include "{escaped_include_path}"')
-    else:
-        warnings.warn(
-            f"nlp-presolve source {source_file!r} is outside the repo root "
-            f"({_REPO_ROOT}); emitting a commented-out absolute $include that "
-            f"will need manual replacement before the pre-solve wrapper can "
-            f"be re-run on another machine.",
-            stacklevel=3,
-        )
-        sections.append(
-            "* #1275: source file is outside the repo root; edit the line "
-            "below to a portable path before re-running."
-        )
-        sections.append(f'*$include "{escaped_include_path}"')
+    sections.append(f'$include "{escaped_include_path}"')
     sections.append("$offMulti")
     sections.append("")
 

--- a/tests/integration/emit/test_emit_full.py
+++ b/tests/integration/emit/test_emit_full.py
@@ -408,13 +408,19 @@ class TestFullGAMSEmission:
 
         kkt = assemble_kkt_system(model, gradient, J_eq, J_ineq)
 
-        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file="/tmp/test_model.gms")
+        # #1275: the emitter skips the presolve block entirely when the
+        # source is outside the repo root (it has no portable $include
+        # path). Use an in-repo path so this test continues to exercise the
+        # presolve structure rather than the soft-skip branch.
+        output = emit_gams_mcp(
+            kkt, nlp_presolve=True, source_file="examples/simple_nlp.gms"
+        )
 
         # Pre-solve block should be present
         assert "$onMultiR" in output
         assert "$offMulti" in output
         assert "$include" in output
-        assert "test_model.gms" in output
+        assert "simple_nlp.gms" in output
 
         # Dual transfer line should be present (bound multiplier for x with lo=0).
         # This minimal model has no equality multipliers (objdef is the

--- a/tests/integration/test_nlp_presolve.py
+++ b/tests/integration/test_nlp_presolve.py
@@ -607,19 +607,19 @@ class TestNLPPresolveGAMSSolve:
         assert result.exit_code == 0
 
         # Solve with GAMS. After #1275 the emitted presolve wrapper uses a
-        # repo-relative `$include` path (e.g., `data/gamslib/raw/bearing.gms`),
-        # so GAMS must be invoked with the repo root as cwd for the include
-        # to resolve. We also route the listing file back to `tmp_path` via
-        # `o=` so the later `output_file.with_suffix('.lst')` assertion still
-        # finds it. This mirrors the intended usage: artifacts are portable
-        # when re-run from the repo root.
+        # repo-relative `$include` path (e.g., `data/gamslib/raw/bearing.gms`).
+        # Keep the solver hermetic by running under `cwd=tmp_path` (so scratch
+        # files, .lxi, .put, etc. all land in the pytest-owned tempdir) and
+        # pointing GAMS at the repo root via `idir=` so the relative include
+        # resolves against the repo instead of against tmp_path. The `.lst`
+        # path is still pinned via `o=` for the downstream assertion.
         repo_root = Path(__file__).resolve().parents[2]
         lst_file = output_file.with_suffix(".lst")
         gams_result = subprocess.run(
-            ["gams", str(output_file), "lo=0", f"o={lst_file}"],
+            ["gams", str(output_file), "lo=0", f"o={lst_file}", f"idir={repo_root}"],
             capture_output=True,
             text=True,
-            cwd=str(repo_root),
+            cwd=str(tmp_path),
         )
         assert gams_result.returncode == 0, (
             "GAMS solve failed.\n"

--- a/tests/integration/test_nlp_presolve.py
+++ b/tests/integration/test_nlp_presolve.py
@@ -151,15 +151,19 @@ class TestNLPPresolveOutput:
         assert "$offMulti" in presolve_output
 
     def test_has_include(self, presolve_output):
-        """Pre-solve block includes the original source file."""
+        """Pre-solve block includes the original source file via a
+        repo-relative path (#1275): absolute paths leak the developer's
+        workstation layout and make the emitted artifact non-portable.
+        """
         assert "$include" in presolve_output
-        # The include should reference an absolute path
-        include_lines = [line for line in presolve_output.splitlines() if "$include" in line]
-        assert len(include_lines) >= 1
-        # The path should be absolute and quoted
-        include_raw = include_lines[0].split("$include")[1].strip()
+        include_lines = [
+            line for line in presolve_output.splitlines() if line.startswith("$include")
+        ]
+        assert len(include_lines) == 1
+        include_raw = include_lines[0].split("$include", 1)[1].strip()
         include_path = include_raw.strip('"')
-        assert Path(include_path).is_absolute() or include_path.startswith("/")
+        assert not Path(include_path).is_absolute()
+        assert not include_path.startswith("/")
 
     def test_include_references_source_file(self, presolve_output):
         """$include references the original .gms source file."""
@@ -602,12 +606,20 @@ class TestNLPPresolveGAMSSolve:
         )
         assert result.exit_code == 0
 
-        # Solve with GAMS
+        # Solve with GAMS. After #1275 the emitted presolve wrapper uses a
+        # repo-relative `$include` path (e.g., `data/gamslib/raw/bearing.gms`),
+        # so GAMS must be invoked with the repo root as cwd for the include
+        # to resolve. We also route the listing file back to `tmp_path` via
+        # `o=` so the later `output_file.with_suffix('.lst')` assertion still
+        # finds it. This mirrors the intended usage: artifacts are portable
+        # when re-run from the repo root.
+        repo_root = Path(__file__).resolve().parents[2]
+        lst_file = output_file.with_suffix(".lst")
         gams_result = subprocess.run(
-            ["gams", str(output_file), "lo=0"],
+            ["gams", str(output_file), "lo=0", f"o={lst_file}"],
             capture_output=True,
             text=True,
-            cwd=str(tmp_path),
+            cwd=str(repo_root),
         )
         assert gams_result.returncode == 0, (
             "GAMS solve failed.\n"
@@ -615,8 +627,7 @@ class TestNLPPresolveGAMSSolve:
             f"stderr:\n{gams_result.stderr}"
         )
 
-        # Check listing file
-        lst_file = output_file.with_suffix(".lst")
+        # Check listing file (path was computed above and passed to GAMS via `o=`).
         assert lst_file.exists(), "GAMS listing file not created"
         lst_content = lst_file.read_text()
 

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -95,14 +95,18 @@ class TestIncludePathPortability:
     def test_out_of_repo_source_skips_presolve_entirely_with_warning(
         self, tmp_path, manual_index_mapping
     ):
-        """Source outside repo root → NO pre-solve block + UserWarning.
+        """Source outside repo root → NO runnable pre-solve content +
+        self-documenting commented banner + UserWarning.
 
         The earlier draft commented out the `$include` but still emitted the
         dual-transfer assignments. Those transfers reference original NLP
         equation names that only come into scope via the `$include`, so the
         resulting artifact wouldn't compile in GAMS without manual edits.
         The emitter now takes the stricter "skip the whole warm-start"
-        branch — the MCP itself remains runnable without the pre-solve.
+        branch — the MCP itself remains runnable, and a short `*`-commented
+        banner in the emitted file explains why the warm-start was dropped
+        (so a downstream reader of `<model>_mcp_presolve.gms` doesn't have
+        to cross-reference the Python warning).
 
         `tmp_path` is a pytest-guaranteed directory outside the repo, so it
         exercises the reject branch without depending on any OS layout.
@@ -114,14 +118,35 @@ class TestIncludePathPortability:
         with pytest.warns(UserWarning, match="outside the repo root"):
             output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
 
-        # Nothing presolve-related should be in the output: no include
-        # (active or commented), no $onMultiR/$offMulti bookends, no
-        # NLP-Pre-Solve banner, no dual transfer lines referencing
-        # original (undeclared) equation names.
-        for needle in ("$include", "$onMultiR", "$offMulti", "NLP Pre-Solve"):
-            assert (
-                needle not in output
-            ), f"expected no {needle!r} when source is outside repo root, got:\n{output}"
+        # No runnable pre-solve content: no $include line (active OR
+        # commented), no $onMultiR/$offMulti bookends, and (crucially) no
+        # warm-start banner or dual-transfer assignments that would reference
+        # undeclared equation names.
+        #
+        # Line-prefix checks avoid false positives from the explanatory
+        # banner (which mentions `$include` as prose) and from any hypothetical
+        # substring matches elsewhere in the emitted GAMS.
+        output_lines = output.splitlines()
+        for line in output_lines:
+            stripped = line.lstrip()
+            assert not stripped.startswith("$include"), (
+                f"expected no active $include line when source is outside "
+                f"repo root, got: {line!r}"
+            )
+            assert not stripped.startswith("*$include"), (
+                f"expected no commented $include line, got: {line!r}"
+            )
+        for needle in ("$onMultiR", "$offMulti", "NLP Pre-Solve (warm-start for MCP duals)"):
+            assert needle not in output, (
+                f"expected no {needle!r} when source is outside repo root, got:\n{output}"
+            )
+
+        # But the emitted file DOES contain a short `*`-commented banner
+        # explaining why the pre-solve block was omitted, so the artifact
+        # remains self-documenting.
+        assert "NLP Pre-Solve omitted" in output
+        assert "outside the repo root" in output
+        assert "#1275" in output
 
     def test_in_repo_source_includes_onmulti_bookends(self, manual_index_mapping):
         """In-repo sources get the `$onMultiR` / `$offMulti` bookends around

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -3,12 +3,14 @@
 Emits an MCP with `nlp_presolve=True` against a synthetic model, then asserts:
   - the emitted `$include` is repo-relative when the source lives under the
     repo root, and
-  - when the source is outside the repo root, the ENTIRE pre-solve block
-    (banner, $onMultiR/$offMulti bookends, $include, dual transfers) is
-    skipped and a `UserWarning` fires. Skipping the whole block is
-    necessary because the dual-transfer assignments reference original
-    equation names that only come into scope via the `$include`; emitting
-    them without a working include produces a `.gms` that won't compile.
+  - when the source is outside the repo root, the runnable pre-solve
+    content ($onMultiR/$offMulti bookends, $include, dual transfers) is
+    skipped and replaced with a short `*`-commented banner explaining the
+    omission. A `UserWarning` fires in parallel. Skipping the runnable
+    block is necessary because the dual-transfer assignments reference
+    original equation names that only come into scope via the `$include`;
+    emitting them without a working include would produce a `.gms` that
+    won't compile.
 
 Running the emitter end-to-end (rather than unit-testing a private helper)
 keeps the test resilient to internal refactors; the contract asserted here
@@ -133,13 +135,13 @@ class TestIncludePathPortability:
                 f"expected no active $include line when source is outside "
                 f"repo root, got: {line!r}"
             )
-            assert not stripped.startswith("*$include"), (
-                f"expected no commented $include line, got: {line!r}"
-            )
+            assert not stripped.startswith(
+                "*$include"
+            ), f"expected no commented $include line, got: {line!r}"
         for needle in ("$onMultiR", "$offMulti", "NLP Pre-Solve (warm-start for MCP duals)"):
-            assert needle not in output, (
-                f"expected no {needle!r} when source is outside repo root, got:\n{output}"
-            )
+            assert (
+                needle not in output
+            ), f"expected no {needle!r} when source is outside repo root, got:\n{output}"
 
         # But the emitted file DOES contain a short `*`-commented banner
         # explaining why the pre-solve block was omitted, so the artifact

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -112,7 +112,11 @@ class TestIncludePathPortability:
         ), f"expected no active $include for out-of-repo source, got {active_lines!r}"
         commented = [line for line in output.splitlines() if line.startswith("*$include")]
         assert len(commented) == 1
-        assert str(external_source) in commented[0]
+        # The emitter writes the absolute path via `Path.as_posix()`, which on
+        # Windows produces `C:/...` while `str(Path(...))` produces `C:\...`.
+        # Compare against the POSIX form on both sides so this test passes on
+        # Linux/macOS runners *and* Windows.
+        assert external_source.resolve().as_posix() in commented[0]
 
     def test_includes_onmulti_directive_regardless_of_path_branch(
         self, tmp_path, manual_index_mapping

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -1,16 +1,19 @@
 """Unit tests for #1275: `$include` path portability in `_emit_nlp_presolve`.
 
-Emits an MCP with `nlp_presolve=True` against a synthetic model, then asserts
-the emitted `$include` directive is:
-  - repo-relative when the source file lives under the repo root, and
-  - commented out + accompanied by a `UserWarning` when the source is
-    outside the repo root (the artifact is then self-documenting about why
-    it can't be re-run verbatim).
+Emits an MCP with `nlp_presolve=True` against a synthetic model, then asserts:
+  - the emitted `$include` is repo-relative when the source lives under the
+    repo root, and
+  - when the source is outside the repo root, the ENTIRE pre-solve block
+    (banner, $onMultiR/$offMulti bookends, $include, dual transfers) is
+    skipped and a `UserWarning` fires. Skipping the whole block is
+    necessary because the dual-transfer assignments reference original
+    equation names that only come into scope via the `$include`; emitting
+    them without a working include produces a `.gms` that won't compile.
 
 Running the emitter end-to-end (rather than unit-testing a private helper)
 keeps the test resilient to internal refactors; the contract asserted here
 is the surface the issue report cares about (the text of the `$include`
-line in `<model>_mcp_presolve.gms`).
+line — or its absence — in `<model>_mcp_presolve.gms`).
 """
 
 from __future__ import annotations
@@ -89,15 +92,20 @@ class TestIncludePathPortability:
         include_line = _extract_include_line(output)
         assert "\\" not in include_line
 
-    def test_out_of_repo_source_emits_commented_include_with_warning(
+    def test_out_of_repo_source_skips_presolve_entirely_with_warning(
         self, tmp_path, manual_index_mapping
     ):
-        """Source outside repo root → commented `*$include ...` + UserWarning.
+        """Source outside repo root → NO pre-solve block + UserWarning.
 
-        The test uses `tmp_path` as the fake-external source location —
-        `tmp_path` is a pytest-guaranteed directory that is NOT under the
-        repo root, so it exercises the portability-reject branch without
-        depending on any specific OS layout.
+        The earlier draft commented out the `$include` but still emitted the
+        dual-transfer assignments. Those transfers reference original NLP
+        equation names that only come into scope via the `$include`, so the
+        resulting artifact wouldn't compile in GAMS without manual edits.
+        The emitter now takes the stricter "skip the whole warm-start"
+        branch — the MCP itself remains runnable without the pre-solve.
+
+        `tmp_path` is a pytest-guaranteed directory outside the repo, so it
+        exercises the reject branch without depending on any OS layout.
         """
         kkt = _toy_kkt(manual_index_mapping)
         external_source = tmp_path / "external_model.gms"
@@ -106,37 +114,24 @@ class TestIncludePathPortability:
         with pytest.warns(UserWarning, match="outside the repo root"):
             output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
 
-        active_lines = [line for line in output.splitlines() if line.startswith("$include")]
-        assert (
-            active_lines == []
-        ), f"expected no active $include for out-of-repo source, got {active_lines!r}"
-        commented = [line for line in output.splitlines() if line.startswith("*$include")]
-        assert len(commented) == 1
-        # The emitter writes the absolute path via `Path.as_posix()`, which on
-        # Windows produces `C:/...` while `str(Path(...))` produces `C:\...`.
-        # Compare against the POSIX form on both sides so this test passes on
-        # Linux/macOS runners *and* Windows.
-        assert external_source.resolve().as_posix() in commented[0]
+        # Nothing presolve-related should be in the output: no include
+        # (active or commented), no $onMultiR/$offMulti bookends, no
+        # NLP-Pre-Solve banner, no dual transfer lines referencing
+        # original (undeclared) equation names.
+        for needle in ("$include", "$onMultiR", "$offMulti", "NLP Pre-Solve"):
+            assert (
+                needle not in output
+            ), f"expected no {needle!r} when source is outside repo root, got:\n{output}"
 
-    def test_includes_onmulti_directive_regardless_of_path_branch(
-        self, tmp_path, manual_index_mapping
-    ):
-        """Both the in-repo and out-of-repo paths preserve the $onMultiR /
-        $offMulti bookends (needed so the pre-solve block doesn't conflict
-        with the MCP's own symbol declarations).
+    def test_in_repo_source_includes_onmulti_bookends(self, manual_index_mapping):
+        """In-repo sources get the `$onMultiR` / `$offMulti` bookends around
+        the `$include`. These are needed so the pre-solve block can redefine
+        MCP symbols without conflict.
         """
         kkt = _toy_kkt(manual_index_mapping)
-        external_source = tmp_path / "external_model.gms"
-        external_source.write_text("* stub file\n")
+        source = REPO_ROOT / "examples" / "simple_nlp.gms"
 
-        with pytest.warns(UserWarning):
-            out_external = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
-        out_in_repo = emit_gams_mcp(
-            kkt,
-            nlp_presolve=True,
-            source_file=str(REPO_ROOT / "examples" / "simple_nlp.gms"),
-        )
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(source))
 
-        for out in (out_external, out_in_repo):
-            assert "$onMultiR" in out
-            assert "$offMulti" in out
+        assert "$onMultiR" in output
+        assert "$offMulti" in output

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -1,0 +1,138 @@
+"""Unit tests for #1275: `$include` path portability in `_emit_nlp_presolve`.
+
+Emits an MCP with `nlp_presolve=True` against a synthetic model, then asserts
+the emitted `$include` directive is:
+  - repo-relative when the source file lives under the repo root, and
+  - commented out + accompanied by a `UserWarning` when the source is
+    outside the repo root (the artifact is then self-documenting about why
+    it can't be re-run verbatim).
+
+Running the emitter end-to-end (rather than unit-testing a private helper)
+keeps the test resilient to internal refactors; the contract asserted here
+is the surface the issue report cares about (the text of the `$include`
+line in `<model>_mcp_presolve.gms`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ad.gradient import GradientVector
+from src.ad.jacobian import JacobianStructure
+from src.emit.emit_gams import emit_gams_mcp
+from src.ir.ast import Binary, Const, VarRef
+from src.ir.model_ir import ModelIR, ObjectiveIR
+from src.ir.symbols import EquationDef, ObjSense, Rel, VariableDef
+from src.kkt.assemble import assemble_kkt_system
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _toy_kkt(manual_index_mapping):
+    """Minimal 1-variable / 1-equation KKT system for presolve emission.
+
+    Mirrors the fixture used elsewhere in `test_nlp_presolve.py`; kept local
+    so this file has no cross-module dependency on that test's helpers.
+    """
+    model = ModelIR()
+    model.objective = ObjectiveIR(sense=ObjSense.MIN, objvar="z")
+    model.equations["zdef"] = EquationDef(
+        name="zdef",
+        domain=(),
+        relation=Rel.EQ,
+        lhs_rhs=(VarRef("z", ()), Binary("^", VarRef("x", ()), Const(2.0))),
+    )
+    model.variables["z"] = VariableDef(name="z", domain=())
+    model.variables["x"] = VariableDef(name="x", domain=(), lo=0.0)
+    model.equalities = ["zdef"]
+    model.model_equations = ["zdef"]
+
+    idx = manual_index_mapping([("z", ()), ("x", ())])
+    grad = GradientVector(num_cols=2, index_mapping=idx)
+    grad.set_derivative(1, Binary("*", Const(2.0), VarRef("x", ())))
+    J_eq = JacobianStructure(num_rows=0, num_cols=2, index_mapping=idx)
+    J_ineq = JacobianStructure(num_rows=0, num_cols=2, index_mapping=idx)
+    return assemble_kkt_system(model, grad, J_eq, J_ineq)
+
+
+def _extract_include_line(output: str) -> str:
+    """Return the single non-commented `$include` line from the emitter output."""
+    lines = [line for line in output.splitlines() if line.startswith("$include")]
+    assert len(lines) == 1, f"expected exactly one $include line, got {lines!r}"
+    return lines[0]
+
+
+class TestIncludePathPortability:
+    """#1275: emitted `$include` must not leak the developer's workstation path."""
+
+    def test_in_repo_source_emits_relative_path(self, manual_index_mapping):
+        """Source under the repo root → `$include "data/gamslib/raw/..."`."""
+        kkt = _toy_kkt(manual_index_mapping)
+        in_repo_source = REPO_ROOT / "examples" / "simple_nlp.gms"
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(in_repo_source))
+
+        include_line = _extract_include_line(output)
+        raw = include_line.split("$include", 1)[1].strip().strip('"')
+        assert not Path(raw).is_absolute()
+        assert raw == "examples/simple_nlp.gms"
+
+    def test_in_repo_source_always_forward_slashes(self, manual_index_mapping):
+        """The emitted path uses POSIX separators even on Windows runners."""
+        kkt = _toy_kkt(manual_index_mapping)
+        source = REPO_ROOT / "examples" / "simple_nlp.gms"
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(source))
+
+        include_line = _extract_include_line(output)
+        assert "\\" not in include_line
+
+    def test_out_of_repo_source_emits_commented_include_with_warning(
+        self, tmp_path, manual_index_mapping
+    ):
+        """Source outside repo root → commented `*$include ...` + UserWarning.
+
+        The test uses `tmp_path` as the fake-external source location —
+        `tmp_path` is a pytest-guaranteed directory that is NOT under the
+        repo root, so it exercises the portability-reject branch without
+        depending on any specific OS layout.
+        """
+        kkt = _toy_kkt(manual_index_mapping)
+        external_source = tmp_path / "external_model.gms"
+        external_source.write_text("* stub file\n")
+
+        with pytest.warns(UserWarning, match="outside the repo root"):
+            output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
+
+        active_lines = [line for line in output.splitlines() if line.startswith("$include")]
+        assert (
+            active_lines == []
+        ), f"expected no active $include for out-of-repo source, got {active_lines!r}"
+        commented = [line for line in output.splitlines() if line.startswith("*$include")]
+        assert len(commented) == 1
+        assert str(external_source) in commented[0]
+
+    def test_includes_onmulti_directive_regardless_of_path_branch(
+        self, tmp_path, manual_index_mapping
+    ):
+        """Both the in-repo and out-of-repo paths preserve the $onMultiR /
+        $offMulti bookends (needed so the pre-solve block doesn't conflict
+        with the MCP's own symbol declarations).
+        """
+        kkt = _toy_kkt(manual_index_mapping)
+        external_source = tmp_path / "external_model.gms"
+        external_source.write_text("* stub file\n")
+
+        with pytest.warns(UserWarning):
+            out_external = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
+        out_in_repo = emit_gams_mcp(
+            kkt,
+            nlp_presolve=True,
+            source_file=str(REPO_ROOT / "examples" / "simple_nlp.gms"),
+        )
+
+        for out in (out_external, out_in_repo):
+            assert "$onMultiR" in out
+            assert "$offMulti" in out


### PR DESCRIPTION
## Summary

Sprint 25 Day 2 deliverables landed in a single PR (two independent commits — reviewable separately):

- **#1275** — `--nlp-presolve` artifacts now emit a portable repo-relative `$include` path instead of the developer's absolute workstation path.
- **WS1 Phase 1 scaffolding** — env-gated debug logging in `_diff_varref` / `_partial_collapse_sum` so tomorrow's prototype for the multi-index concrete→symbolic gap can iterate on a real qabel trace.

## #1275: Repo-relative `$include` (commit `809b5008`)

The emitter at `src/emit/emit_gams.py:933` called `Path(source_file).resolve().as_posix()` and baked `/Users/<dev>/experiments/nlp2mcp/data/gamslib/raw/<model>.gms` into every committed `_mcp_presolve.gms` artifact, defeating the artifact's reproducibility purpose.

After this PR:

- A new `_REPO_ROOT` anchor (computed from `__file__`) resolves the source file relative to the repo.
- **In-repo source**: emit `$include "data/gamslib/raw/<model>.gms"`. GAMS invoked from the repo root resolves the include cleanly.
- **Out-of-repo source**: no portable reference exists. The emitter skips the *runnable* pre-solve content entirely (no `$onMultiR`/`$offMulti` bookends, no `$include` — active or commented — and no dual-transfer assignments that would reference undeclared equation names). In its place it writes a short `*`-commented banner into the generated GAMS explaining the omission, and fires a `UserWarning`. The resulting MCP stays runnable without the warm-start; a downstream reader of `<model>_mcp_presolve.gms` sees the explanation inline. (Earlier drafts during review iterated through two alternatives — active absolute `$include` with warning, then commented-out `*$include` — but both produced un-runnable artifacts because the dual transfers reference original NLP equation names that come into scope only via the `$include`.)

Banner format:

```
* ============================================
* NLP Pre-Solve omitted: source file is outside the repo root
* (#1275 — no portable $include path; re-run with the source
* under the repo root to enable warm-start).
* ============================================
```

`tests/integration/test_nlp_presolve.py`:
- `test_has_include` flipped to reject absolute paths.
- `test_bearing_solves_with_presolve` runs GAMS from the repo root (so the relative include resolves) and routes the listing file back to `tmp_path` via `o=<...>.lst`.

New unit-test file `tests/unit/emit/test_nlp_presolve_include_path.py` (4 tests): in-repo relative emission, POSIX separators, out-of-repo banner + no runnable pre-solve + `UserWarning`, in-repo `$onMultiR`/`$offMulti` bookends.

Committed `data/gamslib/mcp/*_mcp_presolve.gms` still carry the old absolute paths — per `ISSUE_1275.md` "Out of Scope", they'll regenerate cleanly on the next pipeline run; no manual cleanup needed here.

## WS1: `SPRINT25_DAY2` AD instrumentation (commit `75a49479`)

Added env-gated tracing in `src/ad/derivative_rules.py`:

- `SPRINT25_DAY2_DEBUG=1` enables `[SPRINT25_DAY2][diff_varref]` + `[SPRINT25_DAY2][partial_collapse_sum]` stderr logs. Zero cost in production: every call site wraps message construction in `if _SPRINT25_DAY2_DEBUG:` so the f-strings (including `expr.body!r`) never evaluate when the env var is unset.
- `_diff_varref` logs only after the name check, keeping output focused on candidate sites.
- `_partial_collapse_sum` logs entry, candidate enumeration, every enumerated matching, the before/after diff, and the `matched→concrete` substitution step.

Captured the qabel trace under this env var (231k lines at `/tmp/qabel_trace.stderr`) and wrote findings at `/tmp/sprint25-phase1-findings.md` for the Day 3 prototype brief:

- Identifies the fix target: port Sprint 24's `_find_var_indices_in_body` recovery from `_diff_sum` lines 1958–1985 into `_partial_collapse_sum`.
- Describes the qabel call tree and walks matching `(1, 0)` end-to-end.
- Flags open questions (`_same_root_set('k', 'q1', aliases)` behavior; renamed-index interaction with `bound_indices` propagation).

Instrumentation stays in-tree through Day 3 iteration; cleanup in the Day 4 sweep after Phase 1 lands.

## Canary / tests

- Tier 0 dispatch canary: diff against `/tmp/sprint25-golden/dispatch_mcp.gms` is empty.
- `make typecheck && make lint && make format`: clean.
- `make test`: **4559 passed**, 10 skipped, 1 xfailed. One flake on `tests/unit/emit/test_sprint23_day1.py::TestExprBasedBoundsForComplementarity::test_rocket_expr_bound_emitted` reproduced once under `-n auto`; passed solo and on the rerun of the full parallel suite. Unrelated to either WS surface — the failure message references rocket bound emission, not presolve or AD paths.

## Test plan

- [x] New unit tests (`test_nlp_presolve_include_path.py`) cover in-repo, out-of-repo (banner + no runnable content + warning), POSIX, and in-repo bookend invariants
- [x] Existing integration tests updated for the repo-relative contract
- [x] Tier 0 dispatch canary unchanged
- [x] Full suite green (modulo the `test_rocket_expr_bound_emitted` flake — please rerun if it recurs in CI)
- [x] `SPRINT25_DAY2_DEBUG=1` trace reproduces on qabel with no runtime impact when unset
