### PR TITLE
Sprint 25 Day 3: #1280 UEL-dot fix + multi-index _partial_collapse_sum recovery

### DIFF
--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -2443,20 +2443,35 @@ def _partial_collapse_sum(
         # Substitute the symbolic names that were actually used in the body
         # diff back to their concrete wrt values. This spans both the
         # `matched_sum_indices` (for positions where no recovery happened)
-        # and any body-free indices recovered above. We dedupe on symbolic
-        # name to avoid `_substitute_sum_indices` overwriting an earlier
-        # entry when alias matching mapped multiple wrt positions to the
-        # same body index.
+        # and any body-free indices recovered above. Two wrt positions may
+        # share the same symbolic name (alias matching can route them both
+        # through the same sum index): dedupe when the concrete values
+        # agree; skip the whole matching when they conflict, since
+        # `_substitute_sum_indices` uses a dict and would silently drop one
+        # side of the conflict. This mirrors the `duplicate_sym` guard in
+        # the single-index recovery path (derivative_rules.py:2012-2033).
         sub_sym: list[str] = []
         sub_concrete: list[str | IndexOffset] = []
-        seen_sym: set[str] = set()
+        seen_substitutions: dict[str, str | IndexOffset] = {}
+        invalid_substitution = False
         for sub_entry, sub_concrete_val in zip(symbolic_wrt, matched_concrete, strict=True):
             key = sub_entry.base if isinstance(sub_entry, IndexOffset) else sub_entry
-            if key in seen_sym:
+            if key in seen_substitutions:
+                if seen_substitutions[key] != sub_concrete_val:
+                    invalid_substitution = True
+                    if _SPRINT25_DAY2_DEBUG:
+                        _sprint25_day2_log(
+                            "partial_collapse_sum",
+                            "skip: conflicting duplicate symbolic substitution for "
+                            f"{key!r}: {seen_substitutions[key]!r} vs {sub_concrete_val!r}",
+                        )
+                    break
                 continue
-            seen_sym.add(key)
+            seen_substitutions[key] = sub_concrete_val
             sub_sym.append(key)
             sub_concrete.append(sub_concrete_val)
+        if invalid_substitution:
+            continue
         result_body = _substitute_sum_indices(body_derivative, tuple(sub_sym), tuple(sub_concrete))
         if _SPRINT25_DAY2_DEBUG:
             _sprint25_day2_log(

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -2441,35 +2441,57 @@ def _partial_collapse_sum(
             continue
 
         # Substitute the symbolic names that were actually used in the body
-        # diff back to their concrete wrt values. This spans both the
-        # `matched_sum_indices` (for positions where no recovery happened)
-        # and any body-free indices recovered above. Two wrt positions may
-        # share the same symbolic name (alias matching can route them both
-        # through the same sum index): dedupe when the concrete values
-        # agree; skip the whole matching when they conflict, since
-        # `_substitute_sum_indices` uses a dict and would silently drop one
-        # side of the conflict. This mirrors the `duplicate_sym` guard in
-        # the single-index recovery path (derivative_rules.py:2012-2033).
+        # diff back to their concrete wrt values. ALWAYS substitute the
+        # matched sum index names first (so that any `ParamRef(n,k)` or
+        # condition reference still carrying the original sum-index name
+        # gets rewritten — the recovery loop above only renames VarRef
+        # positions in `symbolic_wrt`, not occurrences elsewhere in the
+        # body). Then layer on substitutions for any recovered body-free
+        # names in `symbolic_wrt` that differ from the matched name.
+        #
+        # Two wrt positions may share the same symbolic name (alias matching
+        # can route them both through the same sum index): dedupe when the
+        # concrete values agree; skip the whole matching when they conflict,
+        # since `_substitute_sum_indices` uses a dict and would silently
+        # drop one side of the conflict. This mirrors the `duplicate_sym`
+        # guard in the single-index recovery path
+        # (derivative_rules.py:2012-2033).
         sub_sym: list[str] = []
         sub_concrete: list[str | IndexOffset] = []
         seen_substitutions: dict[str, str | IndexOffset] = {}
         invalid_substitution = False
-        for sub_entry, sub_concrete_val in zip(symbolic_wrt, matched_concrete, strict=True):
+
+        def _add_substitution(
+            sub_entry: str | IndexOffset,
+            sub_concrete_val: str | IndexOffset,
+        ) -> bool:
+            """Append (key, concrete) if not seen; return False on conflict."""
             key = sub_entry.base if isinstance(sub_entry, IndexOffset) else sub_entry
             if key in seen_substitutions:
                 if seen_substitutions[key] != sub_concrete_val:
-                    invalid_substitution = True
                     if _SPRINT25_DAY2_DEBUG:
                         _sprint25_day2_log(
                             "partial_collapse_sum",
                             "skip: conflicting duplicate symbolic substitution for "
                             f"{key!r}: {seen_substitutions[key]!r} vs {sub_concrete_val!r}",
                         )
-                    break
-                continue
+                    return False
+                return True
             seen_substitutions[key] = sub_concrete_val
             sub_sym.append(key)
             sub_concrete.append(sub_concrete_val)
+            return True
+
+        for matched_name, matched_value in zip(matched_sum_indices, matched_concrete, strict=True):
+            if not _add_substitution(matched_name, matched_value):
+                invalid_substitution = True
+                break
+        if invalid_substitution:
+            continue
+        for symbolic_name, symbolic_value in zip(symbolic_wrt, matched_concrete, strict=True):
+            if not _add_substitution(symbolic_name, symbolic_value):
+                invalid_substitution = True
+                break
         if invalid_substitution:
             continue
         result_body = _substitute_sum_indices(body_derivative, tuple(sub_sym), tuple(sub_concrete))

--- a/src/ad/derivative_rules.py
+++ b/src/ad/derivative_rules.py
@@ -2325,8 +2325,10 @@ def _partial_collapse_sum(
 
     for matching in all_matchings:
         # matching[i] = index into sum_index_sets for wrt position i
-        matched_sum_indices = [sum_index_sets[matching[i]] for i in range(len(wrt_indices))]
-        matched_concrete = list(wrt_indices)
+        matched_sum_indices: list[str] = [
+            sum_index_sets[matching[i]] for i in range(len(wrt_indices))
+        ]
+        matched_concrete: list[str | IndexOffset] = list(wrt_indices)
         matched_set = set(matching)
         remaining_sum_indices = [
             sum_index_sets[si] for si in range(len(sum_index_sets)) if si not in matched_set
@@ -2369,7 +2371,7 @@ def _partial_collapse_sum(
                     )
                 final_remaining[ri] = new_name
 
-        # Build symbolic wrt: for each wrt position, use the matched sum index name
+        # Build symbolic wrt: for each wrt position, use the matched sum index name.
         wrt_to_symbolic: list[str | IndexOffset] = []
         for wi, wrt_idx in enumerate(wrt_indices):
             sym_name = matched_sum_indices[wi]
@@ -2377,6 +2379,41 @@ def _partial_collapse_sum(
                 wrt_to_symbolic.append(IndexOffset(sym_name, wrt_idx.offset, wrt_idx.circular))
             else:
                 wrt_to_symbolic.append(sym_name)
+
+        # Sprint 25 Phase 1 (#1111 multi-index port): when the body's VarRefs
+        # reference a FREE symbolic index that differs from the matched sum
+        # index name (possible under aliasing, e.g. sum((n,np), x(a,b)) where
+        # a,b are outer domain names that the concrete wrt values are
+        # instances of), prefer the body's free name over the matched sum
+        # index. Without this recovery the body-diff would return 0 because
+        # `x(a,b)` w.r.t. `(n, np)` doesn't structurally match and neither
+        # the standard indices_match nor _alias_match handle the case.
+        #
+        # This is the multi-index analog of the single-index path's
+        # `_find_var_indices_in_body` logic at lines 1985-2007.
+        var_indices_in_body: list[tuple[str | IndexOffset, ...]] = []
+        body_bound_for_recovery: set[str] = set(sum_index_sets) | set(final_remaining)
+        if config is not None and config.model_ir is not None:
+            var_indices_in_body = _find_var_indices_in_body(working_body, wrt_var)
+            _collect_bound_indices(working_body, body_bound_for_recovery)
+        if var_indices_in_body:
+            for wi, wrt_idx in enumerate(wrt_indices):
+                current_sym = wrt_to_symbolic[wi]
+                if isinstance(current_sym, IndexOffset):
+                    continue
+                if isinstance(wrt_idx, IndexOffset):
+                    continue
+                for var_idx_tuple in var_indices_in_body:
+                    if wi < len(var_idx_tuple):
+                        body_idx = var_idx_tuple[wi]
+                        if (
+                            isinstance(body_idx, str)
+                            and body_idx != current_sym
+                            and body_idx not in body_bound_for_recovery
+                            and _is_concrete_instance_of(wrt_idx, body_idx, config)
+                        ):
+                            wrt_to_symbolic[wi] = body_idx
+                            break
 
         symbolic_wrt: tuple[str | IndexOffset, ...] = tuple(wrt_to_symbolic)
         # Augment bound_indices with remaining (uncollapsed) sum indices
@@ -2403,10 +2440,24 @@ def _partial_collapse_sum(
                 _sprint25_day2_log("partial_collapse_sum", "skip: body_derivative is Const(0.0)")
             continue
 
-        # Substitute matched sum indices with their concrete values
-        result_body = _substitute_sum_indices(
-            body_derivative, tuple(matched_sum_indices), tuple(matched_concrete)
-        )
+        # Substitute the symbolic names that were actually used in the body
+        # diff back to their concrete wrt values. This spans both the
+        # `matched_sum_indices` (for positions where no recovery happened)
+        # and any body-free indices recovered above. We dedupe on symbolic
+        # name to avoid `_substitute_sum_indices` overwriting an earlier
+        # entry when alias matching mapped multiple wrt positions to the
+        # same body index.
+        sub_sym: list[str] = []
+        sub_concrete: list[str | IndexOffset] = []
+        seen_sym: set[str] = set()
+        for sub_entry, sub_concrete_val in zip(symbolic_wrt, matched_concrete, strict=True):
+            key = sub_entry.base if isinstance(sub_entry, IndexOffset) else sub_entry
+            if key in seen_sym:
+                continue
+            seen_sym.add(key)
+            sub_sym.append(key)
+            sub_concrete.append(sub_concrete_val)
+        result_body = _substitute_sum_indices(body_derivative, tuple(sub_sym), tuple(sub_concrete))
         if _SPRINT25_DAY2_DEBUG:
             _sprint25_day2_log(
                 "partial_collapse_sum",

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -20,6 +20,7 @@ from src.emit.original_symbols import (
     _quote_assignment_index,
     _quote_symbol,
     _sanitize_set_element,
+    _sanitize_uel_element,
     collect_missing_param_labels,
     compute_set_assignment_param_deps,
     emit_computed_parameter_assignments,
@@ -1172,7 +1173,11 @@ def emit_gams_mcp(
     # re-introducing explicit zeros into parameter data.
     missing_labels = collect_missing_param_labels(kkt.model_ir)
     if missing_labels:
-        quoted = ", ".join(_sanitize_set_element(str(lab)) for lab in sorted(missing_labels))
+        # #1280: unconditionally single-quote UEL registry elements so that
+        # attribute-access labels like `x1.l` are treated as literal UELs by
+        # GAMS instead of being parsed as 2-tuple notation (which rejects the
+        # set declaration or silently truncates to `x1`).
+        quoted = ", ".join(_sanitize_uel_element(str(lab)) for lab in sorted(missing_labels))
         # Choose a unique name that doesn't collide with existing symbols.
         uel_name = "nlp2mcp_uel_registry"
         existing_lower = (

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -1173,10 +1173,14 @@ def emit_gams_mcp(
     # re-introducing explicit zeros into parameter data.
     missing_labels = collect_missing_param_labels(kkt.model_ir)
     if missing_labels:
-        # #1280: unconditionally single-quote UEL registry elements so that
-        # attribute-access labels like `x1.l` are treated as literal UELs by
-        # GAMS instead of being parsed as 2-tuple notation (which rejects the
-        # set declaration or silently truncates to `x1`).
+        # #1280: sanitize UEL registry elements so that attribute-access
+        # labels like `x1.l` are treated as literal UELs by GAMS instead of
+        # being parsed as 2-tuple notation (which rejects the set
+        # declaration or silently truncates to `x1`). `_sanitize_uel_element`
+        # single-quotes ordinary labels but intentionally passes two shapes
+        # through unchanged: labels already wrapped in single quotes by the
+        # base sanitizer, and GUSS trailing-dot tuple forms like `foo.''`
+        # (whose tuple semantics would be destroyed by outer quoting).
         quoted = ", ".join(_sanitize_uel_element(str(lab)) for lab in sorted(missing_labels))
         # Choose a unique name that doesn't collide with existing symbols.
         uel_name = "nlp2mcp_uel_registry"

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -236,6 +236,34 @@ def _quote_assignment_index(
     return idx
 
 
+def _sanitize_uel_element(element: str) -> str:
+    """Sanitize a UEL registry element, unconditionally single-quoting the result.
+
+    The generic `_sanitize_set_element` treats a dot as GAMS tuple notation
+    (e.g., `upper.egypt` as a 2-tuple label) and so leaves `x1.l` unquoted.
+    That's the right call for ordinary set members, but the
+    `nlp2mcp_uel_registry` set (emit_gams.py) stores LITERAL attribute-access
+    strings (`x1.l`, `x2.l`) produced by zero-filtered parameter lookups. GAMS
+    interprets those as tuple UELs and either rejects the declaration or
+    silently truncates to the first component.
+
+    Fix per ISSUE_1280: run the element through the normal sanitizer (so the
+    dangerous-character rejection still applies) and then quote the result if
+    it wasn't already quoted. GAMS accepts `'foo'` identically to `foo` for
+    plain identifiers, so unconditional quoting has no downside.
+    """
+    sanitized = _sanitize_set_element(element)
+    # `_sanitize_set_element` returns a pre-quoted string unchanged and also
+    # quotes elements that contain spaces, `+`/`-`, or reserved constants.
+    if len(sanitized) >= 2 and sanitized.startswith("'") and sanitized.endswith("'"):
+        return sanitized
+    # GUSS trailing-dot case: `_sanitize_set_element` restores it as
+    # `foo.''` — leave that compound form intact.
+    if sanitized.endswith("''"):
+        return sanitized
+    return "'" + sanitized.replace("'", "''") + "'"
+
+
 def _sanitize_set_element(element: str) -> str:
     """Sanitize a set element name for safe GAMS emission.
 

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -237,7 +237,7 @@ def _quote_assignment_index(
 
 
 def _sanitize_uel_element(element: str) -> str:
-    """Sanitize a UEL registry element, unconditionally single-quoting the result.
+    """Sanitize a UEL registry element and single-quote scalar results.
 
     The generic `_sanitize_set_element` treats a dot as GAMS tuple notation
     (e.g., `upper.egypt` as a 2-tuple label) and so leaves `x1.l` unquoted.
@@ -251,6 +251,19 @@ def _sanitize_uel_element(element: str) -> str:
     dangerous-character rejection still applies) and then quote the result if
     it wasn't already quoted. GAMS accepts `'foo'` identically to `foo` for
     plain identifiers, so unconditional quoting has no downside.
+
+    Two outputs are passed through without wrapping in an outer pair of
+    single quotes:
+
+    - Already-quoted results from `_sanitize_set_element` (e.g., `'foo-bar'`
+      or `'SAE 10'`). Re-quoting would produce `''foo-bar''`.
+    - The GUSS 3-tuple trailing-dot form `foo.''`, which the base sanitizer
+      synthesises from a trailing-dot input. This is intentionally a tuple
+      reference — wrapping it in outer quotes would turn it into the label
+      `'foo.'''`, losing the 3-tuple semantics.
+
+    Callers that need literal quoting of every input should not rely on
+    this helper for the two shapes above.
     """
     sanitized = _sanitize_set_element(element)
     # `_sanitize_set_element` returns a pre-quoted string unchanged and also

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -257,10 +257,13 @@ def _sanitize_uel_element(element: str) -> str:
 
     - Already-quoted results from `_sanitize_set_element` (e.g., `'foo-bar'`
       or `'SAE 10'`). Re-quoting would produce `''foo-bar''`.
-    - The GUSS 3-tuple trailing-dot form `foo.''`, which the base sanitizer
-      synthesises from a trailing-dot input. This is intentionally a tuple
-      reference — wrapping it in outer quotes would turn it into the label
-      `'foo.'''`, losing the 3-tuple semantics.
+    - The GUSS trailing-dot tuple form (e.g., `foo.''` for a 2-tuple,
+      `rapscenarios.scenario.''` for a 3-tuple — see issue #910), which
+      the base sanitizer synthesises from a trailing-dot input. This is
+      intentionally a tuple reference with an empty trailing component —
+      wrapping it in outer quotes would turn it into the label
+      `'foo.'''` / `'rapscenarios.scenario.'''`, losing the tuple
+      semantics.
 
     Callers that need literal quoting of every input should not rely on
     this helper for the two shapes above.

--- a/tests/integration/emit/test_emit_full.py
+++ b/tests/integration/emit/test_emit_full.py
@@ -412,9 +412,7 @@ class TestFullGAMSEmission:
         # source is outside the repo root (it has no portable $include
         # path). Use an in-repo path so this test continues to exercise the
         # presolve structure rather than the soft-skip branch.
-        output = emit_gams_mcp(
-            kkt, nlp_presolve=True, source_file="examples/simple_nlp.gms"
-        )
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file="examples/simple_nlp.gms")
 
         # Pre-solve block should be present
         assert "$onMultiR" in output

--- a/tests/unit/ad/test_sum_aggregation.py
+++ b/tests/unit/ad/test_sum_aggregation.py
@@ -676,3 +676,99 @@ def test_diff_nested_sum_no_spurious_inner_sum():
     assert not _has_spurious_sum_cr_const(
         result
     ), f"Result contains spurious sum(cr, const): {result}"
+
+
+def test_diff_partial_collapse_sum_recovers_outer_domain_free_index():
+    """Sprint 25 #1111 multi-index port: d/dx(consumpt, q1) on a sum whose
+    body references a DIFFERENT domain name than the sum's own indices
+    must recover the body's name during partial collapse.
+
+    Shape:
+      - sum((n, np, k), x(m, k) * w(n, np, m, k))
+      - n, np are aliases. m is a separate set whose members overlap with n.
+      - wrt = (consumpt, q1). consumpt is a member of both `n` and `m`.
+
+    Without the multi-index recovery ported from the single-index path,
+    `_partial_collapse_sum` would pick matching (n=consumpt, k=q1) and ask
+    `_diff_varref(x(m, k), 'x', ('n', 'k'), ...)`. That returns `Const(0.0)`
+    because `m != n` and no alias relationship is declared between them.
+
+    With the recovery: the body's `x(m, k)` has position-0 index `m`, which
+    is a FREE symbolic name (not in sum_index_sets). `consumpt` is a
+    concrete instance of `m`, so the recovery rewrites `symbolic_wrt` from
+    `('n', 'k')` to `('m', 'k')`. The body diff then structurally matches,
+    producing `Const(1.0)` in the relevant factor.
+    """
+    from src.config import Config
+    from src.ir.model_ir import ModelIR
+    from src.ir.symbols import AliasDef, SetDef
+
+    model = ModelIR()
+    model.sets["n"] = SetDef(name="n", domain=(), members=["consumpt", "invest"])
+    model.sets["m"] = SetDef(name="m", domain=(), members=["consumpt", "invest"])
+    model.sets["k"] = SetDef(name="k", domain=(), members=["q1", "q2"])
+    model.aliases["np"] = AliasDef(name="np", target="n")
+
+    config = Config()
+    config.model_ir = model
+
+    # body: x(m, k) * w(n, np, m, k)
+    body = Binary(
+        "*",
+        VarRef("x", ("m", "k")),
+        ParamRef("w", ("n", "np", "m", "k")),
+    )
+    sum_expr = Sum(("n", "np", "k"), body, None)
+
+    # d/dx(consumpt, q1) — _partial_collapse_sum because 3 sum dims > 2 wrt dims.
+    result = differentiate_expr(sum_expr, "x", ("consumpt", "q1"), config)
+
+    from src.ad.derivative_rules import _is_structurally_zero
+
+    assert not _is_structurally_zero(result), (
+        f"Expected non-zero derivative when body's outer domain name "
+        f"(`m`) differs from the sum's matched index name (`n`); got: {result}"
+    )
+
+
+def test_diff_partial_collapse_sum_drops_conflicting_duplicate_substitution():
+    """Sprint 25 #1111 multi-index port: when the recovery plus alias
+    matching would map two different wrt concrete values to the same
+    symbolic substitution key, the matching must be skipped (not silently
+    drop one side via `_substitute_sum_indices`'s dict overwrite).
+
+    Shape:
+      - sum((n, np), x(m, m) * ...)  — body uses `m` at BOTH positions.
+      - wrt = ('consumpt', 'invest'); both are members of `m`.
+      - For matching (n=consumpt, np=invest), recovery rewrites positions
+        0 and 1 to 'm' — but they map to DIFFERENT concretes (consumpt vs
+        invest). The substitution is invalid; that matching is skipped.
+      - (The other matching, (np=consumpt, n=invest), would have the same
+        conflict — both matchings skipped, `_partial_collapse_sum` returns
+        None, falls through to the normal body-diff path.)
+
+    The visible invariant asserted here is that the call doesn't crash and
+    doesn't emit a corrupted derivative with one concrete silently lost.
+    """
+    from src.config import Config
+    from src.ir.model_ir import ModelIR
+    from src.ir.symbols import AliasDef, SetDef
+
+    model = ModelIR()
+    model.sets["n"] = SetDef(name="n", domain=(), members=["consumpt", "invest"])
+    model.sets["m"] = SetDef(name="m", domain=(), members=["consumpt", "invest"])
+    model.aliases["np"] = AliasDef(name="np", target="n")
+
+    config = Config()
+    config.model_ir = model
+
+    # body: x(m, m) — both positions index the same outer set `m`.
+    body = VarRef("x", ("m", "m"))
+    sum_expr = Sum(("n", "np"), body, None)
+
+    # Should not raise; should fall through to normal path, producing
+    # something finite (may be zero after the body-diff path discovers
+    # the structural mismatch, but must not be a crashing TypeError or a
+    # silently-wrong derivative).
+    result = differentiate_expr(sum_expr, "x", ("consumpt", "invest"), config)
+    assert result is not None

--- a/tests/unit/ad/test_sum_aggregation.py
+++ b/tests/unit/ad/test_sum_aggregation.py
@@ -738,18 +738,31 @@ def test_diff_partial_collapse_sum_drops_conflicting_duplicate_substitution():
     drop one side via `_substitute_sum_indices`'s dict overwrite).
 
     Shape:
-      - sum((n, np), x(m, m) * ...)  — body uses `m` at BOTH positions.
-      - wrt = ('consumpt', 'invest'); both are members of `m`.
-      - For matching (n=consumpt, np=invest), recovery rewrites positions
-        0 and 1 to 'm' — but they map to DIFFERENT concretes (consumpt vs
-        invest). The substitution is invalid; that matching is skipped.
-      - (The other matching, (np=consumpt, n=invest), would have the same
-        conflict — both matchings skipped, `_partial_collapse_sum` returns
-        None, falls through to the normal body-diff path.)
+      - `sum((n, np, k), x(m, m))` — 3 sum indices, 2 wrt indices, which
+        is required for `_partial_collapse_sum` to be invoked at all
+        (`_diff_sum`'s full-collapse path only fires when sum and wrt have
+        the same arity).
+      - body uses `m` at BOTH VarRef positions; `m` is a separate set
+        whose members are {consumpt, invest}.
+      - wrt = ('consumpt', 'invest').
+      - Both enumerated matchings ((n=consumpt, np=invest) and (np=consumpt,
+        n=invest)) hit the recovery, which rewrites `symbolic_wrt` to
+        `('m', 'm')`. The substitution-builder's second pass then tries to
+        map `m → consumpt` AND `m → invest` for the same matching — the
+        `_add_substitution` guard flags this as `invalid_substitution` and
+        the matching is skipped.
+      - Every matching is skipped → `_partial_collapse_sum` returns None,
+        `_diff_sum` falls through to the normal body-diff path (which also
+        can't match `x(m,m)` to `(consumpt, invest)` without the recovery),
+        and the overall derivative is structurally zero.
 
-    The visible invariant asserted here is that the call doesn't crash and
-    doesn't emit a corrupted derivative with one concrete silently lost.
+    The alternative behavior the guard prevents is one of the concretes
+    being silently lost by `_substitute_sum_indices`'s dict overwrite,
+    yielding a corrupted Sum result. This test asserts both that
+    `_partial_collapse_sum` returns None on the conflict and that the
+    top-level derivative is structurally zero.
     """
+    from src.ad.derivative_rules import _partial_collapse_sum
     from src.config import Config
     from src.ir.model_ir import ModelIR
     from src.ir.symbols import AliasDef, SetDef
@@ -757,6 +770,7 @@ def test_diff_partial_collapse_sum_drops_conflicting_duplicate_substitution():
     model = ModelIR()
     model.sets["n"] = SetDef(name="n", domain=(), members=["consumpt", "invest"])
     model.sets["m"] = SetDef(name="m", domain=(), members=["consumpt", "invest"])
+    model.sets["k"] = SetDef(name="k", domain=(), members=["q1", "q2"])
     model.aliases["np"] = AliasDef(name="np", target="n")
 
     config = Config()
@@ -764,11 +778,27 @@ def test_diff_partial_collapse_sum_drops_conflicting_duplicate_substitution():
 
     # body: x(m, m) — both positions index the same outer set `m`.
     body = VarRef("x", ("m", "m"))
-    sum_expr = Sum(("n", "np"), body, None)
+    sum_expr = Sum(("n", "np", "k"), body, None)
 
-    # Should not raise; should fall through to normal path, producing
-    # something finite (may be zero after the body-diff path discovers
-    # the structural mismatch, but must not be a crashing TypeError or a
-    # silently-wrong derivative).
+    # Direct check: `_partial_collapse_sum` returns None because every
+    # candidate matching hits the conflicting-duplicate guard.
+    partial_result = _partial_collapse_sum(sum_expr, "x", ("consumpt", "invest"), config)
+    assert partial_result is None, (
+        f"expected `_partial_collapse_sum` to skip all matchings on the "
+        f"conflicting duplicate and return None, got: {partial_result!r}"
+    )
+
+    # End-to-end via the public dispatcher: the normal-path fallback
+    # wraps the body diff in `Sum((n,np,k), <body diff>)`, and the body
+    # diff itself is zero because `x(m,m)` can't match `(consumpt, invest)`
+    # via alias matching either. The critical invariant is that no
+    # corrupted VarRef with one side partially substituted leaks through
+    # — the skip-on-conflict guard plus the normal-path fallback together
+    # must produce an expression whose body-diff position is `Const(0.0)`,
+    # not a silently-wrong `x(m, invest)` or `x(consumpt, m)`.
     result = differentiate_expr(sum_expr, "x", ("consumpt", "invest"), config)
-    assert result is not None
+    assert isinstance(result, Sum), f"expected Sum fallback, got: {result!r}"
+    assert isinstance(result.body, Const) and result.body.value == 0.0, (
+        f"expected Sum body to be Const(0.0) after all matchings skipped, "
+        f"got body={result.body!r}"
+    )

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -3330,9 +3330,10 @@ class TestSanitizeUelElement:
       - labels already wrapped in single quotes by the base sanitizer
         (e.g., `'foo-bar'`, `'SAE 10'`); re-quoting would produce
         `''foo-bar''`.
-      - the GUSS 3-tuple trailing-dot form `foo.''`; outer quotes would
-        collapse it to the scalar label `'foo.'''`, losing the tuple
-        semantics.
+      - the GUSS 3-tuple trailing-dot form `rapscenarios.scenario.''`
+        (see issue #910 for the canonical shape); outer quotes would
+        collapse it to the scalar label `'rapscenarios.scenario.'''`,
+        losing the tuple semantics.
     """
 
     def test_dotted_attribute_label_gets_quoted(self):

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -16,6 +16,7 @@ from src.emit.original_symbols import (
     _needs_quoting,
     _quote_assignment_index,
     _sanitize_set_element,
+    _sanitize_uel_element,
     collect_missing_param_labels,
     emit_computed_parameter_assignments,
     emit_interleaved_params_and_sets,
@@ -3313,3 +3314,59 @@ class TestLoopAttrAccessEmission:
         result = emit_pre_solve_param_assignments(model)
         assert "myparam" in result
         assert "x.scaleOpt" in result
+
+
+@pytest.mark.unit
+class TestSanitizeUelElement:
+    """#1280: `_sanitize_uel_element` unconditionally quotes UEL registry labels.
+
+    The generic `_sanitize_set_element` treats a dot as GAMS tuple notation
+    (so `x1.l` is left unquoted). That's wrong for the `nlp2mcp_uel_registry`
+    set whose members are LITERAL attribute-access strings produced by
+    zero-filtered parameter lookups — GAMS interprets them as tuple UELs and
+    either rejects the declaration or silently truncates to the first
+    component. The UEL-specific helper forces quoting.
+    """
+
+    def test_dotted_attribute_label_gets_quoted(self):
+        """`x1.l` → `'x1.l'` (the #1280 bug)."""
+        assert _sanitize_uel_element("x1.l") == "'x1.l'"
+        assert _sanitize_uel_element("x2.l") == "'x2.l'"
+        assert _sanitize_uel_element("y.m") == "'y.m'"
+
+    def test_plain_identifier_gets_quoted(self):
+        """Plain identifiers are still quoted (GAMS accepts 'foo' === foo)."""
+        assert _sanitize_uel_element("demand") == "'demand'"
+        assert _sanitize_uel_element("i1") == "'i1'"
+
+    def test_prequoted_element_passes_through(self):
+        """Already-quoted labels are returned as-is, not double-quoted."""
+        assert _sanitize_uel_element("'SAE 10'") == "'SAE 10'"
+        assert _sanitize_uel_element("'max-stock'") == "'max-stock'"
+
+    def test_element_with_hyphen_gets_single_quoted(self):
+        """Hyphenated labels (already quoted by the base sanitizer) stay as single-quoted."""
+        assert _sanitize_uel_element("gov-expend") == "'gov-expend'"
+
+    def test_element_with_plus_gets_single_quoted(self):
+        assert _sanitize_uel_element("food+agr") == "'food+agr'"
+
+    def test_reserved_constants_get_quoted(self):
+        """Reserved constants (already quoted by base) remain quoted, not double-quoted."""
+        assert _sanitize_uel_element("inf") == "'inf'"
+        assert _sanitize_uel_element("na") == "'na'"
+
+    def test_dangerous_chars_still_rejected(self):
+        """`_sanitize_uel_element` routes through `_sanitize_set_element` first,
+        so injection-dangerous characters are still rejected."""
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _sanitize_uel_element("bad;element")
+        with pytest.raises(ValueError, match="unsafe characters"):
+            _sanitize_uel_element("bad/element")
+
+    def test_guss_trailing_dot_preserved(self):
+        """GUSS 3-tuple with empty trailing component (e.g.,
+        `rapscenarios.scenario.''`) must keep its `.''` structure — the UEL
+        helper should not re-quote that compound form.
+        """
+        assert _sanitize_uel_element("foo.") == "foo.''"

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -3373,8 +3373,9 @@ class TestSanitizeUelElement:
             _sanitize_uel_element("bad/element")
 
     def test_guss_trailing_dot_preserved(self):
-        """GUSS 3-tuple with empty trailing component (e.g.,
-        `rapscenarios.scenario.''`) must keep its `.''` structure — the UEL
-        helper should not re-quote that compound form.
+        """GUSS trailing-dot tuple form with an empty trailing component
+        (e.g., the 2-tuple `foo.''` asserted below, or the 3-tuple
+        `rapscenarios.scenario.''` from issue #910) must keep its `.''`
+        structure — the UEL helper should not re-quote that compound form.
         """
         assert _sanitize_uel_element("foo.") == "foo.''"

--- a/tests/unit/emit/test_original_symbols.py
+++ b/tests/unit/emit/test_original_symbols.py
@@ -3318,14 +3318,21 @@ class TestLoopAttrAccessEmission:
 
 @pytest.mark.unit
 class TestSanitizeUelElement:
-    """#1280: `_sanitize_uel_element` unconditionally quotes UEL registry labels.
+    """#1280: `_sanitize_uel_element` quotes UEL registry labels with known exceptions.
 
     The generic `_sanitize_set_element` treats a dot as GAMS tuple notation
     (so `x1.l` is left unquoted). That's wrong for the `nlp2mcp_uel_registry`
     set whose members are LITERAL attribute-access strings produced by
     zero-filtered parameter lookups — GAMS interprets them as tuple UELs and
     either rejects the declaration or silently truncates to the first
-    component. The UEL-specific helper forces quoting.
+    component. The UEL-specific helper therefore forces quoting for ordinary
+    unquoted labels, while preserving two shapes as-is:
+      - labels already wrapped in single quotes by the base sanitizer
+        (e.g., `'foo-bar'`, `'SAE 10'`); re-quoting would produce
+        `''foo-bar''`.
+      - the GUSS 3-tuple trailing-dot form `foo.''`; outer quotes would
+        collapse it to the scalar label `'foo.'''`, losing the tuple
+        semantics.
     """
 
     def test_dotted_attribute_label_gets_quoted(self):


### PR DESCRIPTION
## Summary

Sprint 25 Day 3 deliverables on one branch, two independent commits:

- **#1280 (`f95346e8`)** — `nlp2mcp_uel_registry` now single-quotes every element, so mathopt4's attribute-access UELs (`x1.l`, `x2.l`) parse as literal labels instead of tuple notation.
- **WS1 Phase 1 prototype (`8f9fa7a5`)** — multi-index `_partial_collapse_sum` gets the Sprint 24 `_find_var_indices_in_body` recovery ported in. Zero behavior change on the 54-model matching corpus; defensive groundwork for the #1089 Pattern A fix.

## #1280: Quote dotted UEL labels (commit `f95346e8`)

The emitter at `src/emit/emit_gams.py:1175` used `_sanitize_set_element` to format each element of `nlp2mcp_uel_registry`. That helper treats `.` as GAMS tuple notation (e.g., `upper.egypt` as a 2-tuple label), so attribute-access labels like `x1.l` / `x2.l` went out unquoted. GAMS then either rejects the declaration or silently truncates each label at the dot.

New behavior:

- `src/emit/original_symbols.py::_sanitize_uel_element` — unconditionally single-quotes the sanitized result. Routes through the existing `_sanitize_set_element` first, so dangerous-character rejection and pre-quoted pass-through still apply.
- `src/emit/emit_gams.py` calls the new helper at the `nlp2mcp_uel_registry` emission site.

Verified locally: mathopt4 now emits
```
Set nlp2mcp_uel_registry / 'x1.l', 'x1_0', 'x2.l', 'x2_0' /;
```

8 new unit tests in `TestSanitizeUelElement`: dotted attr labels, plain identifiers, pre-quoted pass-through, hyphen/plus handling, reserved constants, dangerous-character rejection, GUSS trailing-dot 3-tuples.

Committed `data/gamslib/mcp/*_mcp.gms` that use the registry (ferts, imsl, indus, korcge, lmp2, saras, turkey) will regenerate with quoted elements on the next pipeline run — no manual cleanup needed in this PR.

## WS1 Phase 1 prototype (commit `8f9fa7a5`)

Port of Sprint 24's single-index `_find_var_indices_in_body` recovery (`derivative_rules.py:1985-2007`) into the multi-index `_partial_collapse_sum`. Before the body-diff, scan the (renamed) working body's VarRefs at each wrt position; if the body uses a FREE symbolic index (not in `sum_index_sets + final_remaining`) that the concrete wrt value belongs to, swap the matched sum index name for the body's free index.

This handles the alias-of-outer-domain shape described in `docs/planning/EPIC_4/SPRINT_25/AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern A. After the diff, the substitution list is rebuilt from the actual `symbolic_wrt` (not `matched_sum_indices`) with name-dedup, so alias matches that collapsed two wrt positions onto the same symbolic index don't overwrite each other.

**Day 3 exit criterion** — "≥1 of {qabel, abel, launch} improves rel_diff by ≥50%" — is **NOT met** by this PR:

- qabel, abel, launch all diff-clean vs Day 2 goldens; the recovery loop finds nothing to swap because the body already references the sum's own index names in those models.
- The actual Pattern A manifestation in {qabel, abel, launch} is a different shape that needs targeted investigation (captured in `/tmp/sprint25-phase1-findings.md`).

The port is **defensive**: zero regression on the 54-model corpus, correct groundwork for future Pattern A shapes where the body uses a synthetic-alias outer domain, and leaves the #1089 core gap visible for a follow-up prototype.

## Canary / tests

- **Tier 0 dispatch canary**: byte-identical to `/tmp/sprint25-golden/dispatch_mcp.gms`.
- **Tier 1 canaries (quocge, partssupply, prolog)**: byte-identical.
- **54-model golden sweep** (enumerated from `gamslib_status.json::comparison_status == match`): `ok=54 diff=0`. None of the 54 matching models exercise the UEL registry path, so the #1280 quoting change has no effect on their output.
- **`make typecheck && make lint && make format`**: clean.
- **`make test`**: 4567 passed (+8 from the new `TestSanitizeUelElement` class), 10 skipped, 1 xfailed.

## Test plan

- [x] 8 new unit tests for `_sanitize_uel_element` cover the #1280 bug pattern + existing quoting semantics
- [x] `mathopt4` translate manually verified — `'x1.l'`, `'x2.l'` emitted correctly
- [x] 54-model golden sweep: zero diff
- [x] `_partial_collapse_sum` port preserves output on qabel/abel/launch and the Tier 0/1 canaries
- [x] Full suite green (`4567 passed`)