### PR TITLE
Sprint 25 Day 4: #1289 ganges calibration emission + Phase 1 Gate 1 NO-GO

### DIFF
--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -2515,6 +2515,44 @@ def emit_gams_mcp(
     if nlp_presolve:
         _emit_nlp_presolve(sections, kkt, add_comments, source_file)
 
+    # Issue #1289: post-initial-solve calibration assignments that read `.l`
+    # values (e.g., `deltas(i)$ls.l(i) = (k(i)/ls.l(i))**(...)` in
+    # ganges/gangesx). These are stripped from the pre-Variables pass above
+    # (`varref_filter="no_varref_attr"`) because `.l` can't be referenced
+    # before Variables are declared. They can only run AFTER a solve has
+    # populated `.l` — in the `--nlp-presolve` flow that's the $include of
+    # the original NLP above. Without that include, `.l` is uninitialized
+    # and the calibration would produce UNDF / divide-by-zero, so we gate
+    # on `nlp_presolve` being active and the source file being portable
+    # (i.e., `_emit_nlp_presolve` actually emitted the include rather than
+    # falling into the #1275 soft-skip branch for an out-of-repo source).
+    if nlp_presolve and source_file is not None:
+        try:
+            Path(source_file).resolve().relative_to(_REPO_ROOT)
+            presolve_include_emitted = True
+        except ValueError:
+            presolve_include_emitted = False
+        if presolve_include_emitted:
+            calibration_code = emit_computed_parameter_assignments(
+                kkt.model_ir,
+                varref_filter="only_varref_attr",
+                exclude_params=_merge_exclude_params(
+                    early_params if early_params else None,
+                    non_model_params,
+                ),
+            )
+            if calibration_code:
+                if add_comments:
+                    sections.append("* ============================================")
+                    sections.append(
+                        "* Post-initial-solve calibration (#1289): parameters "
+                        "computed from `.l` values set by the pre-solve $include above."
+                    )
+                    sections.append("* ============================================")
+                    sections.append("")
+                sections.append(calibration_code)
+                sections.append("")
+
     # Solve statement
     if add_comments:
         sections.append("* ============================================")

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -900,7 +900,7 @@ def _emit_nlp_presolve(
     kkt: KKTSystem,
     add_comments: bool,
     source_file: str | None = None,
-) -> None:
+) -> bool:
     """Emit NLP pre-solve block to warm-start MCP dual variables.
 
     Includes and solves the original NLP model, then transfers equation
@@ -910,18 +910,25 @@ def _emit_nlp_presolve(
 
     The approach re-solves the original NLP (via ``$include``) because
     the MCP's comp_* equation forms can confuse NLP solvers.
+
+    Returns True iff the `$include`-based pre-solve block was actually
+    emitted (i.e., `.l` will be populated at runtime before the MCP
+    Solve). Callers that want to emit `.l`-referencing code (e.g., the
+    #1289 post-initial-solve calibration assignments) should gate on
+    this return value — an early-return path here means no `$include`,
+    so `.l` stays uninitialized.
     """
     if not source_file:
-        return
+        return False
 
     obj_info = extract_objective_info(kkt.model_ir)
     if not obj_info.objvar:
-        return
+        return False
 
     # Collect original model equations (not generated fix/bound equations)
     nlp_eqs = kkt.model_ir.get_solved_model_equations()
     if not nlp_eqs:
-        return
+        return False
 
     # #1275: resolve the source path before committing any output to `sections`.
     # If the source lives under the repo root we emit a portable
@@ -967,7 +974,7 @@ def _emit_nlp_presolve(
                 "repo root (no portable $include path)."
             )
             sections.append("")
-        return
+        return False
 
     # Build sets of equality/inequality names for sign handling
     eq_set = set(kkt.model_ir.equalities)
@@ -1050,6 +1057,7 @@ def _emit_nlp_presolve(
         )
 
     sections.append("")
+    return True
 
 
 def emit_gams_mcp(
@@ -2512,8 +2520,9 @@ def emit_gams_mcp(
     # close to the NLP solution to converge. This solves the original NLP
     # first, then transfers the primal levels and equation marginals to
     # the MCP multiplier variables.
+    presolve_include_emitted = False
     if nlp_presolve:
-        _emit_nlp_presolve(sections, kkt, add_comments, source_file)
+        presolve_include_emitted = _emit_nlp_presolve(sections, kkt, add_comments, source_file)
 
     # Issue #1289: post-initial-solve calibration assignments that read `.l`
     # values (e.g., `deltas(i)$ls.l(i) = (k(i)/ls.l(i))**(...)` in
@@ -2523,35 +2532,30 @@ def emit_gams_mcp(
     # populated `.l` — in the `--nlp-presolve` flow that's the $include of
     # the original NLP above. Without that include, `.l` is uninitialized
     # and the calibration would produce UNDF / divide-by-zero, so we gate
-    # on `nlp_presolve` being active and the source file being portable
-    # (i.e., `_emit_nlp_presolve` actually emitted the include rather than
-    # falling into the #1275 soft-skip branch for an out-of-repo source).
-    if nlp_presolve and source_file is not None:
-        try:
-            Path(source_file).resolve().relative_to(_REPO_ROOT)
-            presolve_include_emitted = True
-        except ValueError:
-            presolve_include_emitted = False
-        if presolve_include_emitted:
-            calibration_code = emit_computed_parameter_assignments(
-                kkt.model_ir,
-                varref_filter="only_varref_attr",
-                exclude_params=_merge_exclude_params(
-                    early_params if early_params else None,
-                    non_model_params,
-                ),
-            )
-            if calibration_code:
-                if add_comments:
-                    sections.append("* ============================================")
-                    sections.append(
-                        "* Post-initial-solve calibration (#1289): parameters "
-                        "computed from `.l` values set by the pre-solve $include above."
-                    )
-                    sections.append("* ============================================")
-                    sections.append("")
-                sections.append(calibration_code)
+    # on `_emit_nlp_presolve` having actually emitted the include. Its
+    # early-return paths cover: a falsy source file, a missing objective
+    # variable, a model with no solved equations, or a source outside the
+    # repo root (#1275 soft-skip banner branch).
+    if presolve_include_emitted:
+        calibration_code = emit_computed_parameter_assignments(
+            kkt.model_ir,
+            varref_filter="only_varref_attr",
+            exclude_params=_merge_exclude_params(
+                early_params if early_params else None,
+                non_model_params,
+            ),
+        )
+        if calibration_code:
+            if add_comments:
+                sections.append("* ============================================")
+                sections.append(
+                    "* Post-initial-solve calibration (#1289): parameters "
+                    "computed from `.l` values set by the pre-solve $include above."
+                )
+                sections.append("* ============================================")
                 sections.append("")
+            sections.append(calibration_code)
+            sections.append("")
 
     # Solve statement
     if add_comments:

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -281,3 +281,41 @@ class TestCalibrationDeferredEmission:
 
         assert "Post-initial-solve calibration" not in output
         assert "calib = x.l" not in output
+
+    def test_calibration_skipped_when_presolve_requested_but_no_source_file(
+        self, manual_index_mapping
+    ):
+        """`nlp_presolve=True` but `source_file=None` → `_emit_nlp_presolve`
+        early-returns without emitting the `$include`, so the post-solve
+        calibration must also be skipped (otherwise the emitted MCP would
+        reference uninitialized `.l` values at runtime).
+
+        Regression test for the gap flagged in PR #1304 review: the
+        original caller gated calibration on the repo-root check alone,
+        which passed when `source_file` was falsy (the relative_to check
+        was never reached), leaving calibration emitted without a
+        matching `$include`.
+        """
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=None)
+
+        assert "Post-initial-solve calibration" not in output
+        assert "calib = x.l" not in output
+
+    def test_calibration_skipped_when_no_solved_model_equations(self, manual_index_mapping):
+        """`nlp_presolve=True` + in-repo source, but no solved-model
+        equations → `_emit_nlp_presolve` early-returns (no dual-transfer
+        lines to emit), so the `$include` that would populate `.l` never
+        fires either. Calibration must therefore be skipped.
+        """
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+        # Clear the list of solved-model equations so
+        # `get_solved_model_equations()` returns something falsy.
+        kkt.model_ir.model_equations = []
+        source = REPO_ROOT / "examples" / "simple_nlp.gms"
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(source))
+
+        assert "Post-initial-solve calibration" not in output
+        assert "calib = x.l" not in output

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -167,9 +167,13 @@ class TestIncludePathPortability:
 def _kkt_with_calibration_param(manual_index_mapping):
     """Minimal KKT system whose ModelIR has one calibration parameter (a
     parameter whose `expressions` RHS references a VarRef with `.l`). The
-    pre-Variables emission pass filters this out (it's in the
-    `only_varref_attr` set); the #1289 deferred pass should emit it when
-    `nlp_presolve=True` and the source is in-repo.
+    pre-Variables emission pass runs `emit_computed_parameter_assignments`
+    under `varref_filter="no_varref_attr"`, which skips this RHS because
+    it contains a `.l` attribute access; the #1289 deferred pass re-runs
+    the same emitter under `varref_filter="only_varref_attr"` after the
+    NLP `$include` populates `.l`, and that pass is the one expected to
+    emit the calibration assignment when `nlp_presolve=True` and the
+    source is in-repo.
     """
     from src.ir.ast import ParamRef
     from src.ir.symbols import ParameterDef
@@ -270,8 +274,6 @@ class TestCalibrationDeferredEmission:
         rely on the include populating `.l` — is also skipped. Otherwise
         the emitted MCP would reference uninitialized `.l` values.
         """
-        import pytest
-
         kkt = _kkt_with_calibration_param(manual_index_mapping)
         external_source = tmp_path / "external.gms"
         external_source.write_text("* stub\n")

--- a/tests/unit/emit/test_nlp_presolve_include_path.py
+++ b/tests/unit/emit/test_nlp_presolve_include_path.py
@@ -162,3 +162,122 @@ class TestIncludePathPortability:
 
         assert "$onMultiR" in output
         assert "$offMulti" in output
+
+
+def _kkt_with_calibration_param(manual_index_mapping):
+    """Minimal KKT system whose ModelIR has one calibration parameter (a
+    parameter whose `expressions` RHS references a VarRef with `.l`). The
+    pre-Variables emission pass filters this out (it's in the
+    `only_varref_attr` set); the #1289 deferred pass should emit it when
+    `nlp_presolve=True` and the source is in-repo.
+    """
+    from src.ir.ast import ParamRef
+    from src.ir.symbols import ParameterDef
+
+    model = ModelIR()
+    model.objective = ObjectiveIR(sense=ObjSense.MIN, objvar="z")
+    # Equation body uses `calib` so the param is model-relevant (not filtered
+    # out by the emitter's non-model-param exclusion at #1036).
+    model.equations["zdef"] = EquationDef(
+        name="zdef",
+        domain=(),
+        relation=Rel.EQ,
+        lhs_rhs=(
+            VarRef("z", ()),
+            Binary("+", Binary("^", VarRef("x", ()), Const(2.0)), ParamRef("calib", ())),
+        ),
+    )
+    model.variables["z"] = VariableDef(name="z", domain=())
+    model.variables["x"] = VariableDef(name="x", domain=(), lo=0.0)
+    model.equalities = ["zdef"]
+    model.model_equations = ["zdef"]
+    # `calib` mirrors the ganges pattern: declared without values, assigned
+    # from a variable's .l level after an initial solve. `VarRef.attribute`
+    # carries the `.l` access (see src/ir/ast.py:53).
+    model.params["calib"] = ParameterDef(
+        name="calib",
+        domain=(),
+        values={},
+        expressions=[((), VarRef("x", (), attribute="l"))],
+    )
+
+    idx = manual_index_mapping([("z", ()), ("x", ())])
+    grad = GradientVector(num_cols=2, index_mapping=idx)
+    grad.set_derivative(1, Binary("*", Const(2.0), VarRef("x", ())))
+    J_eq = JacobianStructure(num_rows=0, num_cols=2, index_mapping=idx)
+    J_ineq = JacobianStructure(num_rows=0, num_cols=2, index_mapping=idx)
+    return assemble_kkt_system(model, grad, J_eq, J_ineq)
+
+
+class TestCalibrationDeferredEmission:
+    """#1289: post-initial-solve calibration assignments referencing `.l`
+    values must be emitted AFTER the `--nlp-presolve` $include (which
+    populates `.l` by running the original NLP) and BEFORE the MCP Solve.
+
+    Without the #1289 fix the emitter strips these assignments entirely
+    (they're filtered by `varref_filter="no_varref_attr"` in the pre-
+    Variables pass because `.l` can't be referenced before Variables are
+    declared), leaving parameters undefined at Solve time — GAMS then
+    raises Error 66 on every stationarity equation that reads them.
+    """
+
+    def test_calibration_emitted_with_presolve_and_in_repo_source(self, manual_index_mapping):
+        """`nlp_presolve=True` + in-repo source → calibration assignment
+        emitted with the #1289 banner.
+        """
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+        source = REPO_ROOT / "examples" / "simple_nlp.gms"
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(source))
+
+        assert "Post-initial-solve calibration (#1289)" in output
+        # The calibration assignment itself should be present.
+        assert "calib = x.l" in output
+
+    def test_calibration_emitted_after_presolve_include(self, manual_index_mapping):
+        """The calibration must be emitted AFTER the `$include` (which
+        populates `.l`) and BEFORE the `Solve mcp_model` (which needs the
+        calibrated values).
+        """
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+        source = REPO_ROOT / "examples" / "simple_nlp.gms"
+
+        output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(source))
+
+        include_pos = output.index("$include")
+        calib_pos = output.index("calib = x.l")
+        solve_pos = output.index("Solve mcp_model")
+        assert include_pos < calib_pos < solve_pos, (
+            f"expected $include < calibration < Solve; got positions "
+            f"include={include_pos} calib={calib_pos} solve={solve_pos}"
+        )
+
+    def test_calibration_skipped_without_presolve(self, manual_index_mapping):
+        """`nlp_presolve=False` → calibration is NOT emitted (without the
+        $include to populate `.l`, the calibration would divide by zero /
+        produce UNDF per the pre-existing #985 blanket-skip).
+        """
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+
+        output = emit_gams_mcp(kkt, nlp_presolve=False)
+
+        assert "Post-initial-solve calibration" not in output
+        assert "calib = x.l" not in output
+
+    def test_calibration_skipped_when_source_outside_repo(self, tmp_path, manual_index_mapping):
+        """`nlp_presolve=True` but source outside repo root → the presolve
+        include is soft-skipped (#1275), so the calibration — which would
+        rely on the include populating `.l` — is also skipped. Otherwise
+        the emitted MCP would reference uninitialized `.l` values.
+        """
+        import pytest
+
+        kkt = _kkt_with_calibration_param(manual_index_mapping)
+        external_source = tmp_path / "external.gms"
+        external_source.write_text("* stub\n")
+
+        with pytest.warns(UserWarning, match="outside the repo root"):
+            output = emit_gams_mcp(kkt, nlp_presolve=True, source_file=str(external_source))
+
+        assert "Post-initial-solve calibration" not in output
+        assert "calib = x.l" not in output


### PR DESCRIPTION
## Summary

Sprint 25 Day 4 on `main`. Two deliverables:

- **WS2 #1289 (commit `0ed6b386`)** — emit post-initial-solve calibration assignments under `--nlp-presolve`. Eliminates the 16 × Error 66 in ganges/gangesx that #1289 describes.
- **WS1 Phase 1 Gate 1: NO-GO**. Day 3's `_partial_collapse_sum` recovery was confirmed byte-identical on {qabel, abel, launch} vs Day-0 goldens. None of the three Phase 1 targets improved rel_diff — the mechanical port doesn't fit the actual Pattern A shape those three models exercise. Phase 2 should be halted per the plan's gate.

## #1289: Calibration-from-`.l` emission (commit `0ed6b386`)

**Bug**: ganges/gangesx declare parameters (deltas, aid, aex, adst, as, av, deltav, aq, deltaq, az, deltaz, an, deltan, pnm00, cg, deltax) without inline values, then assign them from `.l` values after an initial solve (lines 598–747 in ganges.gms). The emitter's pre-Variables `varref_filter="no_varref_attr"` pass (emit_gams.py:1282) strips these assignments because `.l` can't be referenced before Variables are declared. Net: 16 parameters get declared but never assigned, and the MCP Solve produces 16 × Error 66 on every stationarity equation that reads them.

**Fix**: invoke the existing-but-unused `varref_filter="only_varref_attr"` pass of `emit_computed_parameter_assignments` between `_emit_nlp_presolve` (which runs the original NLP via `$include` and populates `.l`) and the MCP Solve. Gated on `nlp_presolve=True` AND the `source_file` resolving under the repo root (per the #1275 portability contract — if the include was soft-skipped, `.l` is never initialized and the calibration would divide by zero).

Self-documenting banner emitted under `add_comments=True`; the non-presolve path is unchanged so the #985 "avoid div-by-zero on uninitialized `.l`" blanket-skip behavior is preserved.

**Validation**:

| Scenario | Before | After |
|---|---|---|
| ganges, no `--nlp-presolve` | 16 × Error 66 | 16 × Error 66 (unchanged; fix is gated on presolve) |
| ganges, `--nlp-presolve` | 16 × Error 66 | **0 × Error 66** |
| ganges, `--nlp-presolve`, compile-only `action=c` | 69 errors | 69 errors (remaining 63 × 141 + 4 × 184 + 2 × 257 are pre-existing ganges-specific compile-only artifacts on dual-transfer lines — unchanged by this PR) |
| bearing, `--nlp-presolve`, compile-only | clean | clean (control) |

4 new unit tests in `TestCalibrationDeferredEmission`:

- emitted with presolve + in-repo source
- positioned between `$include` and `Solve`
- skipped without presolve
- skipped when source is outside repo (presolve soft-skip)

## WS1 Phase 1 Gate 1: NO-GO

Per the Day 4 prompt's Gate 1: *"dispatch identical + ≤1 Tier 1 regression + ≥1 of 3 targets improves ≥50% → GO to Phase 2"*.

| Check | Outcome |
|---|---|
| Tier 0 dispatch (golden diff) | CLEAN ✓ |
| Tier 1 (quocge, partssupply, prolog) | CLEAN ✓ |
| qabel vs Day-0 golden | byte-identical (0 lines diff) |
| abel vs Day-0 golden | byte-identical (0 lines diff) |
| launch vs Day-0 golden | byte-identical (0 lines diff) |
| ≥1 target improved ≥50% rel_diff | **NO** (0 / 3) |

The Day 3 `_partial_collapse_sum` recovery port is defensive: it fires only when body VarRefs reference a FREE outer-domain name that differs from the matched sum index. None of the three Phase 1 targets have that shape — qabel's criterion sum already uses the sum's own indices (`n`, `np`, `k`) in the body, abel is structurally similar, and launch hits Pattern A through an IndexOffset-alias path (`AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern C, deferred to Days 7–9).

**Recommendation** (per the plan as written): halt Phase 2 Day 5. The evidence says the specified Phase 1 fix doesn't move the needle on any of the three target models, so a Phase 2 investment aimed at further elaborating the same hypothesis is not justified.

Two alternate paths, flagged in the commit body for strategic review:
1. **Pause the alias workstream**, reroute remaining sprint budget to the WS2 emitter batch (more `--nlp-presolve`-style catalogued fixes).
2. **Pivot WS1** to evidence-driven work: fresh `SPRINT25_DAY2_DEBUG=1` traces on qabel/abel/launch to identify the *actual* failure shape, then prototype against whatever the trace reveals.

Deferred to your call.

## Canary / tests

- **54-model golden sweep**: `ok=54 diff=0`. None of the 54 matching models emit calibration params, so this PR has no effect on their output.
- **Tier 0 + Tier 1 canaries**: CLEAN.
- `make typecheck && make lint && make format`: clean.
- `make test`: **4573 passed** (+4 new), 10 skipped, 1 xfailed.

## Test plan

- [x] 4 new unit tests for `TestCalibrationDeferredEmission` cover gated emission
- [x] ganges compiles with `--nlp-presolve` → 16 × Error 66 gone
- [x] 54-model golden sweep clean
- [x] Full suite green
- [x] Gate 1 NO-GO flagged for Phase 2 strategy decision