### PR TITLE
Sprint 25 Day 5: Phase 1 Pattern A investigation — hypothesis disproved

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -1,0 +1,207 @@
+# Sprint 25 Day 5 — Phase 1 Pattern A Investigation (Evidence-Driven)
+
+**Branch:** `sprint25-day5-pattern-a-investigation`
+**Date:** 2026-04-24
+**Purpose:** Identify the ACTUAL failure shape of qabel, abel, launch (the three
+Phase 1 targets the Day 3 mechanical port of `_find_var_indices_in_body` into
+`_partial_collapse_sum` failed to move). Traces captured at
+`/tmp/sprint25-day5/{qabel,abel,launch}_trace.stderr` (231k / 3k / ~21k lines)
+under `SPRINT25_DAY2_DEBUG=1`.
+
+---
+
+## TL;DR
+
+None of the three Phase 1 targets exhibits a Pattern A bug. Their rel_diff
+mismatches come from **KKT stationarity assembly**, not the AD layer:
+
+- **qabel, abel (rel_diff 0.08, 0.30):** AD criterion derivative is
+  byte-correct (symmetric quadratic form). The mismatch — if it's a real
+  bug at all — lives in the stateq Lagrangian term's sign / offset /
+  domain-condition handling (uses `nu_stateq(n, k-1)` with `$(ord(k) > 1)`
+  where a naïve formulation would expect `nu_stateq(n, k)` with
+  `$(ord(k) >= 2)`; the emitter's declared domain for `nu_stateq` is
+  `(n, k)` shifted vs. the formal `(n, k+1)`, so the `k-1` may be
+  deliberate — needs end-to-end solve to confirm, not action=c).
+
+- **launch (rel_diff 0.17):** Stationarity emitter invents IndexOffset
+  shifts on an alias that has none in the source. `stat_iweight` emits
+  `nu_dweight(s+1)`, `(s+2)`, `(s-1)`, `(s-2)` — none of which appear in
+  the original `dweight(s).. weight(s) =e= sum(ss$ge(ss,s), ...)`. This is
+  **Pattern C** (alias-of-IndexOffset, deferred Days 7–9) manifesting
+  during KKT assembly as an "expand the alias via ±N offsets" strategy.
+
+**Gate 2 (speculated Day 6+): NO-GO for Phase 2 in its original shape.**
+The Phase 1 hypothesis (`_partial_collapse_sum` recovery helps multi-index
+alias cases) is orthogonal to the actual bug surface. Defer the alias
+workstream to Pattern C. Phase 2's "broader Pattern A rollout" should be
+dropped from the sprint.
+
+---
+
+## Evidence — AD layer is correct (qabel / abel)
+
+qabel and abel share the same criterion shape:
+
+```gams
+criterion..
+  j =e= .5 * sum((k, n, np), (x(n,k) - xtilde(n,k))
+                             * w(n, np, k)
+                             * (x(np, k) - xtilde(np, k)));
+```
+
+Expected derivative w.r.t. `x(n_row, k_row)`:
+
+```text
+∂j/∂x(n_row, k_row)
+  = 0.5 * (sum(np, w(n_row, np, k_row) * (x(np, k_row) - xt(np, k_row)))
+         + sum(n,  (x(n, k_row) - xt(n, k_row)) * w(n, n_row, k_row)))
+```
+
+Emitter output for abel's `stat_x(n, k)` criterion portion:
+
+```gams
+0.5 * (sum(np__, (x(np__,k) - xtilde(np__,k)) * w(n, np__, k))
+     + sum(n__,  (x(n__,k)  - xtilde(n__,k))  * w(n__, n, k)))
+```
+
+Byte-for-byte match to the expected form (with `np__`/`n__` being the
+Sprint 24 renamed remaining sum indices). Confirmed via Day 2
+`SPRINT25_DAY2_DEBUG` trace: `_partial_collapse_sum` enumerates both
+alias matchings, recovery doesn't fire (body's indices already match
+the sum's own names), substitution emits correctly.
+
+**The criterion-level AD is correct.** Day 3's port doesn't help because
+there's nothing to help — qabel/abel aren't blocked by Pattern A.
+
+## Evidence — KKT stateq term on qabel/abel
+
+The non-criterion portion of `stat_x(n, k)` in both models:
+
+```gams
++ ((-1) * a(n,n)) * nu_stateq(n,k)
++ (((-1) * a(n+1,n)) * nu_stateq(n+1,k))$(ord(n) <= card(n) - 1)
++ nu_stateq(n, k-1)$(ord(k) > 1)
++ (((-1) * a(n-1,n)) * nu_stateq(n-1,k))$(ord(n) > 1)
+```
+
+Notes:
+
+- `nu_stateq` is declared as `nu_stateq(n, k)` even though the formal
+  domain of `stateq` is `(n, k+1)`. The emitter indexes the multiplier by
+  the pre-shift k, so `nu_stateq(n, k-1)$(ord(k) > 1)` is consistent with
+  the "formal row t = k+1, nu indexed by k = formal_k" convention.
+- The three `a(n±0, n) * nu_stateq(n±0, k)` terms together sum over all
+  `n_e ∈ n` by enumeration (card(n)=2 for abel; the ±1 shifts plus the
+  identity case cover both elements). Mathematically acceptable for this
+  specific set cardinality, but the strategy is fragile.
+
+I can't verify rightness at compile-time (the GAMS `action=c` compile on
+ganges/qabel/abel throws pre-existing Error 141 cascades on dual-transfer
+lines — unrelated to this analysis). A full PATH solve is the only
+ground truth for whether the current stat_x is numerically correct.
+
+**Tentative conclusion:** qabel/abel may be "correct but nonconvex +
+poor init" (rel_diff from solver behavior, not emission) OR may have a
+subtle sign/condition bug in the stateq term. Either way, **Pattern A
+fix in `_partial_collapse_sum` is irrelevant.**
+
+## Evidence — launch's `stat_iweight` is malformed (NOT Pattern A)
+
+Source (`data/gamslib/raw/launch.gms:86`):
+
+```gams
+dweight(s)..  weight(s) =e= sum(ss$ge(ss,s), iweight(ss) + pweight(ss))
+                            + instweight + pl;
+```
+
+One alias (`ss` aliases `s`), one conditional sum. No IndexOffset.
+
+Emitter output (`stat_iweight` body):
+
+```gams
+ iwf(s) * nu_diweight(s)
++ sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s))
++ sum(ss, (((-1) * 1$(ge(ss,s))) * nu_dweight(s+1))$(ord(s) <= card(s) - 1))
++ sum(ss, (((-1) * 1$(ge(ss,s))) * nu_dweight(s+2))$(ord(s) <= card(s) - 2))
++ sum(ss, (((-1) * 1$(ge(ss,s))) * nu_dweight(s-1))$(ord(s) > 1))
++ sum(ss, (((-1) * 1$(ge(ss,s))) * nu_dweight(s-2))$(ord(s) > 2))
+ ...
+```
+
+Two bugs visible in the emission:
+
+1. **Phantom IndexOffsets on `s`.** The source has `sum(ss$ge(ss,s), ...)` — a
+   conditional sum over the alias `ss`, not any lead/lag shifts. But the
+   emitter produces five copies of the term indexed by `s+0, s+1, s+2,
+   s-1, s-2`, presumably trying to enumerate all possible alias bindings
+   via ±N offsets (card(s)=5 for launch's `stages` set). This is
+   **Pattern C** (alias-of-IndexOffset from the AUDIT) manifesting in the
+   KKT stationarity emitter.
+
+2. **Misscoped `$(ge(ss, s))` condition inside an outer sum.** Each of
+   the five `sum(ss, ...)` clauses still has `1$(ge(ss, s))` in the body
+   referencing the sum variable `ss`. But the body multiplies by
+   `nu_dweight(s+N)` (or `(s)`/`(s-N)`), which doesn't depend on `ss` at
+   all. Result: the sum over `ss` degenerates into `card(ss-satisfying-ge) *
+   nu_dweight(s±N)` — a spurious multiplicative factor vs. the expected
+   single-term contribution `$(ge(ss, s))` acting as a gate.
+
+**Pattern A fix in `_partial_collapse_sum` doesn't touch any of this.**
+The bugs are in KKT stationarity assembly, not AD.
+
+---
+
+## Gate decision — Sprint 25 shape
+
+Per the user's Day 4 decision to pivot WS1:
+
+### Day 5 outcome (today)
+Investigation complete. Phase 1 hypothesis disproved on all three
+target models. AD layer is correct. Bugs live in KKT stationarity
+assembly (Pattern C + alias-as-offset enumeration).
+
+### Recommended Day 6–9 plan
+
+1. **Day 6**: Pivot to Pattern C in KKT emit/stationarity. Target:
+   launch's `stat_iweight` phantom-offset generation. Reproduce
+   minimally, locate the enumeration code, prototype a gate that
+   only runs when the source has an actual IndexOffset.
+2. **Day 7**: Validate on launch + regression sweep (54 models + the
+   deferred multi-solve cluster from the AUDIT). Document rel_diff
+   impact if any.
+3. **Day 8**: Revisit qabel/abel stateq term — run a full PATH solve
+   (not `action=c`) and measure rel_diff post-Day-6-fix. If
+   unchanged, their rel_diff is nonconvex-solver noise, not an
+   emission bug.
+4. **Day 9+**: WS2 emitter batch 3 (remaining `ANALYSIS_RECOVERED_TRANSLATES`
+   priorities) — independent of Pattern A/C.
+
+### Sprint timeline
+
+Original Phase 2 (broader Pattern A rollout, Days 5–9) is dropped.
+Replaced by Pattern C investigation + prototype (Days 6–7) plus
+remaining WS2 catalog work (Days 8–10+). Sprint may extend 1–2 days
+to accommodate the Pattern C prototype ramp.
+
+---
+
+## Files referenced
+
+- Traces: `/tmp/sprint25-day5/{qabel,abel,launch}_trace.stderr`
+- Emitted MCPs: `/tmp/sprint25-day5/{qabel,abel,launch}_mcp.gms`
+- Day 2 findings (prior context): `/tmp/sprint25-phase1-findings.md`
+
+## Key code pointers for Day 6
+
+Pattern C manifestation in launch's stat_iweight — the phantom
+`s+1..s+2, s-1..s-2` terms come from somewhere in KKT stationarity
+emission. Candidate locations to inspect:
+
+- `src/kkt/stationarity.py::_compute_lead_lag_conditions` (line ~59)
+  and `_collect_lead_lag_offsets` (line ~95) — these compute
+  IndexOffset-based domain restrictions; worth checking whether the
+  alias `ss` in a conditional sum is being coerced into offset form.
+- Anywhere stationarity emission iterates the equation body and
+  enumerates alias bindings — grep for `card` + `ord` + alias name
+  patterns on the emitter side.

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -48,8 +48,10 @@ mismatches come from **KKT stationarity assembly**, not the AD layer:
   shifts on an alias that has none in the source. `stat_iweight` emits
   `nu_dweight(s+1)`, `(s+2)`, `(s-1)`, `(s-2)` — none of which appear in
   the original `dweight(s).. weight(s) =e= sum(ss$ge(ss,s), ...)`. This is
-  **Pattern C** (alias-of-IndexOffset, deferred Days 7–9) manifesting
-  during KKT assembly as an "expand the alias via ±N offsets" strategy.
+  **Pattern C** (alias-of-IndexOffset, originally deferred to Days 7–9
+  in the pre-pivot plan — now promoted to Day 6 per the revised Sprint 25
+  schedule in `PLAN.md`) manifesting during KKT assembly as an "expand
+  the alias via ±N offsets" strategy.
 
 **Gate 2 (speculated Day 6+): NO-GO for Phase 2 in its original shape.**
 The Phase 1 hypothesis (`_partial_collapse_sum` recovery helps multi-index

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -119,7 +119,7 @@ Notes:
   specific set cardinality, but the strategy is fragile.
 
 I can't verify rightness at compile-time (the GAMS `action=c` compile on
-ganges/qabel/abel throws pre-existing Error 141 cascades on dual-transfer
+qabel/abel throws pre-existing Error 141 cascades on dual-transfer
 lines — unrelated to this analysis). A full PATH solve is the only
 ground truth for whether the current stat_x is numerically correct.
 

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -53,7 +53,7 @@ mismatches come from **KKT stationarity assembly**, not the AD layer:
   schedule in `PLAN.md`) manifesting during KKT assembly as an "expand
   the alias via ±N offsets" strategy.
 
-**Gate 2 (speculated Day 6+): NO-GO for Phase 2 in its original shape.**
+**Gate 1 (Phase 2 GO/NO-GO): NO-GO for Phase 2 in its original shape.**
 The Phase 1 hypothesis (`_partial_collapse_sum` recovery helps multi-index
 alias cases) is orthogonal to the actual bug surface. Defer the alias
 workstream to Pattern C. Phase 2's "broader Pattern A rollout" should be

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -177,7 +177,7 @@ The bugs are in KKT stationarity assembly, not AD.
 
 ## Gate decision — Sprint 25 shape
 
-Per the user's Day 4 decision to pivot WS1:
+Per the Day 5 investigation outcome, pivot WS1 to Pattern C:
 
 ### Day 5 outcome (today)
 Investigation complete. Phase 1 hypothesis disproved on all three

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -74,8 +74,8 @@ Expected derivative w.r.t. `x(n_row, k_row)`:
 
 ```text
 ∂j/∂x(n_row, k_row)
-  = 0.5 * (sum(np, w(n_row, np, k_row) * (x(np, k_row) - xt(np, k_row)))
-         + sum(n,  (x(n, k_row) - xt(n, k_row)) * w(n, n_row, k_row)))
+  = 0.5 * (sum(np, w(n_row, np, k_row) * (x(np, k_row) - xtilde(np, k_row)))
+         + sum(n,  (x(n, k_row) - xtilde(n, k_row)) * w(n, n_row, k_row)))
 ```
 
 Emitter output for abel's `stat_x(n, k)` criterion portion:

--- a/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
+++ b/docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md
@@ -8,6 +8,26 @@ Phase 1 targets the Day 3 mechanical port of `_find_var_indices_in_body` into
 `/tmp/sprint25-day5/{qabel,abel,launch}_trace.stderr` (231k / 3k / ~21k lines)
 under `SPRINT25_DAY2_DEBUG=1`.
 
+## Repro
+
+The `/tmp/sprint25-day5/` paths below are ephemeral scratch; to regenerate
+the three traces + emitted MCPs:
+
+```bash
+mkdir -p /tmp/sprint25-day5
+for m in qabel abel launch; do
+  SPRINT25_DAY2_DEBUG=1 .venv/bin/python -m src.cli \
+    data/gamslib/raw/${m}.gms \
+    -o /tmp/sprint25-day5/${m}_mcp.gms \
+    --skip-convexity-check --quiet \
+    2> /tmp/sprint25-day5/${m}_trace.stderr
+done
+```
+
+The `SPRINT25_DAY2_DEBUG=1` env var activates `[SPRINT25_DAY2]` trace
+lines in `src/ad/derivative_rules.py::_diff_varref` and
+`_partial_collapse_sum`; greppable by the `[SPRINT25_DAY2][<tag>]` prefix.
+
 ---
 
 ## TL;DR
@@ -108,7 +128,10 @@ fix in `_partial_collapse_sum` is irrelevant.**
 
 ## Evidence — launch's `stat_iweight` is malformed (NOT Pattern A)
 
-Source (`data/gamslib/raw/launch.gms:86`):
+Source — the `dweight` equation definition in `data/gamslib/raw/launch.gms`
+(the `data/gamslib/raw/` directory is gitignored; the file is downloaded
+via `scripts/download_gamslib_raw.sh`. Grep `^dweight\b` in the source to
+locate):
 
 ```gams
 dweight(s)..  weight(s) =e= sum(ss$ge(ss,s), iweight(ss) + pweight(ss))
@@ -139,7 +162,7 @@ Two bugs visible in the emission:
    **Pattern C** (alias-of-IndexOffset from the AUDIT) manifesting in the
    KKT stationarity emitter.
 
-2. **Misscoped `$(ge(ss, s))` condition inside an outer sum.** Each of
+2. **Mis-scoped `$(ge(ss, s))` condition inside an outer sum.** Each of
    the five `sum(ss, ...)` clauses still has `1$(ge(ss, s))` in the body
    referencing the sum variable `ss`. But the body multiplies by
    `nu_dweight(s+N)` (or `(s)`/`(s-N)`), which doesn't depend on `ss` at
@@ -198,10 +221,12 @@ Pattern C manifestation in launch's stat_iweight — the phantom
 `s+1..s+2, s-1..s-2` terms come from somewhere in KKT stationarity
 emission. Candidate locations to inspect:
 
-- `src/kkt/stationarity.py::_compute_lead_lag_conditions` (line ~59)
-  and `_collect_lead_lag_offsets` (line ~95) — these compute
-  IndexOffset-based domain restrictions; worth checking whether the
-  alias `ss` in a conditional sum is being coerced into offset form.
+- `src/kkt/stationarity.py::_compute_lead_lag_conditions`
+  and `_collect_lead_lag_offsets` — these compute IndexOffset-based
+  domain restrictions; worth checking whether the alias `ss` in a
+  conditional sum is being coerced into offset form. (Function names
+  used as stable references per the convention in
+  `docs/planning/EPIC_4/SPRINT_25/PROFILE_HARD_TIMEOUTS.md`.)
 - Anywhere stationarity emission iterates the equation body and
   enumerates alias bindings — grep for `card` + `ord` + alias name
   patterns on the emitter side.

--- a/docs/planning/EPIC_4/SPRINT_25/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_25/PLAN.md
@@ -84,7 +84,7 @@ Sprint 25 originally scoped 11 alias-AD carryforward issues + 7 emitter backlog 
 | Phase | Focus | Issues | Days | Status |
 |---|---|---|---|---|
 | 1 | Pattern A single-index validation + `_partial_collapse_sum` multi-index mechanical port | — (architecture) | 2–4 | DONE — PR #1302, #1303 merged; no behavioral change on qabel/abel/launch (they were never Pattern-A-blocked, per Day 5 evidence). |
-| 1.5 | Day 5 evidence-driven investigation | — | 5 | DONE — PR #1305 (in flight); findings disprove Phase 2 hypothesis. |
+| 1.5 | Day 5 evidence-driven investigation | — | 5 | DONE — PR #1305; findings disprove Phase 2 hypothesis. |
 | 2 | ~~Pattern A across all 6 issues~~ **DROPPED** | ~~#1138, #1139, #1140, #1142, #1145, #1150~~ | — | DROPPED per Day 5 findings. |
 | 3 | Pattern C alias-of-IndexOffset handling in KKT stationarity + launch `stat_iweight` fix | New-issue (filed Day 6) + latent #1143, #1146, #1277 | 6–7 | NEW — replaces Phase 2. |
 | 3.5 | Pattern A cohort sanity sweep (confirm #1138, #1139, #1140, #1142, #1145, #1150 are not AD-blocked) | Inspection only | 7 | NEW — confirms Phase 2 drop. |
@@ -182,7 +182,7 @@ Alias-AD recoveries are a **different failure mode**: the MCP structure is synta
 - #1289 ganges/gangesx calibration-from-`.l` stripping landed. +1 Solve / +1 Match from ganges confirmed.
 - Gate 1 (Phase 2 GO/NO-GO) deferred to end of Day 5 pending investigation.
 
-### Day 5 — Pattern A Investigation — DONE (PR #1305, in flight)
+### Day 5 — Pattern A Investigation — DONE (PR #1305)
 - Evidence-driven investigation of all three Phase 1 targets.
 - **Finding:** None exhibit a Pattern A bug. qabel/abel criterion AD is byte-correct; launch's `stat_iweight` has phantom `s±N` offsets from KKT stationarity assembly (Pattern C).
 - **Gate 1 outcome:** NO-GO for Phase 2 in original shape. Pivot to Pattern C.

--- a/docs/planning/EPIC_4/SPRINT_25/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_25/PLAN.md
@@ -122,7 +122,7 @@ Landed in PR #1301 (merged). Option D grammar fix in `src/ir/parser.py::_resolve
 **Effort:** ~7.5–9.5h combined (per `DESIGN_SMALL_PRIORITIES.md`).
 **Target:** saras-style model flagged by extended multi-solve gate; dispatcher refactor with zero byte-diff regression.
 
-- **#1270 gate extension (3.5–4.5h):** Approach A cross-reference — flag `eq.m` reads whose receiving parameter later appears in another declared model's constraint body. Code site `src/validation/driver.py:151–225`. 4-fixture test matrix with explicit expected outcomes.
+- **#1270 gate extension (3.5–4.5h):** Approach A cross-reference — flag `eq.m` reads whose receiving parameter later appears in another declared model's constraint body. Code sites: `src/validation/driver.py::scan_multi_solve_driver` and its helper `_collect_equation_marginals` (function-name anchors preferred over line ranges per the convention used elsewhere in the sprint docs). 4-fixture test matrix with explicit expected outcomes.
 - **#1271 dispatcher refactor (4–5h):** Unified signature `_loop_tree_to_gams(node, *, token_subst=None)`. Byte-diff regression test: snapshot 135 currently-translating models pre-refactor (PYTHONHASHSEED=0), regenerate post, `diff -r` must be empty.
 
 ### WS5: Pipeline Retest and Close (Days 14–15 — shifted from Days 13–14)

--- a/docs/planning/EPIC_4/SPRINT_25/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_25/PLAN.md
@@ -61,7 +61,7 @@ Sprint 25 originally scoped 11 alias-AD carryforward issues + 7 emitter backlog 
 | Parse | 143/143 (100%) | ≥ 143/143 | — | Invariant. |
 | Translate | 135/143 (94.4%) | ≥ 135/143 | ≥ 137/143 | 5 timeouts + `mine` deferred to Sprint 26. |
 | Solve | 99 | ≥ 100 | ≥ 102 | +1 from #1289 (landed Day 4 — ganges/gangesx unblock). Pattern C may add +1 (launch) if the fix passes regression. Pattern A Phase 2 dropped — previously projected +3 removed. |
-| Match | 54 | ≥ 56 | ≥ 58 | +2 from Pattern C on launch + qabel (IF Day 8 PATH solve shows emission bug, not nonconvex noise). +2 stretch if cohort sweep finds another Pattern-C-shaped bug. Pattern A Phase 2 dropped — previously projected +5 removed; the +6 Match ladder is no longer the gate. |
+| Match | 54 | ≥ 56 | ≥ 58 | +1 from Pattern C on launch (phantom-offset gate, Days 6–7). +1 potentially from qabel, contingent on the Day 8 PATH-solve reassessment exposing a recoverable emission bug rather than nonconvex-solver noise (a distinct workstream — not Pattern C). +2 stretch if the Day 7 cohort sweep surfaces another Pattern-C-shaped bug in #1138/1140/1142/1145/1150. Pattern A Phase 2 dropped — previously projected +5 removed; the +6 Match ladder is no longer the gate. |
 | path_syntax_error | 11 | ≤ 7 | ≤ 5 | #1275 + #1280 (DONE Days 2–3) removed ~2; Batch 2 (#1276, #1281) targets ~2 more; Batch 3 (#1290, #1291) ~1 more. |
 | path_solve_terminated | 10 | ≤ 9 | ≤ 8 | Pattern C (launch phantom-offset fix) may remove 1. |
 | model_infeasible | 8 | ≤ 7 | ≤ 5 | Pattern C fixes on alias-sum emissions may recover one CGE-family infeasible. |

--- a/docs/planning/EPIC_4/SPRINT_25/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_25/PLAN.md
@@ -106,7 +106,7 @@ Sprint 25 originally scoped 11 alias-AD carryforward issues + 7 emitter backlog 
 
 | Batch | Focus | Issues | Effort | Days | Status |
 |---|---|---|---|---|---|
-| 1 | presolve paths + UEL quoting | #1275, #1280 | 3–5h | 2–3 | DONE (PR #1301 / post-Day-2 commit). |
+| 1 | presolve paths + UEL quoting | #1275, #1280 | 3–5h | 2–3 | DONE — #1275 via PR #1302 (Day 2), #1280 via PR #1303 (Day 3). |
 | 2.5 | Ganges calibration stripping (highest-leverage single fix — unblocks ganges + gangesx) | #1289 | 4–6h | 4 | DONE (PR #1304). |
 | 2 | IR-normalize + emitter idempotency + turkpow line wrap | #1279, #1276, #1281, #1292 | 7–11h | 8–9 | PENDING — slipped from original Days 4–6 due to Day 5 pivot. |
 | 3 | AD / stationarity (post-Pattern-C) + ferts identifier length + clearlak statement ordering | #1277, #1278, #1290, #1291 | 8–12h | 10–11 | PENDING — #1277 gated on Pattern C landing Day 7. |
@@ -211,7 +211,7 @@ Alias-AD recoveries are a **different failure mode**: the MCP structure is synta
 
 **Tasks:**
 1. Run full 54-set golden-file regression with the Day 6 Pattern C prototype. Document any regressions (expected 0; Pattern C only fires when phantom-offset enumeration was already happening).
-2. Translate launch fresh → compile via `action=c` → PATH solve. Measure rel_diff against the baseline NLP solution. If rel_diff improves materially, +1 Match candidate for Day 14 pipeline retest.
+2. Translate launch fresh. First run compile-only (`gams /tmp/launch_mcp.gms action=c`) as a syntax/symbol sanity check. Then run a separate full PATH solve on the emitted MCP and measure rel_diff against the baseline NLP solution. If rel_diff improves materially, +1 Match candidate for Day 14 pipeline retest.
 3. Pattern A cohort sanity sweep: for each of the 6 models in #1138, #1139, #1140, #1142, #1145, #1150, capture the derivative-emission shape via `SPRINT25_DAY2_DEBUG=1` trace. Classify each as:
    - **Pattern A shape (AD-blocked):** `_partial_collapse_sum` rejects the body-index match → emits `0` for a known-nonzero derivative.
    - **Pattern C shape (phantom offsets):** derivative emission has ±N offsets that don't come from the source.

--- a/docs/planning/EPIC_4/SPRINT_25/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_25/PLAN.md
@@ -1,22 +1,44 @@
 # Sprint 25 Detailed Plan
 
 **Created:** 2026-04-22
-**Sprint Duration:** 15 days (Day 0 – Day 14)
-**Effort:** ~59.5–80.5 hours (Priority 1 19–26h + Priority 2 23–33h + Priorities 3–4 7.5–9.5h + Day 1 determinism infrastructure 4–6h [Option D grammar fix + PR12 harness] + retest/close ~6h); Budget ~4.0–5.5h/day effective capacity
-**Risk Level:** MEDIUM-HIGH (alias-AD workstream has history of regressions; mitigated by 4-phase rollout + 4 quantitative gates + 5 stop-the-sprint triggers from `DESIGN_ALIAS_AD_ROLLOUT.md`)
+**Revised:** 2026-04-24 (Day 5 evidence-driven pivot — see §Day 5 Pivot below)
+**Sprint Duration:** 16 days (Day 0 – Day 15) — extended by 1 day from original Day 14 close to absorb the Pattern C ramp.
+**Effort:** ~55–75h (reduced from original ~59.5–80.5h because Phase 2 broader Pattern A rollout is dropped; Pattern C prototype + validation replaces it); Budget ~4.0–5.5h/day effective capacity.
+**Risk Level:** MEDIUM (reduced from MEDIUM-HIGH — the risky 4-phase alias-AD rollout is trimmed to Phase 1 validation only + a targeted Pattern C pivot with narrower scope).
 **Baseline:** `main @ fc038801` — Parse 143/143 (100%), Translate 135/143 (94.4%), Solve 99, Match 54, Tests 4,522 (Sprint 24 Day 14 final). Scope LOCKED at 143 per Sprint 24 retrospective PR15 and `BASELINE_METRICS.md` §5.
+
+---
+
+## Day 5 Pivot (2026-04-24) — Executive Summary of the Mid-Sprint Revision
+
+The Day 5 investigation (`DAY5_PATTERN_A_INVESTIGATION.md`, PR #1305) examined the three Phase 1 target models — qabel, abel, launch — whose rel_diff mismatches were the originating justification for the Pattern A workstream (WS1).
+
+**Finding:** None of the three models has a Pattern A bug. Their rel_diff is driven by KKT stationarity assembly, not the AD layer.
+
+- **qabel / abel (rel_diff 0.08, 0.30):** AD criterion derivative is byte-correct (symmetric quadratic form verified). The mismatch, if real, lives in the stateq Lagrangian term's sign / offset / domain-condition handling, which uses a specific `nu_stateq(n, k-1)$(ord(k) > 1)` form that may be deliberate given the emitter's shifted-domain convention. Resolution requires a full PATH solve (`action=c` hits pre-existing Error 141 cascades on dual-transfer lines, blocking compile-only verification).
+- **launch (rel_diff 0.17):** The `stat_iweight` emission shows phantom `s+1, s+2, s-1, s-2` IndexOffsets on an alias `ss` that has **no offset in the source** (`sum(ss$ge(ss,s), ...)`). This is **Pattern C (alias-of-IndexOffset)** manifesting in the KKT stationarity emitter as an "expand the alias via ±N offsets" strategy. Pattern A fix in `_partial_collapse_sum` doesn't touch this code path.
+
+**Consequences for the sprint:**
+
+- **Phase 2 (broader Pattern A rollout, original Days 5–6): DROPPED.** The Phase 1 hypothesis — "multi-index concrete→symbolic recovery in `_partial_collapse_sum` unblocks #1138/1139/1140/1142/1145/1150" — is orthogonal to the bug surface we actually see.
+- **Pattern C moves EARLIER.** Formerly Phase 3 (Days 7–9), the Pattern C work is now Days 6–7, targeting launch's `stat_iweight` phantom-offset enumeration in `src/kkt/stationarity.py`.
+- **A "Pattern A cohort sanity sweep" is added (Day 7).** Before declaring Pattern A dead, we re-inspect the other six Pattern A candidate models (#1138, #1139, #1140, #1142, #1145, #1150) to confirm they exhibit the same symptom shape (AD correct, bug elsewhere) and are not genuinely blocked by the `_partial_collapse_sum` gap.
+- **qabel/abel resolution moved to Day 8** via full PATH solve (not `action=c`) to separate nonconvex-solver noise from emission bugs.
+- **Sprint extended 1 day** (Day 14 → Day 15) to absorb the Pattern C prototype ramp. WS2 (emitter backlog) is otherwise unchanged; WS4 (small priorities) moves from Day 11 → Day 12.
+
+Gate 1 (Phase 2 GO/NO-GO) and Checkpoint 1 (Day 6 Phase 2 evaluation) are therefore **CANCELLED** — the gate criteria assumed Phase 2 was real. Checkpoint 2 (Match/Solve/path_syntax_error evaluation) moves from Day 10 → Day 11 and retains its GO/NO-GO role for Phase E routing.
 
 ---
 
 ## Executive Summary
 
-Sprint 25 executes Sprint 24's 11 alias-AD carryforward issues + 7 emitter backlog issues + 4 recovered-translate bugs, with a parallel determinism-invariant test infrastructure landing Day 1. The sprint is scheduled in 4 phases (Task 6 rollout) with 2 checkpoints (Day 6, Day 10). The alias-AD architecture is already live (Sprint 23 base layer + Sprint 24 additions — see `AUDIT_ALIAS_AD_CARRYFORWARD.md`); Sprint 25's work is **extending `_partial_collapse_sum` multi-index concrete→symbolic recovery** (Pattern A root cause) and **extending `_alias_match` for `IndexOffset.base`** (Pattern C).
+Sprint 25 originally scoped 11 alias-AD carryforward issues + 7 emitter backlog issues + 4 recovered-translate bugs, with a parallel determinism-invariant test infrastructure landing Day 1. After the Day 5 pivot, the sprint focuses on:
 
-- **WS1: Alias-AD (Priority 1, Days 2–12)** — 4 phases with Gates 1–4; cumulative Match ladder ≥+3/+5/+6 at each gate.
-- **WS2: Emitter backlog (Priority 2, Days 2–10 parallel)** — 3 batches for #1275–#1281 + 4 new issues #1289–#1292; `#1289 ganges` is Day 4 focus (highest single-fix leverage).
-- **WS3: Determinism infrastructure (Day 1)** — Option D grammar fix (Task 3) + PR12 test harness (Task 10); must land before any metric-affecting PR.
-- **WS4: Small priorities (Days 11)** — #1270 multi-solve gate extension + #1271 dispatcher refactor.
-- **WS5: Pipeline retest & close (Days 13–14)** — full pipeline + retrospective.
+- **WS1: Alias-AD (Priority 1, Days 2–4 DONE; Days 6–8 Pattern C + cohort sweep)** — Phase 1 validation (DONE, landed `_find_var_indices_in_body` mechanical port without behavioral change); Pattern C pivot targets launch's `stat_iweight`; Pattern A cohort sanity sweep Day 7; qabel/abel PATH-solve Day 8.
+- **WS2: Emitter backlog (Priority 2, Days 2–4 DONE; Days 8–11 remainder)** — Batch 1 (#1275, #1280) DONE; Batch 2.5 (#1289 ganges) DONE; Batch 2 remainder (#1279, #1276, #1281, #1292) Days 8–9; Batch 3 (#1277, #1278, #1290, #1291) Days 10–11.
+- **WS3: Determinism infrastructure (Day 1 DONE)** — Option D grammar fix + PR12 test harness landed in PR #1301.
+- **WS4: Small priorities (Day 12)** — #1270 multi-solve gate extension + #1271 dispatcher refactor.
+- **WS5: Pipeline retest & close (Days 14–15)** — full pipeline + retrospective.
 
 **Process requirements (carried forward from Sprint 23/24 retrospectives):**
 - **PR6:** Full pipeline for all definitive metrics (`scripts/gamslib/run_full_test.py --quiet`).
@@ -24,282 +46,391 @@ Sprint 25 executes Sprint 24's 11 alias-AD carryforward issues + 7 emitter backl
 - **PR8:** Absolute counts and percentages.
 - **PR9:** Targets against 143-model pipeline scope (LOCKED per PR15).
 - **PR10 (re-calibrated via Unknown 6.3):** Budget **30%** error influx for alias-AD recoveries (not the 100% PR13 figure — PR13 applies only to previously-timeout-excluded models; alias-AD bugs produce valid-but-wrong MCPs, a fundamentally different failure mode). Budget **80–100%** influx for Priority 2 emitter recoveries (they come from the same "latent emitter bug" category PR13 describes).
-- **PR11:** Highest-leverage fix (alias-AD Phase 1) in Days 2–4.
-- **PR12:** Determinism regression test — lands Day 1 (per `DESIGN_DETERMINISM_TESTS.md`).
+- **PR11:** Highest-leverage fix (originally alias-AD Phase 1) in Days 2–4. Post-pivot: #1289 ganges (landed Day 4) is the highest-leverage single fix, and Pattern C is the new Phase 1 equivalent at Days 6–7.
+- **PR12:** Determinism regression test — lands Day 1 (per `DESIGN_DETERMINISM_TESTS.md`) — DONE.
 - **PR13:** Unchanged — 100% influx budget applies to timeout recoveries.
 - **PR14:** Known unknowns captured in `KNOWN_UNKNOWNS.md` before sprint start (done).
 - **PR15:** Scope frozen at 143 pre-Day-0 (done per `BASELINE_METRICS.md`).
 
 ---
 
-## Sprint 25 Targets
+## Sprint 25 Targets (Revised Post-Day-5)
 
-| Metric | Baseline (143-scope) | Target | Stretch | Rationale |
+| Metric | Baseline (143-scope) | Target (Revised) | Stretch | Rationale |
 |---|---|---|---|---|
 | Parse | 143/143 (100%) | ≥ 143/143 | — | Invariant. |
-| Translate | 135/143 (94.4%) | ≥ 135/143 | ≥ 137/143 | 5 timeouts + `mine` deferred to Sprint 26 per Task 8 (srpchase + iswnm recoverable if Option 1 fix lands Day 11 overflow). |
-| Solve | 99 | ≥ 102 | ≥ 105 | +3 via alias-AD (qabel/abel mismatched-value recoveries + 1 Pattern C); +1 via Priority 2 #1289 ganges unblock. |
-| Match | 54 | ≥ 60 | ≥ 62 | +6 via Task 6 Match ladder; Gate 4 threshold. |
-| path_syntax_error | 11 | ≤ 6 | ≤ 4 | Task 4 Batch 1 removes ~2 (#1275, #1280); Batch 2 removes ~2 (#1276, #1281); Batch 3 removes ~1 (#1291 clearlak statement ordering, landed Day 9); alias-AD influx ~1 budgeted. |
-| path_solve_terminated | 10 | ≤ 9 | ≤ 8 | Pattern C (#1277 twocge offsets) removes 1; Priority 5 timeout work deferred. |
-| model_infeasible | 8 | ≤ 6 | ≤ 4 | Pattern A fixes may recover chenery (#1177) + partial CGE; Category B (cesam, fawley, korcge) remains hard. |
-| Tests | 4,522 | ≥ 4,560 | — | PR12 test harness adds 6 new tests + per-fix unit tests (~40 new). |
+| Translate | 135/143 (94.4%) | ≥ 135/143 | ≥ 137/143 | 5 timeouts + `mine` deferred to Sprint 26. |
+| Solve | 99 | ≥ 100 | ≥ 102 | +1 from #1289 (landed Day 4 — ganges/gangesx unblock). Pattern C may add +1 (launch) if the fix passes regression. Pattern A Phase 2 dropped — previously projected +3 removed. |
+| Match | 54 | ≥ 56 | ≥ 58 | +2 from Pattern C on launch + qabel (IF Day 8 PATH solve shows emission bug, not nonconvex noise). +2 stretch if cohort sweep finds another Pattern-C-shaped bug. Pattern A Phase 2 dropped — previously projected +5 removed; the +6 Match ladder is no longer the gate. |
+| path_syntax_error | 11 | ≤ 7 | ≤ 5 | #1275 + #1280 (DONE Days 2–3) removed ~2; Batch 2 (#1276, #1281) targets ~2 more; Batch 3 (#1290, #1291) ~1 more. |
+| path_solve_terminated | 10 | ≤ 9 | ≤ 8 | Pattern C (launch phantom-offset fix) may remove 1. |
+| model_infeasible | 8 | ≤ 7 | ≤ 5 | Pattern C fixes on alias-sum emissions may recover one CGE-family infeasible. |
+| Tests | 4,522 | ≥ 4,560 | — | PR12 landed 6 determinism tests + Day 3/Day 4/Day 5 added unit tests (#1283, #1289 + phase1 mechanical-port test). |
 
-**Error influx budgets (Unknown 6.3 calibration — §Influx Calibration below).**
+**Error influx budgets unchanged (Unknown 6.3 calibration — §Influx Calibration below).**
+
+**What was removed from the Sprint 24-era targets:** the Match +6 ladder (Gates 1–4) was premised on Pattern A landing a Phase 2 cohort sweep that Day 5 disproved. The revised Match target uses the smaller, better-calibrated Pattern C + #1289 totals.
 
 ---
 
 ## Workstreams
 
-### WS1: Alias-AD (Priority 1)
+### WS1: Alias-AD (Priority 1) — REVISED
 
-**Effort:** ~19–26h across 4 phases (per `DESIGN_ALIAS_AD_ROLLOUT.md`).
-**Target:** Cumulative Match ladder +3/+5/+6/+6 at each gate; final Match ≥60; stretch ≥62.
-**Source:** [`AUDIT_ALIAS_AD_CARRYFORWARD.md`](./AUDIT_ALIAS_AD_CARRYFORWARD.md), [`DESIGN_ALIAS_AD_ROLLOUT.md`](./DESIGN_ALIAS_AD_ROLLOUT.md).
+**Effort:** ~8–12h (reduced from 19–26h by dropping Phase 2 cohort rollout).
+**Target:** Pattern C recovers launch + opportunistically 1–2 Pattern-C-shaped cohort models. Phase 1 mechanical-port landed Days 2–4 with no regressions.
+**Source:** [`AUDIT_ALIAS_AD_CARRYFORWARD.md`](./AUDIT_ALIAS_AD_CARRYFORWARD.md), [`DESIGN_ALIAS_AD_ROLLOUT.md`](./DESIGN_ALIAS_AD_ROLLOUT.md), [`DAY5_PATTERN_A_INVESTIGATION.md`](./DAY5_PATTERN_A_INVESTIGATION.md).
 
-| Phase | Focus | Issues | Days | Gate |
+| Phase | Focus | Issues | Days | Status |
 |---|---|---|---|---|
-| 1 | Pattern A single-index validation + `_partial_collapse_sum` multi-index prototype (qabel, abel, launch) | — (architecture) | 2–4 | — |
-| 2 | Pattern A across all 6 issues | #1138, #1139, #1140, #1142, #1145, #1150 | 5–6 | Gate 2 = Checkpoint 1 (Day 6) |
-| 3 | Pattern C IndexOffset.base extraction + #1277 re-validation | #1143, #1146 (+ #1277) | 7–9 | Gate 3 (Day 9) |
-| 4 | Final sweep + Pattern E routing + Checkpoint 2 | #1141, #1144, #1147 | 10–12 | Gate 4 = Checkpoint 2 (Day 10) |
+| 1 | Pattern A single-index validation + `_partial_collapse_sum` multi-index mechanical port | — (architecture) | 2–4 | DONE — PR #1302, #1303 merged; no behavioral change on qabel/abel/launch (they were never Pattern-A-blocked, per Day 5 evidence). |
+| 1.5 | Day 5 evidence-driven investigation | — | 5 | DONE — PR #1305 (in flight); findings disprove Phase 2 hypothesis. |
+| 2 | ~~Pattern A across all 6 issues~~ **DROPPED** | ~~#1138, #1139, #1140, #1142, #1145, #1150~~ | — | DROPPED per Day 5 findings. |
+| 3 | Pattern C alias-of-IndexOffset handling in KKT stationarity + launch `stat_iweight` fix | New-issue (filed Day 6) + latent #1143, #1146, #1277 | 6–7 | NEW — replaces Phase 2. |
+| 3.5 | Pattern A cohort sanity sweep (confirm #1138, #1139, #1140, #1142, #1145, #1150 are not AD-blocked) | Inspection only | 7 | NEW — confirms Phase 2 drop. |
+| 4 | qabel/abel PATH-solve reassessment (separate nonconvex-solver noise from emission bug) | #1138, #1139 (if emission bug) | 8 | NEW — replaces original Phase 3. |
+| 5 | Pattern E routing — contingent on Checkpoint 2 GO | #1141, #1144, #1147 | 13 (buffer) | OPTIONAL — same scope as original Phase 4 but demoted to buffer-day contingency. |
 
-**Regression canaries (per `AUDIT_ALIAS_AD_CARRYFORWARD.md` tier list):**
+**Regression canaries (unchanged per `AUDIT_ALIAS_AD_CARRYFORWARD.md` tier list):**
 - **Tier 0 (non-negotiable):** `dispatch`.
 - **Tier 1 (alias-using matching):** `quocge, partssupply, prolog, sparta, gussrisk, ps2_f, ps3_f, ship, splcge`, plus defensive `paklive` (non-alias).
 - **Tier 2:** all 44 non-alias matching models — golden-file diff expected identical.
 
-**Touched files:** `src/ad/derivative_rules.py` (`_partial_collapse_sum`, `_alias_match`), `src/kkt/stationarity.py` (`_apply_alias_offset_to_deriv`).
+**Touched files (revised):** `src/kkt/stationarity.py` (Pattern C — `_compute_lead_lag_conditions`, `_collect_lead_lag_offsets`, and/or the emission site that enumerates alias bindings via ±N offsets); `src/ad/derivative_rules.py` (Phase 1 mechanical port — DONE).
 
-### WS2: Emitter Backlog (Priority 2)
+### WS2: Emitter Backlog (Priority 2) — Largely Unchanged
 
-**Effort:** ~23–33h across 3 batches + Task 5 recovered-translate fixes.
-**Target:** 5+ path_syntax_error reductions; at least 1 Match gain (#1289 ganges).
+**Effort:** ~18–28h across 3 batches + Task 5 recovered-translate fixes (reduced from 23–33h by deferring #1277 AD-dependent re-validation to Pattern C landing).
+**Target:** 4+ path_syntax_error reductions; at least 1 Match gain from #1289 (LANDED Day 4).
 **Source:** [`CATALOG_EMITTER_BACKLOG.md`](./CATALOG_EMITTER_BACKLOG.md), [`ANALYSIS_RECOVERED_TRANSLATES.md`](./ANALYSIS_RECOVERED_TRANSLATES.md).
 
-| Batch | Focus | Issues | Effort | Days |
-|---|---|---|---|---|
-| 1 | presolve paths + UEL quoting | #1275, #1280 | 3–5h | 2–3 (parallel with WS1 Phase 1) |
-| 2 | IR-normalize + emitter idempotency + turkpow line wrap | #1279, #1276, #1281, #1292 | 7–11h | 4–6 (parallel with WS1 Phase 2) |
-| 2.5 | Ganges calibration stripping (highest-leverage single fix — unblocks ganges + gangesx, 2 of 5 Task 5 models) | #1289 | 4–6h | 4 |
-| 3 | AD / stationarity (post-Pattern-C) + ferts identifier length + clearlak statement ordering | #1277, #1278, #1290, #1291 | 8–12h | 7–10 (parallel with WS1 Phase 3–4) |
+| Batch | Focus | Issues | Effort | Days | Status |
+|---|---|---|---|---|---|
+| 1 | presolve paths + UEL quoting | #1275, #1280 | 3–5h | 2–3 | DONE (PR #1301 / post-Day-2 commit). |
+| 2.5 | Ganges calibration stripping (highest-leverage single fix — unblocks ganges + gangesx) | #1289 | 4–6h | 4 | DONE (PR #1304). |
+| 2 | IR-normalize + emitter idempotency + turkpow line wrap | #1279, #1276, #1281, #1292 | 7–11h | 8–9 | PENDING — slipped from original Days 4–6 due to Day 5 pivot. |
+| 3 | AD / stationarity (post-Pattern-C) + ferts identifier length + clearlak statement ordering | #1277, #1278, #1290, #1291 | 8–12h | 10–11 | PENDING — #1277 gated on Pattern C landing Day 7. |
 
-**Touched files:** `src/emit/emit_gams.py` (#1275, #1280, #1281, #1292), `src/ir/normalize.py` (#1279), `src/kkt/stationarity.py` (#1277, #1278), new `_DeclaredSymbolTracker` helper.
+**Touched files:** `src/emit/emit_gams.py` (#1275 DONE, #1280 DONE, #1281, #1292), `src/ir/normalize.py` (#1279), `src/kkt/stationarity.py` (#1277, #1278; overlap with Pattern C work), new `_DeclaredSymbolTracker` helper.
 
-### WS3: Determinism Infrastructure (Day 1)
+### WS3: Determinism Infrastructure (Day 1) — DONE
 
-**Effort:** ~4–6h (Option D fix 2–3h + PR12 test harness 2–3h).
-**Target:** #1283 fix lands + byte-stability regression test CI-enforced.
-**Source:** [`INVESTIGATION_PARSER_NON_DETERMINISM.md`](./INVESTIGATION_PARSER_NON_DETERMINISM.md), [`DESIGN_DETERMINISM_TESTS.md`](./DESIGN_DETERMINISM_TESTS.md).
+Landed in PR #1301 (merged). Option D grammar fix in `src/ir/parser.py::_resolve_ambiguities` + PR12 test harness (`tests/integration/test_pipeline_determinism.py`, `.github/workflows/nightly.yml`, `determinism` pytest marker).
 
-- **Option D fix:** Extend `_resolve_ambiguities()` in `src/ir/parser.py:166–225` with a greediest-value `table_row` heuristic. Expected regression surface: LOW.
-- **PR12 test harness:** 5 fixtures (chenery, indus89, abel, partssupply, ps2_f) × 5 seeds [0, 1, 42, 12345, 99999]; new `determinism` pytest marker; `tests/integration/test_pipeline_determinism.py`; new `.github/workflows/nightly.yml` for full-corpus nightly sweep.
-- **Ordering constraint:** Option D MUST land before PR12 test enables (else CI stays red on chenery).
-
-### WS4: Small Priorities (Day 11)
+### WS4: Small Priorities (Day 12 — shifted from Day 11)
 
 **Effort:** ~7.5–9.5h combined (per `DESIGN_SMALL_PRIORITIES.md`).
 **Target:** saras-style model flagged by extended multi-solve gate; dispatcher refactor with zero byte-diff regression.
 
-- **#1270 gate extension (3.5–4.5h):** Approach A cross-reference — flag `eq.m` reads whose receiving parameter later appears in another declared model's constraint body. Code site `src/validation/driver.py:151–225`. 4-fixture test matrix with explicit expected outcomes: **only saras-style feedback cases flag**; post-solve reporting MUST NOT flag; multi-stage display MUST NOT flag; partssupply `var.l` MUST NOT flag. Canaries: `gussrisk, sparta` (MUST NOT flag — currently matching); `saras` (MUST flag).
+- **#1270 gate extension (3.5–4.5h):** Approach A cross-reference — flag `eq.m` reads whose receiving parameter later appears in another declared model's constraint body. Code site `src/validation/driver.py:151–225`. 4-fixture test matrix with explicit expected outcomes.
 - **#1271 dispatcher refactor (4–5h):** Unified signature `_loop_tree_to_gams(node, *, token_subst=None)`. Byte-diff regression test: snapshot 135 currently-translating models pre-refactor (PYTHONHASHSEED=0), regenerate post, `diff -r` must be empty.
 
-### WS5: Pipeline Retest and Close (Days 13–14)
+### WS5: Pipeline Retest and Close (Days 14–15 — shifted from Days 13–14)
 
 **Effort:** ~6h.
 
 | Day | Task |
 |---|---|
-| 13 | Full pipeline retest (per PR6); acceptance-criteria evaluation against §Sprint 25 Targets; error-influx accounting (per PR7, PR10 re-calibrated). |
-| 14 | Sprint retrospective; CHANGELOG updates; PROJECT_PLAN KPIs; Sprint 26 carryforward issue filing. |
+| 14 | Full pipeline retest (per PR6); acceptance-criteria evaluation against §Sprint 25 Targets; error-influx accounting (per PR7, PR10 re-calibrated). |
+| 15 | Sprint retrospective; CHANGELOG updates; PROJECT_PLAN KPIs; Sprint 26 carryforward issue filing. |
 
 ---
 
-## Influx Calibration (Unknown 6.3)
+## Influx Calibration (Unknown 6.3) — Unchanged
 
 **Finding:** The Sprint 24 retrospective's PR13 "100% influx" finding was specific to **previously-timeout-excluded models** (5 models: ganges, gangesx, ferts, clearlak, turkpow went 5/5 to `path_syntax_error` after translate recovery). This category is dominated by latent emitter bugs that also slow translation — their failure mode is "valid emission is broken."
 
-Alias-AD recoveries are a **different failure mode**: the MCP structure is syntactically valid; only the derivative values are wrong. When an alias-AD fix lands, the recovered model produces valid GAMS that typically compiles and either solves correctly (best case → Match gain) or hits a PATH solver-convergence issue (`path_solve_terminated`). It rarely produces new `path_syntax_error` unless the fix itself introduces an emission bug (Sprint 24 Day 5 `a(n+1,n)` → `a(np+1,n)` episode, caught in-sprint).
+Alias-AD recoveries are a **different failure mode**: the MCP structure is syntactically valid; only the derivative values are wrong. When an alias-AD fix lands, the recovered model produces valid GAMS that typically compiles and either solves correctly (best case → Match gain) or hits a PATH solver-convergence issue (`path_solve_terminated`). It rarely produces new `path_syntax_error` unless the fix itself introduces an emission bug.
 
 **Calibrated Sprint 25 influx budgets:**
 
 | Recovery source | Influx rate | Rationale |
 |---|---|---|
-| Alias-AD (Priority 1) | **30%** | 1 per ~3 recoveries. Worst-case absorbs one accidental emitter regression like the Sprint 24 Day 5 Error 125 episode. Well below PR13's 100% because the failure mode is different. |
-| Priority 2 emitter (recovered-translates #1289–#1292) | **80–100%** | These are PR13's category — latent emitter bugs that also previously caused failure. Same dynamics expected. |
-| Priority 2 emitter (existing in-scope, non-timeout-recovered — #1275, #1276, #1280, #1281, #1279) | **10–20%** | These fix bugs in models already in scope (some matching like fawley-adjacent canaries, others currently `model_infeasible` like robustlp/chain or `path_syntax_error` like mathopt4). The bucket is NOT limited to currently-matching models; the budget covers accidental regression on any in-scope model the fix touches. |
+| Alias-AD / Pattern C (Priority 1, revised scope) | **30%** | 1 per ~3 recoveries. Pattern C's surface area is smaller than the original Phase 2 cohort rollout, so absolute influx is expected small; percentage budget kept. |
+| Priority 2 emitter (recovered-translates #1289–#1292) | **80–100%** | PR13 category — latent emitter bugs that also previously caused failure. Same dynamics expected. |
+| Priority 2 emitter (existing in-scope, non-timeout-recovered — #1275, #1276, #1280, #1281, #1279) | **10–20%** | Fix bugs in models already in scope; accidental regression budget. |
 | Priority 3 multi-solve gate | **0%** (by construction) | Gate only excludes; cannot introduce new errors on kept models. |
 
-**Verification Status:** Unknown 6.3 — ✅ VERIFIED via `../SPRINT_24/SPRINT_RETROSPECTIVE.md` §2 and `../SPRINT_24/SPRINT_LOG.md` Days 3–5; PR10 split into two sub-budgets (alias-AD 30% vs emitter-recovered 80–100%).
+**Verification Status:** Unknown 6.3 — ✅ VERIFIED via `../SPRINT_24/SPRINT_RETROSPECTIVE.md` §2 and `../SPRINT_24/SPRINT_LOG.md` Days 3–5.
 
 ---
 
-## Daily Schedule
+## Daily Schedule (Revised Post-Day-5)
 
-### Day 0 — Setup & Kickoff
-- Verify baseline metrics match `BASELINE_METRICS.md` (Parse 143, Translate 135, Solve 99, Match 54).
-- Generate Tier 1 + Tier 2 golden files for WS1 canary work (`dispatch, quocge, partssupply, prolog, sparta, gussrisk, ps2_f, ps3_f, ship, splcge, paklive`, plus the 44 Tier 2 non-alias matching set).
-- Initialize `SPRINT_LOG.md` Day 0 entry.
+### Day 0 — Setup & Kickoff — DONE
+- Verified baseline metrics match `BASELINE_METRICS.md`.
+- Generated Tier 1 + Tier 2 golden files.
+- Initialized `SPRINT_LOG.md`.
 
-### Day 1 — WS3 Determinism Landing
-- Implement Option D fix in `src/ir/parser.py::_resolve_ambiguities` (greediest-value `table_row` heuristic).
-- Re-run the 20-seed sweep on chenery — expect 20/20 byte-identical.
-- Land PR12 test harness: register `determinism` marker, create `tests/integration/test_pipeline_determinism.py`, create `.github/workflows/nightly.yml`.
-- Verify fast suite cost delta ≈ +60s; stays under 5-minute CI budget.
+### Day 1 — WS3 Determinism Landing — DONE (PR #1301)
+- Option D fix in `_resolve_ambiguities` landed.
+- PR12 test harness landed.
+- 20-seed sweep on chenery: 20/20 byte-identical.
 
-### Day 2 — WS1 Phase 1 Start + WS2 Batch 1 Start (parallel)
-- **WS1:** Add debug logging to `_diff_varref` and `_partial_collapse_sum`. Translate qabel; trace derivative computation for the specific Pattern A cross-term. Identify the multi-index `_partial_collapse_sum` concrete→symbolic gap.
-- **WS2 Batch 1 (fresh contributor or tail-end of Day 2):** Fix #1275 (presolve absolute paths) in `src/emit/emit_gams.py:889` `_emit_nlp_presolve`.
+### Day 2 — WS1 Phase 1 Start + WS2 Batch 1 Start — DONE (PR #1302 + #1275)
+- Debug instrumentation added to `_diff_varref` and `_partial_collapse_sum` (SPRINT25_DAY2 tag, env-gated).
+- #1275 presolve-path portability landed.
+- qabel trace captured; Phase 1 findings documented.
 
-### Day 3 — WS1 Phase 1 Prototype + WS2 Batch 1 Complete
-- **WS1:** Prototype `_partial_collapse_sum` multi-index extension. Validate on qabel (stationarity output changes). Run dispatch canary — MUST match.
-- **WS2:** Fix #1280 (unquoted UEL dots). Run golden-file regression for all 54 matching models.
+### Day 3 — WS1 Phase 1 Prototype + WS2 Batch 1 Complete — DONE (PR #1303)
+- `_partial_collapse_sum` multi-index mechanical port landed (structural no-op on qabel/abel/launch — they never hit the gap path).
+- #1280 unquoted-UEL-dots fix landed.
+- Tier 0 + Tier 1 canary: no regressions.
 
-### Day 4 — WS1 Phase 1 Complete + WS2 Batch 2.5 (#1289)
-- **WS1:** Validate on abel, launch. Run Tier 1 canary. Run `make test`. Quality gate.
-- **WS2:** **High-leverage day** — fix #1289 (ganges/gangesx calibration-from-`.l` stripping). Per Task 5, this unblocks 2 of 5 recovered-translate models. Validate compile + solve + Match.
+### Day 4 — WS1 Phase 1 Complete + WS2 Batch 2.5 (#1289) — DONE (PR #1304)
+- Phase 1 validation on abel, launch — all three models still hit their original rel_diff (see Day 5 for why: AD was never the bug).
+- #1289 ganges/gangesx calibration-from-`.l` stripping landed. +1 Solve / +1 Match from ganges confirmed.
+- Gate 1 (Phase 2 GO/NO-GO) deferred to end of Day 5 pending investigation.
 
-### Day 5 — WS1 Phase 2 Start + WS2 Batch 2 Start
-- **WS1:** Apply Pattern A fix across #1138, #1139, #1140, #1142, #1145, #1150 candidate models. Measure Match/Solve delta per model.
-- **WS2:** Fix #1279 (robustlp `defobj(i)` scalar-equation widening) in `src/ir/normalize.py`.
+### Day 5 — Pattern A Investigation — DONE (PR #1305, in flight)
+- Evidence-driven investigation of all three Phase 1 targets.
+- **Finding:** None exhibit a Pattern A bug. qabel/abel criterion AD is byte-correct; launch's `stat_iweight` has phantom `s±N` offsets from KKT stationarity assembly (Pattern C).
+- **Gate 1 outcome:** NO-GO for Phase 2 in original shape. Pivot to Pattern C.
+- Deliverable: `DAY5_PATTERN_A_INVESTIGATION.md` (repo-tracked via PR #1305).
 
-### Day 6 — Checkpoint 1 + WS2 Batch 2 Continue
-- **Checkpoint 1 evaluation (end of Day 6):**
+### Day 6 — Pattern C Prototype (NEW)
+
+**Branch:** `sprint25-day6-pattern-c-prototype`.
+
+**Objective:** Locate the phantom-offset enumeration code in KKT stationarity, reproduce launch's `stat_iweight` bug minimally, prototype a gate that only enumerates ±N offsets when the source actually has an IndexOffset.
+
+**Tasks:**
+1. Locate the emission site. Candidate functions per `DAY5_PATTERN_A_INVESTIGATION.md`: `src/kkt/stationarity.py::_compute_lead_lag_conditions`, `_collect_lead_lag_offsets`. Grep for `card` + `ord` + alias-enumeration patterns.
+2. Reproduce minimally. Build a synthetic unit test that mirrors launch's `dweight(s).. weight(s) =e= sum(ss$ge(ss,s), iweight(ss) + pweight(ss))` and asserts the emitted `stat_iweight` has no `s+N`/`s-N` offsets in the alias-only case.
+3. Prototype a gate: only enumerate ±N offsets on alias bindings when the equation's source contains at least one actual `IndexOffset` node referring to the alias's base set. This requires inspecting the equation IR, not just the alias table.
+4. Verify launch translates correctly post-fix. Check Tier 0 dispatch canary + Tier 1 canary remain identical (most matching models don't exercise the phantom-offset path, so a conservative gate should be safe).
+5. File a new Sprint 25 issue `pattern_c_phantom_offset_stat_iweight` referencing `DAY5_PATTERN_A_INVESTIGATION.md`.
+
+**Deliverable:** PR with prototype + launch-specific synthetic test. Tier 0/1 canary must match golden. **Do NOT run full 54-set regression yet** — defer to Day 7 to isolate the prototype failure surface.
+
+### Day 7 — Pattern C Validation + Pattern A Cohort Sanity Sweep (NEW)
+
+**Branch:** `sprint25-day7-pattern-c-validation`.
+
+**Objective:** Validate the Day 6 prototype on the full 54-set golden-file regression. In parallel, do a short evidence-gathering sweep on the other six Pattern A candidate models (#1138, #1139, #1140, #1142, #1145, #1150) to confirm they are not AD-blocked — establishing that dropping Phase 2 was correct.
+
+**Tasks:**
+1. Run full 54-set golden-file regression with the Day 6 Pattern C prototype. Document any regressions (expected 0; Pattern C only fires when phantom-offset enumeration was already happening).
+2. Translate launch fresh → compile via `action=c` → PATH solve. Measure rel_diff against the baseline NLP solution. If rel_diff improves materially, +1 Match candidate for Day 14 pipeline retest.
+3. Pattern A cohort sanity sweep: for each of the 6 models in #1138, #1139, #1140, #1142, #1145, #1150, capture the derivative-emission shape via `SPRINT25_DAY2_DEBUG=1` trace. Classify each as:
+   - **Pattern A shape (AD-blocked):** `_partial_collapse_sum` rejects the body-index match → emits `0` for a known-nonzero derivative.
+   - **Pattern C shape (phantom offsets):** derivative emission has ±N offsets that don't come from the source.
+   - **Other:** nonconvex-solver noise, scalar/domain mismatch, or a latent KKT stationarity bug.
+4. If ≥1 Pattern-C-shaped cohort model is found, extend the Day 6 prototype to cover it; re-run 54-set regression. If all 6 models are "Other," document in `DAY7_COHORT_SWEEP.md` and close out the original Pattern A Phase 2 hypothesis formally.
+5. Tier 0 + Tier 1 canary.
+
+**Deliverable:** PR for Pattern C validation (Day 6 prototype graduated) + `DAY7_COHORT_SWEEP.md` classifying the 6 models.
+
+### Day 8 — qabel/abel PATH-Solve Reassessment + WS2 Batch 2 Start (#1279)
+
+**Branch:** `sprint25-day8-qabel-abel-reassess-plus-1279`.
+
+**Objective:** Determine whether qabel/abel's rel_diff is a real emission bug or nonconvex-solver noise by running a full PATH solve (not `action=c`). Start WS2 Batch 2 with #1279 robustlp scalar-widening.
+
+**Tasks:**
+1. Translate qabel + abel (they should already be unchanged post-Day-7 since neither is Pattern-C-shaped per Day 5). Compile + full PATH solve. Measure rel_diff.
+2. If rel_diff still materially off, bisect the `stat_x` emission vs. the expected symbolic form. Specifically: the `nu_stateq(n, k-1)$(ord(k) > 1)` term is the prime suspect per Day 5 — check the emitter's domain-shift handling for `stateq(n, k+1)` → `nu_stateq(n, k)`.
+3. If rel_diff acceptable (solver noise on a nonconvex problem), mark #1138/#1139 as "non-bug" in `AUDIT_ALIAS_AD_CARRYFORWARD.md` and close corresponding GH issues with resolution note.
+4. #1279: Fix robustlp `defobj(i)` scalar-equation widening in `src/ir/normalize.py`. The emitter currently emits `defobj(i)` as a domain-indexed equation when the AD treats it as scalar — fix the normalize pass.
+5. Tier 0 + Tier 1 + 54-set golden-file regression.
+
+**Deliverable:** PR covering qabel/abel classification (document or fix) + #1279 robustlp fix.
+
+### Day 9 — WS2 Batch 2 Continue (#1276, #1281, #1292)
+
+**Branch:** `sprint25-day9-batch2-complete`.
+
+**Objective:** Land Batch 2 remainder.
+
+**Tasks:**
+1. Implement shared `_DeclaredSymbolTracker` helper.
+2. #1276: fawley duplicate `.fx` — use `_DeclaredSymbolTracker` to detect already-emitted `.fx` assignments and skip duplicates.
+3. #1281: lmp2 duplicate Parameter declaration — same helper, different call site.
+4. #1292: turkpow `stat_zt` 144k-char single-line emission — add line-wrapping in the emitter for `sameas()` Cartesian-product expansions when line length exceeds ~1000 chars.
+5. Tier 0 + Tier 1 + 54-set golden-file regression.
+
+**Deliverable:** PR with Batch 2 complete.
+
+### Day 10 — WS2 Batch 3 Core (#1277 post-Pattern-C, #1278)
+
+**Branch:** `sprint25-day10-batch3-core`.
+
+**Objective:** Re-validate #1277 now that Pattern C is live; fix #1278 tautology.
+
+**Tasks:**
+1. Re-translate twocge. #1277 was partially subsumed by Pattern C per the original plan — verify the `stat_tz` offset-alias emission. If still broken, file a narrow follow-up issue and continue.
+2. #1278: Fix the `ord(r) <> ord(r)` (always-false) tautology bug in `src/kkt/stationarity.py`. The stationarity emitter should produce `ord(r) <> ord(rp)` (alias-correct form). Identify the substitution site; fix + unit test.
+3. Tier 0 + Tier 1 + 54-set golden-file regression.
+
+**Deliverable:** PR with #1277 re-validation + #1278 fix.
+
+### Day 11 — WS2 Batch 3 Finish (#1290, #1291) + Checkpoint 2
+
+**Branch:** `sprint25-day11-batch3-complete-plus-checkpoint2`.
+
+**Objective:** Close Batch 3; evaluate Checkpoint 2.
+
+**Tasks:**
+1. #1290: fix ferts multiplier-name 67-char length violation — add a synthetic-hash-shortening pass in the emitter.
+2. #1291: fix clearlak statement ordering — hoist `sum(leaf, ...)` AFTER `leaf(n) = yes$(...)` initialization. Deterministic verification via 3-seed run.
+3. Full pipeline retest: `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m).
+4. Evaluate **Checkpoint 2** (see table below). Decide whether to include Phase E routing (optional Day 13 buffer work) or lock main.
+
+**Checkpoint 2 criteria:**
 
 | Criterion | GO | CONDITIONAL GO | NO-GO |
 |---|---|---|---|
-| Tier 0 canary (dispatch) | Identical | Identical | Any diff |
-| Tier 1 canary regressions | 0 | ≤ 1 | > 1 |
-| Pattern A improvement (Match/Solve on #1138/1139/1140/1142/1145/1150) | ≥ 3 of 6 improved ≥50% | ≥ 1 improved | 0 improved |
-| Cumulative Match delta | ≥ +3 | ≥ +1 | < 0 (regression) |
-| Tests | All pass | All pass | Any failure |
-| path_syntax_error | ≤ 10 | ≤ 11 | > 11 |
-
-- **GO:** proceed to WS1 Phase 3 + WS2 Batch 2 completion.
-- **CONDITIONAL GO:** extend Phase 2 into Day 7; slip Phase 3 start to Day 8.
-- **NO-GO:** revert Phase 2 PRs; Day 7 is root-cause investigation; Phase 3 slips to Day 9.
-
-- **WS2 Batch 2 continues:** #1276 (fawley duplicate `.fx`) + #1281 (lmp2 duplicate Parameter) using new `_DeclaredSymbolTracker` helper.
-
-### Day 7 — WS1 Phase 3 Start + WS2 Batch 3 Setup
-- **WS1 Phase 3:** Extend `_alias_match()` at `src/ad/derivative_rules.py:304–307` to handle `IndexOffset` with `_same_root_set(expr_idx.base, wrt_idx, aliases)`. Target models: polygon, himmel16 (#1143, #1146).
-- **WS2:** Fix #1292 (turkpow `stat_zt` line wrap) — short emitter fix.
-
-### Day 8 — WS1 Phase 3 Continue + WS2 Batch 3 Core
-- **WS1:** Re-validate #1277 (twocge `stat_tz` mixed offsets) now that Pattern C infrastructure is live — per Task 4 this is partially subsumed by Pattern C.
-- **WS2:** Fix #1278 (twocge `ord(r) <> ord(r)` tautology) in `src/kkt/stationarity.py`.
-
-### Day 9 — Gate 3 + WS2 Batch 3 Completion
-- **Gate 3 (end of Day 9):** Pattern C target (polygon, himmel16) improves ≥50% OR Pattern A not regressed AND #1277 resolved → GO to Phase 4.
-- **WS2:** Fix #1290 (ferts identifier length) + #1291 (clearlak statement ordering).
-
-### Day 10 — Checkpoint 2 + WS1 Phase 4 Start
-- **Checkpoint 2 evaluation (end of Day 10):**
-
-| Criterion | GO | CONDITIONAL GO | NO-GO |
-|---|---|---|---|
-| Match | ≥ 60 | ≥ 58 | < 55 (regression) |
-| Solve | ≥ 102 | ≥ 100 | < 99 (regression) |
+| Match | ≥ 56 | ≥ 55 | < 54 (regression) |
+| Solve | ≥ 100 | ≥ 99 | < 99 (regression) |
 | path_syntax_error | ≤ 7 | ≤ 9 | > 11 (regression) |
 | model_infeasible | ≤ 7 | ≤ 8 | > 8 (regression) |
 | Tier 0 + Tier 1 canaries | All match | ≤ 1 regression | > 1 regression |
 | Tests | All pass | All pass | Any failure |
 
-- **GO:** lock main; WS1 Phase 4 is cleanup + Pattern E routing (#1141, #1144, #1147) + optional stretch targets.
-- **CONDITIONAL GO:** Phase 4 limited to cleanup; no new architectural changes.
-- **NO-GO:** main locked; Day 11 revert offending PRs; Phase 4 cancelled.
+- **GO:** Day 13 buffer may include Pattern E routing (#1141, #1144, #1147 — OPTIONAL stretch).
+- **CONDITIONAL GO:** Day 13 buffer limited to tail-cleanup; no new architectural changes.
+- **NO-GO:** main locked; Day 13 reverts offending PRs; Phase E cancelled.
 
-### Day 11 — WS4 Small Priorities
-- **#1270 gate extension (3.5–4.5h):** Implement + test matrix (saras flag + post-solve reporting + multi-stage display + partssupply `var.l` non-flag). Verify gussrisk/sparta remain un-flagged; verify saras is flagged.
-- **#1271 dispatcher refactor (4–5h):** Snapshot 135 models → refactor → regen → `diff -r /tmp/pre /tmp/post` must be empty.
+**Deliverable:** PR with Batch 3 complete + Checkpoint 2 decision documented in `SPRINT_LOG.md`.
 
-### Day 12 — Buffer / Overflow / Sprint-Close Prep
-- Buffer for any Phase 4 / Priority 2 Batch 3 slippage.
-- **Stretch (Priority 5 contingency):** per Task 8, srpchase + iswnm Option 1 fix (short-circuit empty-subset fallback in `src/ad/index_mapping.py::enumerate_equation_instances`, 4–6h effort; 0–2 Solve delta expected). Land ONLY if schedule has slack.
-- File deferred-to-Sprint-26 issues (label `sprint-26`). Update `KNOWN_UNKNOWNS.md` with end-of-sprint discoveries.
+### Day 12 — WS4 Small Priorities (#1270, #1271)
 
-### Day 13 — Final Pipeline Retest
-- `scripts/gamslib/run_full_test.py --quiet` (~2h15m under doubled timeouts).
-- Record definitive final metrics (per PR6). Cross-check against §Sprint 25 Targets.
-- Error-influx accounting: categorize any new path_syntax_error / path_solve_terminated / model_infeasible against PR10 re-calibrated budgets.
+**Branch:** `sprint25-day12-small-priorities`.
 
-### Day 14 — Sprint Close + Retrospective
-- Write Sprint 25 Retrospective using Sprint 24 template.
-- Update `CHANGELOG.md` with Sprint 25 Summary.
-- Update `PROJECT_PLAN.md` Rolling KPIs.
-- File Sprint 26 recommendations.
+**Objective:** Land the #1270 multi-solve gate extension and the #1271 dispatcher refactor.
+
+**Tasks:**
+1. #1270 (3.5–4.5h): Implement + 4-fixture test matrix (saras must flag; post-solve reporting, multi-stage display, partssupply `var.l` must NOT flag). Verify gussrisk/sparta remain un-flagged; verify saras is flagged.
+2. #1271 (4–5h): Unified signature `_loop_tree_to_gams(node, *, token_subst=None)`. Byte-diff regression test on all 135 currently-translating models (`diff -r /tmp/pre /tmp/post` must be empty).
+
+**Deliverable:** PR with both WS4 items.
+
+### Day 13 — Buffer / Phase E (if Checkpoint 2 GO) / Sprint-Close Prep
+
+**Branch:** `sprint25-day13-buffer`.
+
+**Objective:** Absorb slippage; optional Phase E routing; file Sprint 26 issues.
+
+**Tasks:**
+1. Buffer for any Batch 3 / WS4 tail.
+2. **OPTIONAL (only if Checkpoint 2 was GO and schedule has slack):** Phase E routing — re-inspect #1141 (kand multi-solve driver re-verify), #1144 (launch post-Pattern-C re-check), #1147 (camshape). Drop anything that doesn't fit in the day.
+3. **OPTIONAL stretch (only if slack):** Per Task 8 contingency, Option 1 short-circuit in `src/ad/index_mapping.py::enumerate_equation_instances` (srpchase + iswnm). Effort 4–6h; do NOT land unless ≥4h clear headroom.
+4. File Sprint 26 carryforward issues (label `sprint-26`):
+   - Translation timeouts: 4 of 5 hard timeouts (iswnm, sarf, mexls, nebrazil) unless Option 1 landed today.
+   - `mine` `internal_error`.
+   - Any Pattern E issue not resolved.
+   - Original Pattern A Phase 2 cohort models (#1138, #1139, #1140, #1142, #1145, #1150) with Day 7 cohort-sweep classification labels — reclassified from "Pattern A" to whatever shape they actually are.
+5. Update `KNOWN_UNKNOWNS.md` with end-of-sprint discoveries.
+
+### Day 14 — Final Pipeline Retest
+
+**Branch:** `sprint25-day14-retest`.
+
+**Objective:** Definitive pipeline metrics per PR6.
+
+**Tasks:**
+1. Full pipeline: `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m).
+2. Record final metrics: Parse / Translate / Solve / Match + 4 `outcome_category` counts.
+3. Cross-check against `PLAN.md` §Sprint 25 Targets (revised).
+4. Error-influx accounting (per PR7 + PR10 re-calibrated):
+   - Alias-AD / Pattern C gross fixes vs new errors. Check against 30% budget.
+   - Emitter-recovered gross fixes vs new errors. Check against 80–100% budget.
+5. Commit updated `data/gamslib/gamslib_status.json`.
+
+### Day 15 — Sprint Close + Retrospective
+
+**Branch:** `sprint25-day15-retro`.
+
+**Objective:** Write retrospective, update CHANGELOG + PROJECT_PLAN, file Sprint 26 recommendations.
+
+**Tasks:**
+1. Write `docs/planning/EPIC_4/SPRINT_25/SPRINT_RETROSPECTIVE.md` using Sprint 24 template:
+   - Metrics delta against §Sprint 25 Targets (Revised).
+   - Acceptance criteria pass/fail.
+   - Went well / what could be improved.
+   - **Special section:** Day 5 pivot retrospective — what the original Phase 2 assumption got wrong, how the investigation approach (capture traces, read emissions, disprove hypothesis) could have been run Pre-Sprint-25 to avoid the mid-sprint rewrite.
+   - PR10 re-calibration outcome (did the 30% / 80–100% split hold against Pattern C's narrower scope?).
+   - New recommendations (PR16+) for Sprint 26.
+2. Update `CHANGELOG.md` Sprint 25 Summary.
+3. Update `PROJECT_PLAN.md` Rolling KPIs.
+4. File Sprint 26 recommendations — Pattern A cohort reclassification, Pattern C remainder, translation timeouts, Phase E remainders, any new discoveries.
 
 ---
 
-## Contingency Plans
+## Contingency Plans (Revised)
 
-### Risk 1: Alias-AD Regression on Tier 0/1 Canary (most likely)
-**Trigger:** dispatch or any Tier 1 canary regresses post-WS1 PR.
-**Action:** Immediate revert per `DESIGN_ALIAS_AD_ROLLOUT.md` stop-trigger #2; isolate root cause via alias-match vs offset-alias logging; narrow-scope re-land.
-**Fallback:** If the pattern repeatedly regresses, defer that specific pattern to Sprint 26; focus on patterns that are safe.
+### Risk 1: Pattern C Prototype Breaks Matching Models
+**Trigger:** Day 6 prototype causes regression on any Tier 0/1/2 canary.
+**Action:** Narrow the Pattern C gate. The conservative principle is: only suppress ±N enumeration when the equation body has zero IndexOffset nodes referring to the alias's base set. If narrowing doesn't preserve launch's fix, defer Pattern C to Sprint 26.
+**Fallback:** Launch stays in current rel_diff state; Match target drops to +1 (ganges only).
 
-### Risk 2: Priority 2 Batch 3 Post-Pattern-C Dependency Not Ready
-**Trigger:** Pattern C (#1143, #1146) NOT landed by Day 9, so #1277 re-validation blocked.
-**Action:** Drop #1277 Day 10 re-validation to Day 11 buffer; do not slip Sprint close.
-**Fallback:** Defer #1277 to Sprint 26; note reason in retrospective.
+### Risk 2: Pattern A Cohort Sweep Finds Real AD Bugs
+**Trigger:** Day 7 inspection of #1138/1139/1140/1142/1145/1150 finds ≥2 actually Pattern-A-shaped models.
+**Action:** Re-open Phase 2 in a narrowed form on Day 13 buffer. Only land if dispatch + Tier 1 canary stays clean.
+**Fallback:** File as Sprint 26 carryforward with classification data from the sweep.
 
-### Risk 3: Checkpoint 1 NO-GO
-**Trigger:** Day 6 Gate 2 NO-GO (see Checkpoint 1 table).
-**Action:** Revert Phase 2 PRs; Day 7 is root-cause investigation day; Phase 3 slips to Day 9; Phase 4 effectively compressed into Day 10 only (Pattern E routing may be deferred to Sprint 26).
-**Fallback:** Sprint pivots to Priority 2-only work; Match target lowered to ≥57.
+### Risk 3: qabel/abel PATH Solve Confirms Emission Bug (not solver noise)
+**Trigger:** Day 8 rel_diff measurement shows systematic bias inconsistent with nonconvex-solver noise.
+**Action:** Extend Day 8 to locate the `stat_x` / `nu_stateq` domain-shift bug. This may extend into Day 9 WS2 time; compensate by trimming Batch 2 scope if necessary.
+**Fallback:** File qabel/abel as open Sprint 26 issues with precise emitter-bug localization.
 
-### Risk 4: PR12 Catches a New #1283-Class Bug Mid-Sprint
-**Trigger:** PR12 nightly sweep flags a non-chenery corruption on Day 2+.
-**Action:** File new issue `multi_row_label_ambiguity_<model>`; extend Option D pattern to cover it; re-run nightly.
-**Fallback:** If Option D doesn't generalize, skip the test for that model via temporary skipif, file Sprint-26 issue.
+### Risk 4: Checkpoint 2 NO-GO
+**Trigger:** Day 11 full pipeline shows regression below baseline (Match < 54 OR Solve < 99).
+**Action:** Day 12 reverts offending PRs; Phase E cancelled; Day 13 buffer used for revert stabilization.
+**Fallback:** Sprint close with baseline-equivalent metrics but documented learnings.
 
 ### Risk 5: Error Influx Above Budget
-**Trigger:** Day 13 retest shows alias-AD influx >30% OR Priority 2 emitter-recovered influx >100%.
-**Action:** Classify new errors; file Sprint 26 issues. If influx destroys Match gain (e.g., Match net-zero), document in retrospective as PR10 recalibration item for Sprint 26.
+**Trigger:** Day 14 retest shows alias-AD/Pattern C influx >30% OR emitter-recovered influx >100%.
+**Action:** Classify new errors; file Sprint 26 issues. Document in retrospective as PR10 recalibration item for Sprint 26.
 
 ---
 
-## Workstream to Issue Mapping
+## Workstream to Issue Mapping (Revised)
 
-### WS1: Alias-AD
-- **Pattern A (Phase 2):** #1138, #1139, #1140, #1142, #1145, #1150 — 6 issues, ~16 comparison-scope models.
-- **Pattern C (Phase 3):** #1143, #1146 — offset-alias extension.
-- **Pattern E (Phase 4 routing):** #1141 (B→E), #1144, #1147 — multi-solve driver route or stationarity-level.
+### WS1: Alias-AD / Pattern C
+- **Phase 1 (DONE):** Mechanical port — no issue IDs; architecture prep.
+- **Phase 3 (Pattern C — NEW, Days 6–7):** new-issue (filed Day 6); indirectly covers #1143, #1146, #1277.
+- **Phase 3.5 (Cohort sanity sweep — NEW, Day 7):** #1138, #1139, #1140, #1142, #1145, #1150 — **inspection only**, reclassification outputs go to `DAY7_COHORT_SWEEP.md` and Sprint 26 carryforward issues.
+- **Phase 4 (qabel/abel PATH solve — NEW, Day 8):** #1138, #1139 (if real emission bug).
+- **Phase 5 (Pattern E routing — OPTIONAL, Day 13):** #1141 (B→E), #1144, #1147 — contingent on Checkpoint 2 GO.
 
 ### WS2: Emitter Backlog
-- **Batch 1:** #1275 (presolve paths), #1280 (unquoted UEL dots).
-- **Batch 2:** #1279 (robustlp scalar-widening), #1276 (fawley duplicate `.fx`), #1281 (lmp2 duplicate Parameter), #1292 (turkpow line wrap).
-- **Batch 2.5:** #1289 (ganges calibration stripping) — Day 4 focus.
-- **Batch 3:** #1277 (twocge mixed offsets), #1278 (tautology), #1290 (ferts identifier length), #1291 (clearlak statement ordering).
+- **Batch 1 (DONE):** #1275 (presolve paths), #1280 (unquoted UEL dots).
+- **Batch 2.5 (DONE):** #1289 (ganges calibration stripping).
+- **Batch 2 (Days 8–9):** #1279 (robustlp scalar-widening), #1276 (fawley duplicate `.fx`), #1281 (lmp2 duplicate Parameter), #1292 (turkpow line wrap).
+- **Batch 3 (Days 10–11):** #1277 (twocge mixed offsets — post-Pattern-C re-validation), #1278 (tautology), #1290 (ferts identifier length), #1291 (clearlak statement ordering).
 
-### WS3: Determinism
-- #1283 (parser non-determinism): Option D fix + PR12 test harness.
+### WS3: Determinism (DONE)
+- #1283 (parser non-determinism): Option D fix + PR12 test harness — LANDED PR #1301.
 
-### WS4: Small Priorities
+### WS4: Small Priorities (Day 12)
 - #1270 (multi-solve gate extension).
 - #1271 (dispatcher refactor).
 
-### WS5 (deferred to Sprint 26):
-- Translation timeouts (#1169, #1185, #1192 family + #1228 + Task 8's 5 models): DEFER per Task 8 Priority 5 recommendation.
-- `mine` (`internal_error` / `SetMembershipTest`): DEFER — same architectural fix.
+### WS5 (deferred to Sprint 26, unchanged):
+- Translation timeouts (#1169, #1185, #1192 family + #1228 + Task 8's 5 models).
+- `mine` (`internal_error` / `SetMembershipTest`).
+- Pattern A cohort reclassification (#1138, #1139, #1140, #1142, #1145, #1150 — per Day 7 sweep outputs).
 
 ---
 
-## Unknown 6.3 Verification Summary
+## Unknown 6.3 Verification Summary (Unchanged)
 
 **Status:** ✅ VERIFIED via `../SPRINT_24/SPRINT_RETROSPECTIVE.md` §2 + `../SPRINT_24/SPRINT_LOG.md` Days 3–5.
 
-- Sprint 23 `_alias_match` / `_same_root_set` / `_partial_collapse_sum` base layer + Sprint 24 Day 3–5 single-index-sum-collapse fix landed qabel and abel from mismatch/IOerror → `model_optimal` + mismatch-value (eventually Match via subsequent fixes). **No new `path_syntax_error` observed** after the Sprint 24 Day 5 Error 125 `a(n+1,n)` episode was resolved in-PR via alias-substitution.
-- Final Sprint 24 Match delta: +5 (49 → 54); the 11 open alias-AD issues (#1138–#1147, #1150) are this sprint's highest-leverage remaining work.
-- PR13 "100% influx" applies specifically to previously-timeout-excluded models (5/5 went to path_syntax_error); NOT representative of alias-AD dynamics.
+- Sprint 23 `_alias_match` / `_same_root_set` / `_partial_collapse_sum` base layer + Sprint 24 Day 3–5 single-index-sum-collapse fix landed qabel and abel from mismatch/IOerror → `model_optimal` + mismatch-value. Day 5 Sprint 25 investigation confirmed the criterion AD is correct; remaining mismatch stems from KKT stateq emission (not AD) — further narrowing the scope of what alias-AD workstreams need to cover.
+- Final Sprint 24 Match delta: +5 (49 → 54).
+- PR13 "100% influx" applies specifically to previously-timeout-excluded models; NOT representative of alias-AD or Pattern C dynamics.
 
-**Sprint 25 decision:** PR10 split into two sub-budgets — alias-AD 30%, emitter-recovered 80–100%. Match target +6 calibrated against the 30% figure with one-model reserve.
+**Sprint 25 decision:** PR10 split into two sub-budgets — alias-AD 30%, emitter-recovered 80–100%. Match target calibrated against +2 Pattern C + 0 Phase 2 (dropped); stretch +2 via cohort sweep Pattern-C-shaped finds.
 
 ---
 
 ## Related Documents
 
 - Prep task deliverables (all merged to main): `AUDIT_ALIAS_AD_CARRYFORWARD.md`, `INVESTIGATION_PARSER_NON_DETERMINISM.md`, `CATALOG_EMITTER_BACKLOG.md`, `ANALYSIS_RECOVERED_TRANSLATES.md`, `DESIGN_ALIAS_AD_ROLLOUT.md`, `DESIGN_SMALL_PRIORITIES.md`, `PROFILE_HARD_TIMEOUTS.md`, `BASELINE_METRICS.md`, `DESIGN_DETERMINISM_TESTS.md`.
-- Day-by-day execution prompts: `prompts/PLAN_PROMPTS.md`.
+- **Day 5 pivot evidence (new):** `DAY5_PATTERN_A_INVESTIGATION.md` (PR #1305).
+- **Day 7 cohort sweep output (new):** `DAY7_COHORT_SWEEP.md` (to be created Day 7).
+- Day-by-day execution prompts: `prompts/PLAN_PROMPTS.md` (revised to match this plan).
 - Known unknowns + calibrated influx budgets: `KNOWN_UNKNOWNS.md`.
 - Sprint 24 templates: `../SPRINT_24/PLAN.md`, `../SPRINT_24/prompts/PLAN_PROMPTS.md`.

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -23,7 +23,7 @@ Days 0–5 have been executed. PR links:
 
 The Day 5 pivot DROPS the originally-planned Phase 2 broader Pattern A rollout and replaces it with Pattern C work (Days 6–7) plus a cohort sanity sweep and qabel/abel PATH-solve reassessment (Days 7–8). See `../PLAN.md` §"Day 5 Pivot" for full rationale.
 
-Original Day 0–5 prompts are preserved in git history at `docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md` on commit `fd1110d2` and earlier.
+Original Day 0–5 prompts are preserved in the file history of `docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md` on `main`; the merged PRs listed above (PR #1301–#1305) mark the relevant points in that history for locating the pre-revision version (`git log --follow -- docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md`).
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -230,11 +230,11 @@ Original Day 0–5 prompts are preserved in the file history of `docs/planning/E
 
 **Prerequisites:**
 - Read `docs/planning/EPIC_4/SPRINT_25/DESIGN_SMALL_PRIORITIES.md`.
-- Key sources: `src/validation/driver.py:151–225` (#1270), `src/emit/original_symbols.py::emit_pre_solve_param_assignments` (nested `_loop_tree_to_gams_subst_dispatch`).
+- Key sources: `src/validation/driver.py::scan_multi_solve_driver` + its helper `_collect_equation_marginals` (#1270); `src/emit/original_symbols.py::emit_pre_solve_param_assignments` (nested `_loop_tree_to_gams_subst_dispatch`).
 
 **Tasks to Complete (~7.5–9.5 hours):**
 
-1. **#1270 (3.5–4.5h):** Implement Approach A cross-reference in `_collect_top_level_marginals_with_param_feedback`. 4-fixture test matrix (per `DESIGN_SMALL_PRIORITIES.md` fixture table — only F1 should flag):
+1. **#1270 (3.5–4.5h):** Implement Approach A cross-reference in `scan_multi_solve_driver` (with supporting changes in `_collect_equation_marginals`) in `src/validation/driver.py`. 4-fixture test matrix (per `DESIGN_SMALL_PRIORITIES.md` fixture table — only F1 should flag):
    - F1 saras-style feedback (MUST flag).
    - F2 post-solve reporting (MUST NOT flag).
    - F3 multi-stage display (MUST NOT flag).

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -1,101 +1,361 @@
-# Sprint 25 Day-by-Day Execution Prompts
+# Sprint 25 Day-by-Day Execution Prompts (Revised Post-Day-5)
 
-Step-by-step execution prompts for Sprint 25 Days 0–14.
+Step-by-step execution prompts for Sprint 25 Days 0–15. **Revised 2026-04-24** after the Day 5 evidence-driven investigation disproved the Phase 2 Pattern A hypothesis. See `../DAY5_PATTERN_A_INVESTIGATION.md` and `../PLAN.md` §"Day 5 Pivot" for context.
 
 **Usage:** Copy the relevant day's prompt into a new conversation to execute that day's work. Each prompt is self-contained; the contributor does not need prior context beyond the prerequisites section.
 
 **Branch naming convention:** `sprint25-dayN-<slug>` (one branch per day; rebase/merge to main at PR merge).
 
-**Pipeline retest command:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m under doubled timeouts; use for Day 6 Checkpoint 1 + Day 10 Checkpoint 2 + Day 13 final retest).
+**Pipeline retest command:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m under doubled timeouts; use for Day 11 Checkpoint 2 + Day 14 final retest).
 
 ---
 
-## Day 0 Prompt: Setup & Kickoff
+## Days 0–5: COMPLETED — Historical Reference
 
-**Branch:** Create a new branch named `sprint25-day0-setup` from `main`.
+Days 0–5 have been executed. PR links:
 
-**Objective:** Verify baseline, generate golden files for Tier 0/1/2 canaries, initialize sprint log.
+- **Day 0** — Setup & Kickoff (baseline verification, golden-file generation, SPRINT_LOG initialization).
+- **Day 1** — WS3 Determinism Landing (Option D + PR12) → **PR #1301 (merged)**.
+- **Day 2** — WS1 Phase 1 Start + WS2 Batch 1 Start (#1275 presolve paths; trace instrumentation) → **PR #1302 (merged)**.
+- **Day 3** — WS1 Phase 1 Prototype + #1280 (unquoted UEL dots; `_partial_collapse_sum` multi-index mechanical port) → **PR #1303 (merged)**.
+- **Day 4** — WS1 Phase 1 Complete + WS2 Batch 2.5 (#1289 ganges calibration stripping) → **PR #1304 (merged)**.
+- **Day 5** — **Pattern A Investigation (pivot day)** — evidence-driven examination of qabel/abel/launch concluded none exhibit Pattern A. Launch has Pattern C phantom offsets in KKT stationarity; qabel/abel AD is byte-correct. → **PR #1305 (in flight)**; deliverable `DAY5_PATTERN_A_INVESTIGATION.md`.
 
-**Prerequisites:**
-- `data/gamslib/raw/` populated (gitignored; `python scripts/gamslib/download_models.py` if missing).
-- Read `docs/planning/EPIC_4/SPRINT_25/PLAN.md` end-to-end.
-- Read `docs/planning/EPIC_4/SPRINT_25/BASELINE_METRICS.md` — baseline numbers are LOCKED per PR15.
+The Day 5 pivot DROPS the originally-planned Phase 2 broader Pattern A rollout and replaces it with Pattern C work (Days 6–7) plus a cohort sanity sweep and qabel/abel PATH-solve reassessment (Days 7–8). See `../PLAN.md` §"Day 5 Pivot" for full rationale.
 
-**Tasks to Complete (~2–3 hours):**
-
-1. **Verify baseline matches `BASELINE_METRICS.md`:** Parse 143/143, Translate 135/143, Solve 99, Match 54. If any number drifts, STOP and investigate — baseline freeze was the whole point of Task 9.
-2. **Generate Tier 0/1 canary golden files** (11 models): `mkdir -p /tmp/sprint25-golden && for m in dispatch quocge partssupply prolog sparta gussrisk ps2_f ps3_f ship splcge paklive; do python -m src.cli data/gamslib/raw/$m.gms -o /tmp/sprint25-golden/${m}_mcp.gms --skip-convexity-check; done`.
-3. **Generate Tier 2 (44 non-alias matching) golden files** — extract the list from Task 9 baseline + filter out Tier 1 models + alias-using models per `AUDIT_ALIAS_AD_CARRYFORWARD.md` §regression canary tiers.
-4. **Initialize `SPRINT_25/SPRINT_LOG.md`** with a Day 0 entry (mirror `SPRINT_24/SPRINT_LOG.md` format).
-
-**Quality Checks:** Skip unless `.py` touched.
+Original Day 0–5 prompts are preserved in git history at `docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md` on commit `fd1110d2` and earlier.
 
 ---
 
-## Day 1 Prompt: WS3 Determinism Landing (Option D + PR12)
+## Day 6 Prompt: Pattern C Prototype (NEW — replaces original Day 6 Checkpoint 1)
 
-**Branch:** `sprint25-day1-determinism`.
+**Branch:** `sprint25-day6-pattern-c-prototype`.
 
-**Objective:** Land the #1283 Option D grammar fix and the PR12 byte-stability test harness. These MUST land together so CI stays green going forward.
+**Objective:** Locate the phantom-offset enumeration code in KKT stationarity, reproduce launch's `stat_iweight` bug minimally, prototype a conservative gate that only enumerates ±N offsets when the source has a real IndexOffset.
 
 **Prerequisites:**
-- Read `docs/planning/EPIC_4/SPRINT_25/INVESTIGATION_PARSER_NON_DETERMINISM.md` — Option D design at §Proposed Fix.
-- Read `docs/planning/EPIC_4/SPRINT_25/DESIGN_DETERMINISM_TESTS.md` — §7 CI Integration Plan for the test harness.
-- Key source files: `src/ir/parser.py::_resolve_ambiguities` (lines 166–225), `src/gams/gams_grammar.lark` (`table_row` / `simple_label` rules), `pyproject.toml` (marker registration).
+- Read `docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md` — findings + §"Key code pointers for Day 6".
+- Read `docs/planning/EPIC_4/SPRINT_25/PLAN.md` §"Day 6 — Pattern C Prototype".
+- Key source files: `src/kkt/stationarity.py` (candidate functions `_compute_lead_lag_conditions`, `_collect_lead_lag_offsets`; also any site that iterates equation bodies and enumerates alias bindings).
+- Reference emission from Day 5 trace (`/tmp/sprint25-day5/launch_mcp.gms`):
+  ```gams
+  stat_iweight body contains phantom offsets:
+    sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s+1))$(ord(s) <= card(s) - 1)
+    sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s+2))$(ord(s) <= card(s) - 2)
+    sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s-1))$(ord(s) > 1)
+    sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s-2))$(ord(s) > 2)
+  ```
+  Source `dweight(s)..` has NO IndexOffset — just a conditional alias sum.
 
 **Tasks to Complete (~4–6 hours):**
 
-1. **Option D fix:** Extend `_resolve_ambiguities()` with a greediest-value `table_row` heuristic — prefer the `_ambig` alternative that packs the most `table_value` children into the fewest `table_row` nodes. Unit test at `tests/unit/ir/test_resolve_ambiguities.py` covering a minimal `(low,medium,high).ynot` reproducer.
-2. **Verify fix via 20-seed sweep on chenery:** `for s in $(seq 0 19); do PYTHONHASHSEED=$s python -m src.cli data/gamslib/raw/chenery.gms -o /tmp/chenery_s${s}.gms --skip-convexity-check; done; shasum -a 256 /tmp/chenery_s*.gms` — expect 20/20 identical. (`shasum` is portable across macOS and Linux; on GNU-only systems substitute `sha256sum`.)
-3. **Register `determinism` pytest marker** in `pyproject.toml` under `[tool.pytest.ini_options] markers = [...]`.
-4. **Create `tests/integration/test_pipeline_determinism.py`** with `TestDeterminismFast` (5 fixtures × 5 seeds, `@pytest.mark.integration @pytest.mark.determinism`) and `TestDeterminismFull` (`@pytest.mark.slow @pytest.mark.determinism`). Use the subprocess pattern from `DESIGN_DETERMINISM_TESTS.md` §7 (`-o <path>` + `Path.read_bytes()`).
-5. **Create `.github/workflows/nightly.yml`** per `DESIGN_DETERMINISM_TESTS.md` §7 — mirrors ci.yml's dependency install sequence + adds `pip install -r requirements.txt`.
-6. **Verify CI budget:** `pytest -m "integration and determinism" --tb=short` locally should complete in ~60s.
+1. **Locate the emission site.** Grep `src/kkt/` for `card(` and `ord(` adjacent to alias-iteration patterns; inspect `_compute_lead_lag_conditions` and `_collect_lead_lag_offsets`. Document the call path that produces the launch `stat_iweight` ±N terms. If neither candidate is the culprit, broaden search to `src/kkt/assemble.py` and `src/emit/emit_gams.py`.
+2. **Reproduce minimally.** Add a new test in `tests/unit/kkt/test_pattern_c_alias_offset_gate.py`:
+   - Build a synthetic IR mirroring `dweight(s).. weight(s) =e= sum(ss$ge(ss,s), iweight(ss) + pweight(ss)) + ...` — alias `ss` over `s`, conditional sum, no IndexOffset on `s`.
+   - Assemble KKT stationarity for the equation.
+   - Assert the emitted `stat_iweight` body has NO `s+N`/`s-N` terms (only the identity alias case, i.e. a single `sum(ss, ...)` with `nu_dweight(s)`).
+   - Verify the test FAILS against current main (documents the bug) and will PASS against the prototype.
+3. **Prototype the gate.** Two-sided approach:
+   - Check the equation IR for actual `IndexOffset` nodes on the alias's base set before enumerating ±N offsets. If the body contains no IndexOffset on `s` (or whatever the alias base set is), skip ±N enumeration entirely.
+   - If IndexOffsets do exist, preserve the current enumeration logic (so models like twocge #1277 aren't broken — see Day 10 for post-Pattern-C twocge re-validation).
+4. **Verify launch translates correctly.** Translate launch (`python -m src.cli data/gamslib/raw/launch.gms -o /tmp/launch_mcp.gms --skip-convexity-check`) and inspect `stat_iweight` — should now have only `iwf(s) * nu_diweight(s) + sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s))`.
+5. **Tier 0 dispatch canary:** `diff /tmp/sprint25-golden/dispatch_mcp.gms <(python -m src.cli data/gamslib/raw/dispatch.gms -o /dev/stdout --skip-convexity-check)` — MUST be empty.
+6. **Tier 1 canary:** run the Reference command at the bottom of this file on quocge, partssupply, prolog, sparta, gussrisk, ps2_f, ps3_f, ship, splcge, paklive. MUST match golden.
+7. **Do NOT run full 54-set regression today** — defer to Day 7 to isolate the prototype failure surface. A mid-prototype regression on a Tier 2 model is easier to triage on Day 7 when we also have the cohort-sweep data.
+8. **File a new GH issue** `pattern_c_phantom_offset_stat_iweight` — title "Pattern C: KKT stationarity emits phantom ±N offsets on alias-only conditional sums (launch)"; body references `DAY5_PATTERN_A_INVESTIGATION.md`.
 
 **Quality Checks:** `make typecheck && make lint && make format && make test`.
 
-**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 1: Land #1283 Option D grammar fix + PR12 determinism test harness`.
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 6: Pattern C prototype — gate phantom-offset enumeration on real IndexOffset presence`.
 
 ---
 
-## Day 2 Prompt: WS1 Phase 1 Start + WS2 Batch 1 #1275
+## Day 7 Prompt: Pattern C Validation + Pattern A Cohort Sanity Sweep (NEW)
 
-**Branch:** `sprint25-day2-alias-phase1-start`.
+**Branch:** `sprint25-day7-pattern-c-validation-plus-cohort-sweep`.
 
-**Objective:** Begin Pattern A debugging for `_partial_collapse_sum` multi-index gap (qabel). Land #1275 presolve-path fix in parallel.
+**Objective:** Validate the Day 6 prototype on the full 54-set golden-file regression. Run a short evidence-gathering sweep on the six Pattern A candidate models to confirm they are not AD-blocked (establishing that dropping the original Phase 2 was correct) and classify each.
 
 **Prerequisites:**
-- Read `docs/planning/EPIC_4/SPRINT_25/DESIGN_ALIAS_AD_ROLLOUT.md` §Phase 1.
-- Read `docs/planning/EPIC_4/SPRINT_25/AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern A.
-- Key source files: `src/ad/derivative_rules.py::_partial_collapse_sum` (lines ~2173+), `src/ad/derivative_rules.py::_alias_match` (lines 258–312), `src/emit/emit_gams.py::_emit_nlp_presolve` (line 889 for #1275).
+- Day 6 PR merged or cherry-picked onto this branch.
+- `DAY5_PATTERN_A_INVESTIGATION.md` for the investigation methodology (trace capture + emission inspection).
+- `AUDIT_ALIAS_AD_CARRYFORWARD.md` for the original Pattern A cohort list: #1138, #1139, #1140, #1142, #1145, #1150.
 
-**Tasks to Complete (~4–5 hours):**
+**Tasks to Complete (~5–7 hours):**
 
-1. **WS1:** Add debug logging to `_diff_varref` and `_partial_collapse_sum` (tag with `SPRINT25_DAY2`).
-2. **WS1:** Translate qabel: `python -m src.cli data/gamslib/raw/qabel.gms -o /tmp/qabel_mcp.gms --skip-convexity-check -vvv`. Trace the `sum(np, a(n,np)*x(np,k))` derivative w.r.t. `x(consumpt,q1)`.
-3. **WS1:** Identify the multi-index concrete→symbolic gap. Document findings in a scratch file under `/tmp/sprint25-phase1-findings.md` for tomorrow's prototype.
-4. **WS2:** Fix #1275 presolve absolute `$include` paths at the emit site in `src/emit/emit_gams.py:933` (the `Path(source_file).resolve().as_posix()` call per `CATALOG_EMITTER_BACKLOG.md` Batch 1). Per the issue writeup and `CATALOG_EMITTER_BACKLOG.md`, emit a repo-relative path when the source is inside the repo (e.g., `$include data/gamslib/raw/<model>.gms`), or use a configurable macro such as `%NLP2MCP_SRC%` with a default like `data/gamslib/raw` so the presolve wrapper is portable across workstations and CI. Unit test under `tmp_path`.
-5. **Tier 0 dispatch canary:** `diff /tmp/sprint25-golden/dispatch_mcp.gms <(python -m src.cli data/gamslib/raw/dispatch.gms -o /dev/stdout --skip-convexity-check)` — MUST be empty.
+1. **Full 54-set golden-file regression with Day 6 prototype.** Enumerate matching models from the frozen baseline status JSON, then diff each (see `../PLAN.md` and the Sprint 24 prompts for the standard incantation). Expected 0 regressions; if regressions appear, classify by whether they involve alias-of-IndexOffset patterns — that tells you whether to narrow the Pattern C gate or widen it.
+2. **Full launch re-validation:** Translate launch fresh → `gams /tmp/launch_mcp.gms action=c` (compile-only) → PATH solve. Measure rel_diff against the baseline NLP solution. Document in `DAY7_COHORT_SWEEP.md`. If rel_diff materially improves (e.g., 0.17 → <0.01), mark launch as a Match candidate for Day 14 pipeline retest.
+3. **Pattern A cohort sanity sweep** — for each of the 6 models in #1138, #1139, #1140, #1142, #1145, #1150:
+   - Map the GH issue to the concrete model name (check `AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern A rows).
+   - Run `SPRINT25_DAY2_DEBUG=1 .venv/bin/python -m src.cli data/gamslib/raw/<model>.gms -o /tmp/sprint25-day7/<model>_mcp.gms --skip-convexity-check --quiet 2> /tmp/sprint25-day7/<model>_trace.stderr`.
+   - Inspect the model's primary stationarity equation(s) in the emitted MCP. Classify as:
+     - **Pattern A shape (AD-blocked):** `_partial_collapse_sum` gap → emits `0` where a known-nonzero derivative belongs.
+     - **Pattern C shape (phantom offsets):** stationarity emission has ±N offsets not present in the source.
+     - **Other:** nonconvex-solver noise, scalar/domain mismatch, or latent KKT bug.
+   - Record the classification in `DAY7_COHORT_SWEEP.md` (one row per model with: model name, issue ID, symptom shape, evidence reference [trace file path or specific line in emitted MCP], proposed Sprint 26 follow-up issue title).
+4. **If any cohort model is classified as Pattern-C-shaped,** extend the Day 6 prototype gate to cover it; re-run the 54-set regression after the extension.
+5. **If any cohort model is classified as genuinely Pattern-A-shaped** (the Day 5 investigation missed it), document in `DAY7_COHORT_SWEEP.md` + flag for potential Day 13 buffer-day work; file a Sprint 26 carryforward.
+6. **Create `docs/planning/EPIC_4/SPRINT_25/DAY7_COHORT_SWEEP.md`** — structure mirrors DAY5_PATTERN_A_INVESTIGATION.md with a "Classification Table" section + one short evidence subsection per model.
+7. **Tier 0 + Tier 1 canary** — same commands as Day 6.
 
 **Quality Checks:** `make typecheck && make lint && make format && make test`.
 
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 7: Pattern C full-regression validation + Pattern A cohort classification sweep`. Body references `DAY5_PATTERN_A_INVESTIGATION.md` + the new `DAY7_COHORT_SWEEP.md`.
+
 ---
 
-## Day 3 Prompt: WS1 Phase 1 Prototype + WS2 Batch 1 #1280
+## Day 8 Prompt: qabel/abel PATH-Solve Reassessment + WS2 Batch 2 Start (#1279)
 
-**Branch:** `sprint25-day3-alias-prototype`.
+**Branch:** `sprint25-day8-qabel-abel-reassess-plus-1279`.
 
-**Objective:** Prototype `_partial_collapse_sum` multi-index extension; land #1280 unquoted-UEL-dots fix.
+**Objective:** Determine whether qabel/abel rel_diff (0.08, 0.30) reflects a real emission bug or nonconvex-solver noise. Start WS2 Batch 2 with #1279 robustlp scalar-widening.
 
-**Tasks to Complete (~4–5 hours):**
+**Prerequisites:**
+- `DAY5_PATTERN_A_INVESTIGATION.md` §"Evidence — KKT stateq term on qabel/abel" — specifically the `nu_stateq(n, k-1)$(ord(k) > 1)` shift and its compatibility with the declared `nu_stateq(n, k)` domain.
+- GAMS + PATH solver installed locally. (If not — run the PATH solve on a CI runner; this day's results can be captured asynchronously.)
 
-1. **WS1:** Implement multi-index concrete→symbolic recovery in `_partial_collapse_sum` (guard with `_find_var_indices_in_body` and `bound_indices`). Target: qabel `stat_x` now includes the correct cross-term `sum(n', a(n',n)*x(n',k))`.
-2. **WS1:** Validate qabel: translate → diff stationarity against Day 2 baseline → GAMS compile via `gams /tmp/qabel_mcp.gms action=c` → PATH solve.
-3. **WS1:** Tier 0 dispatch canary + Tier 1 canary (quocge, partssupply, prolog) MUST still match.
-4. **WS2:** Fix #1280 (mathopt4 unquoted UEL dots) — quote synthetic element labels containing `.` in emitter.
-5. **Run golden-file regression** on all 54 matching models. Enumerate them from the frozen baseline status JSON, then diff each:
+**Tasks to Complete (~5–7 hours):**
+
+1. **Translate qabel + abel fresh** (they should be unchanged from Day 5 since neither is Pattern-C-shaped):
+   ```bash
+   for m in qabel abel; do
+     python -m src.cli data/gamslib/raw/$m.gms -o /tmp/sprint25-day8/${m}_mcp.gms --skip-convexity-check
+   done
+   ```
+2. **Full PATH solve** (NOT `action=c` — action=c hits pre-existing Error 141 cascades per Day 5). Capture solve output + rel_diff measurement.
+3. **Classify the result:**
+   - **If rel_diff < ~1e-4 (acceptable numerical noise on nonconvex problem):** mark #1138 (qabel) and/or #1139 (abel) as "non-bug; nonconvex-solver noise" in `AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern A rows. Close the corresponding GH issues with resolution note linking to this Day 8 PR.
+   - **If rel_diff remains material (systematic bias):** bisect the `stat_x` emission against the expected symbolic form. Prime suspects per Day 5 evidence: the `nu_stateq(n, k-1)$(ord(k) > 1)` domain-shift term (check emitter's handling of equations declared over `(n, k+1)`). File a narrow follow-up issue with the specific emission bug localized; add to Day 13 buffer if a same-day fix is feasible, otherwise Sprint 26 carryforward.
+4. **#1279 robustlp scalar-widening:** Fix in `src/ir/normalize.py`. The emitter currently emits `defobj(i)` as a domain-indexed equation when the AD treats it as scalar. Fix the normalize pass to consistently widen OR consistently narrow. Add unit test in `tests/unit/ir/test_normalize_scalar_widening.py`.
+5. **Tier 0 + Tier 1 + full 54-set golden-file regression.** Expected 0 regressions from the #1279 fix (it only affects robustlp-shaped models).
+
+**Quality Checks:** `make typecheck && make lint && make format && make test`.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 8: qabel/abel PATH-solve reassessment + #1279 robustlp scalar-widening`.
+
+---
+
+## Day 9 Prompt: WS2 Batch 2 Continue (#1276, #1281, #1292)
+
+**Branch:** `sprint25-day9-batch2-complete`.
+
+**Objective:** Land Batch 2 remainder: #1276 fawley duplicate `.fx`, #1281 lmp2 duplicate Parameter declaration, #1292 turkpow line wrap.
+
+**Prerequisites:**
+- Read `CATALOG_EMITTER_BACKLOG.md` §Batch 2.
+- Key source files: `src/emit/emit_gams.py` (assignment-emit + declaration-emit sites for `.fx` and Parameter); new `_DeclaredSymbolTracker` helper.
+
+**Tasks to Complete (~5–7 hours):**
+
+1. **Implement `_DeclaredSymbolTracker` helper.** Module-local in `src/emit/emit_gams.py` (or a small new file). Tracks `(symbol_name, scope_tuple)` pairs that have already been emitted so subsequent duplicate declarations/assignments can be skipped. Unit test under `tests/unit/emit/`.
+2. **#1276 fawley:** Use the tracker to detect already-emitted `.fx` assignments on `(var_name, indices)` pairs and skip duplicates. Confirm fawley translates + compiles.
+3. **#1281 lmp2:** Same helper, applied to Parameter declarations. Confirm lmp2 translates + compiles.
+4. **#1292 turkpow:** Add line-wrapping in the emitter for `sameas()` Cartesian-product expansions when the emitted line length exceeds ~1000 chars. Wrap at natural boundaries (after `+`/`-` operators in top-level sums). Add synthetic test with a known-large expansion asserting max line length.
+5. **Tier 0 + Tier 1 + full 54-set golden-file regression.**
+
+**Quality Checks:** `make typecheck && make lint && make format && make test`.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 9: WS2 Batch 2 complete (#1276 fawley .fx dedup, #1281 lmp2 Parameter dedup, #1292 turkpow line wrap)`.
+
+---
+
+## Day 10 Prompt: WS2 Batch 3 Core (#1277 post-Pattern-C + #1278 tautology)
+
+**Branch:** `sprint25-day10-batch3-core`.
+
+**Objective:** Re-validate #1277 twocge mixed offsets now that Pattern C is live; fix #1278 `ord(r) <> ord(r)` tautology.
+
+**Prerequisites:**
+- Day 6 Pattern C prototype merged.
+- `CATALOG_EMITTER_BACKLOG.md` §#1277, §#1278.
+
+**Tasks to Complete (~5–7 hours):**
+
+1. **#1277 twocge re-validation:** Re-translate twocge. Inspect `stat_tz` for offset-alias correctness. If still broken, file a narrow follow-up issue with the specific mis-emission localized and move on (Batch 3 is not a single-fix blocker).
+2. **#1278 `ord(r) <> ord(r)` tautology:** Locate the substitution site in `src/kkt/stationarity.py`. The stationarity emitter produces `ord(r) <> ord(r)` (always false) where `ord(r) <> ord(rp)` is intended (the alias-correct form). Fix + unit test in `tests/unit/kkt/`.
+3. **Tier 0 + Tier 1 + full 54-set golden-file regression.**
+
+**Quality Checks:** `make typecheck && make lint && make format && make test`.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 10: WS2 Batch 3 core — #1277 twocge post-Pattern-C + #1278 tautology fix`.
+
+---
+
+## Day 11 Prompt: WS2 Batch 3 Finish (#1290, #1291) + Checkpoint 2
+
+**Branch:** `sprint25-day11-batch3-complete-plus-checkpoint2`.
+
+**Objective:** Close Batch 3 with #1290 ferts identifier length + #1291 clearlak statement ordering. Evaluate Checkpoint 2 (GO/CONDITIONAL/NO-GO) via full pipeline retest.
+
+**Prerequisites:**
+- `CATALOG_EMITTER_BACKLOG.md` §#1290, §#1291.
+- `../PLAN.md` §"Day 11 — WS2 Batch 3 Finish ... + Checkpoint 2" for the Checkpoint 2 criteria table.
+
+**Tasks to Complete (~6–8 hours):**
+
+1. **#1290 ferts identifier length:** Fix the 67-char multiplier-name violation. Add a synthetic-hash-shortening pass in the emitter: when an emitted identifier would exceed the GAMS 63-char identifier limit, replace the tail with a short deterministic hash of the full name. Record the mapping in a comment banner near the declaration so a human reader can trace back.
+2. **#1291 clearlak statement ordering:** Hoist `sum(leaf, ...)` AFTER `leaf(n) = yes$(...)` initialization, not before. Verify determinism via 3-seed run (`for s in 0 1 42; do PYTHONHASHSEED=$s python -m src.cli data/gamslib/raw/clearlak.gms -o /tmp/clearlak_s${s}.gms --skip-convexity-check; done; shasum -a 256 /tmp/clearlak_s*.gms`).
+3. **Run full pipeline retest:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m).
+4. **Evaluate Checkpoint 2 criteria** (see `../PLAN.md` §"Day 11"):
+
+   | Criterion | Day 11 value | GO threshold | Status |
+   |---|---|---|---|
+   | Match | | ≥56 (GO) / ≥55 (COND) / <54 (NO-GO) | |
+   | Solve | | ≥100 (GO) / ≥99 (COND) / <99 (NO-GO) | |
+   | path_syntax_error | | ≤7 (GO) / ≤9 (COND) / >11 (NO-GO) | |
+   | model_infeasible | | ≤7 (GO) / ≤8 (COND) / >8 (NO-GO) | |
+   | Canaries (Tier 0+1) | | All match (GO) / ≤1 regression (COND) | |
+   | Tests | | All pass | |
+
+5. **Document decision in `SPRINT_LOG.md`** Day 11 entry. If NO-GO: Day 12 reverts offending PRs; Phase E cancelled; Day 13 buffer used for revert stabilization.
+
+**Quality Checks:** `make typecheck && make lint && make format && make test`.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 11: WS2 Batch 3 complete (#1290 ferts, #1291 clearlak) + Checkpoint 2`.
+
+---
+
+## Day 12 Prompt: WS4 Small Priorities (#1270 + #1271)
+
+**Branch:** `sprint25-day12-small-priorities`.
+
+**Objective:** Land the #1270 multi-solve gate extension and the #1271 dispatcher refactor.
+
+**Prerequisites:**
+- Read `docs/planning/EPIC_4/SPRINT_25/DESIGN_SMALL_PRIORITIES.md`.
+- Key sources: `src/validation/driver.py:151–225` (#1270), `src/emit/original_symbols.py::emit_pre_solve_param_assignments` (nested `_loop_tree_to_gams_subst_dispatch`).
+
+**Tasks to Complete (~7.5–9.5 hours):**
+
+1. **#1270 (3.5–4.5h):** Implement Approach A cross-reference in `_collect_top_level_marginals_with_param_feedback`. 4-fixture test matrix (per `DESIGN_SMALL_PRIORITIES.md` fixture table — only F1 should flag):
+   - F1 saras-style feedback (MUST flag).
+   - F2 post-solve reporting (MUST NOT flag).
+   - F3 multi-stage display (MUST NOT flag).
+   - F4 partssupply-style `var.l` (MUST NOT flag).
+   - Canaries: gussrisk / sparta (MUST NOT flag — currently matching).
+2. **#1271 (4–5h):** Unify signature `_loop_tree_to_gams(node, *, token_subst=None)`. Remove nested `_loop_tree_to_gams_subst_dispatch`. Byte-diff regression — enumerate the 135 currently-translating models from the frozen baseline status JSON:
 
    ```bash
+   TRANSLATING=$(python - <<'PY'
+   import json
+   from pathlib import Path
+   data = json.loads(Path('data/gamslib/gamslib_status.json').read_text())
+   print(' '.join(e['model_id'] for e in data['models']
+                  if (e.get('nlp2mcp_translate') or {}).get('status') == 'success'))
+   PY
+   )
+   mkdir -p /tmp/pre /tmp/post
+   for m in $TRANSLATING; do
+     PYTHONHASHSEED=0 python -m src.cli data/gamslib/raw/$m.gms -o /tmp/pre/${m}.gms --skip-convexity-check
+   done
+   # apply refactor
+   for m in $TRANSLATING; do
+     PYTHONHASHSEED=0 python -m src.cli data/gamslib/raw/$m.gms -o /tmp/post/${m}.gms --skip-convexity-check
+   done
+   diff -r /tmp/pre /tmp/post  # MUST be empty
+   ```
+
+**Quality Checks:** `make typecheck && make lint && make format && make test`.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 12: WS4 small priorities — #1270 multi-solve gate extension + #1271 dispatcher refactor`.
+
+---
+
+## Day 13 Prompt: Buffer / Optional Phase E / Sprint-Close Prep
+
+**Branch:** `sprint25-day13-buffer`.
+
+**Objective:** Absorb slippage; optional Phase E routing if Checkpoint 2 was GO; file Sprint 26 carryforward issues.
+
+**Tasks to Complete (~3–6 hours):**
+
+1. **Buffer:** Close any Batch 3 / WS4 tail.
+2. **OPTIONAL (Checkpoint 2 GO + ≥3h slack):** Phase E routing — re-inspect:
+   - **#1141 (kand):** re-verify after Sprint 24 multi-solve gate extension. If still broken, classify as Pattern E via `DESIGN_ALIAS_AD_ROLLOUT.md` §Phase 4.
+   - **#1144 (launch post-Pattern-C):** Day 6 Pattern C fix may have already resolved this. Re-check.
+   - **#1147 (camshape):** Re-verify.
+3. **OPTIONAL stretch (≥4h clear headroom):** Per Task 8 contingency, implement Option 1 short-circuit in `src/ad/index_mapping.py::enumerate_equation_instances` (with supporting behavior in `resolve_set_members` + static `SetMembershipTest` failure path in `src/ir/condition_eval.py`). Target: unblock srpchase (+1 Solve) and possibly iswnm (+1 Solve).
+4. **OPTIONAL (if Day 8 flagged qabel/abel as real emission bug with a localized fix):** Land the narrow qabel/abel `nu_stateq` domain-shift fix here; otherwise carry forward to Sprint 26.
+5. **File Sprint 26 carryforward issues (label `sprint-26`):**
+   - Translation timeouts: 4 of 5 hard timeouts (iswnm, sarf, mexls, nebrazil) unless Option 1 landed today.
+   - `mine` `internal_error` / `SetMembershipTest`.
+   - Any Phase E issue not resolved (#1141, #1144, #1147 if not landed today).
+   - **Original Pattern A Phase 2 cohort models reclassified per Day 7 cohort sweep** — close original issues with resolution note "reclassified via Day 7 sweep as <shape>; see `DAY7_COHORT_SWEEP.md`"; file new Sprint 26 issues under the correct bug category.
+6. **Update `KNOWN_UNKNOWNS.md`** with end-of-sprint discoveries.
+
+**Quality Checks:** Skip unless `.py` touched.
+
+**Commit + PR:** One PR for this day (if any code changes) + `SPRINT_LOG.md` entry for Sprint 26 issue-filing. Title: `Sprint 25 Day 13: buffer + Sprint 26 carryforward issue filing`.
+
+---
+
+## Day 14 Prompt: Final Pipeline Retest
+
+**Branch:** `sprint25-day14-retest`.
+
+**Objective:** Definitive pipeline metrics per PR6.
+
+**Tasks to Complete (~3–4 hours):**
+
+1. **Full pipeline:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m).
+2. **Record final metrics:** Parse / Translate / Solve / Match + 4 `outcome_category` counts.
+3. **Cross-check against `../PLAN.md` §Sprint 25 Targets (Revised).**
+4. **Error-influx accounting (per PR7 + PR10 re-calibrated):**
+   - Alias-AD / Pattern C gross fixes vs new errors. Check against 30% budget.
+   - Emitter-recovered gross fixes vs new errors. Check against 80–100% budget.
+5. **Commit updated `data/gamslib/gamslib_status.json`** (and note that `.gms` emitted artifacts remain advisory-only until PR12 fully stabilizes per `BASELINE_METRICS.md` §6).
+
+**Quality Checks:** Skip unless `.py` touched.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 14: final pipeline retest`.
+
+---
+
+## Day 15 Prompt: Sprint Close + Retrospective
+
+**Branch:** `sprint25-day15-retro`.
+
+**Objective:** Write retrospective (with special focus on the Day 5 pivot lessons), update CHANGELOG + PROJECT_PLAN, file Sprint 26 recommendations.
+
+**Prerequisites:**
+- Read `docs/planning/EPIC_4/SPRINT_24/SPRINT_RETROSPECTIVE.md` as template.
+- Day 14 final metrics recorded in `SPRINT_LOG.md`.
+
+**Tasks to Complete (~3–4 hours):**
+
+1. **Write `docs/planning/EPIC_4/SPRINT_25/SPRINT_RETROSPECTIVE.md`** using Sprint 24 template:
+   - Metrics delta against `../PLAN.md` §Sprint 25 Targets (Revised).
+   - Acceptance criteria pass/fail.
+   - Went well / what could be improved.
+   - **Special section: Day 5 pivot retrospective.** What the original Phase 2 Pattern A hypothesis got wrong. The evidence methodology that disproved it — trace capture under `SPRINT25_DAY2_DEBUG=1`, reading the emitted GAMS, comparing to the formal symbolic derivative — is reusable. Recommend: in future sprints where a multi-issue workstream shares a single hypothesized root cause, run the Day 5 investigation Pre-Sprint-0 rather than post-hoc mid-sprint.
+   - PR10 re-calibration outcome — did the 30% / 80–100% split hold against Pattern C's narrower scope?
+   - New recommendations (PR16+) for Sprint 26.
+2. **Update `CHANGELOG.md`** Sprint 25 Summary (mirror Sprint 24's format). Include the Day 5 pivot as a key narrative beat, not just a metrics delta.
+3. **Update `PROJECT_PLAN.md` Rolling KPIs.**
+4. **File Sprint 26 recommendations** — Pattern A cohort reclassification, Pattern C remainder, translation timeouts, Phase E remainders, any new discoveries.
+
+**Quality Checks:** Skip unless `.py` touched.
+
+**Commit + PR:** One PR for this day. Title: `Sprint 25 Day 15: retrospective + sprint close`.
+
+---
+
+## Reference: Tier 1 Canary Command (unchanged)
+
+```bash
+# Run before any WS1 / Pattern C / WS2 PR merges — expect zero diffs from golden files
+for m in dispatch quocge partssupply prolog sparta gussrisk ps2_f ps3_f ship splcge paklive; do
+  diff /tmp/sprint25-golden/${m}_mcp.gms \
+    <(python -m src.cli data/gamslib/raw/$m.gms -o /dev/stdout --skip-convexity-check 2>/dev/null) \
+    && echo "✅ $m" || echo "❌ $m REGRESSED"
+done
+```
+
+---
+
+## Reference: 54-Set Golden-File Regression Command (unchanged)
+
+```bash
 MATCHING=$(python - <<'PY'
 import json
 from pathlib import Path
@@ -105,282 +365,6 @@ print(' '.join(e['model_id'] for e in data['models']
 PY
 )
 for m in $MATCHING; do
-  diff /tmp/sprint25-golden/${m}_mcp.gms \
-    <(python -m src.cli data/gamslib/raw/$m.gms -o /dev/stdout --skip-convexity-check 2>/dev/null) \
-    && echo "✅ $m" || echo "❌ $m REGRESSED"
-done
-   ```
-
-   No diffs expected.
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 4 Prompt: WS1 Phase 1 Complete + WS2 Batch 2.5 (#1289 high-leverage)
-
-**Branch:** `sprint25-day4-phase1-complete-plus-ganges`.
-
-**Objective:** Complete Phase 1 validation (qabel, abel, launch). Land the highest-leverage single fix of the sprint: #1289 ganges/gangesx calibration stripping (unblocks 2 of 5 Task 5 models).
-
-**Prerequisites:**
-- Read `docs/planning/EPIC_4/SPRINT_25/ANALYSIS_RECOVERED_TRANSLATES.md` §#1289.
-
-**Tasks to Complete (~5–7 hours):**
-
-1. **WS1:** Validate Phase 1 fix on abel, launch. Measure `stat_x` / `stat_u` line count change vs Day 0 golden. Document any Pattern A model that now matches.
-2. **WS1:** Run Tier 0 + Tier 1 canary. Run `make test`. Quality gate.
-3. **WS1:** **Gate 1 (Day 3 deferred into Day 4):** dispatch identical + ≤1 Tier 1 regression + ≥1 of 3 targets improves ≥50% → GO to Phase 2 Day 5.
-4. **WS2 #1289:** Fix ganges calibration-from-`.l` stripping in `src/emit/emit_gams.py`. Per `ANALYSIS_RECOVERED_TRANSLATES.md` §1.2, the emitter currently strips calibration assignments like `deltas(i)$ls.l(i) = (k(i)/ls.l(i))**(1/sigmas(i))*...` because they reference `.l` values. For ganges/gangesx the pattern is "declare + initial-solve + calibrate + final-solve": the calibration must run **after** an initial NLP solve (typically supplied via `--nlp-presolve` `$include`). Update the stripping logic to retain post-initial-solve calibration assignments when the presolve flow will supply their `.l` values; preserve any pre-solve calibration assignments too if present. Verify ganges + gangesx translate → PATH compile → PATH solve → Match.
-5. **WS2:** Check whether the #1289 post-solve calibration-preservation change causes any regression on the 54 matching set (it should not — the fix is additive for calibration-stripped models).
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 5 Prompt: WS1 Phase 2 Start + WS2 Batch 2 Start
-
-**Branch:** `sprint25-day5-phase2-start`.
-
-**Objective:** Apply Pattern A fix across all 6 issues (#1138, #1139, #1140, #1142, #1145, #1150). Begin Batch 2 with #1279 robustlp scalar widening.
-
-**Tasks to Complete (~4–5 hours):**
-
-1. **WS1:** Validate Pattern A fix on model set: {quocge (already matching), irscge, lrgcge, moncge, stdcge, cesam, korcge, chenery, ps2_s, ps3_s, ps3_s_gic, ps3_s_mn, ps5_s_mn, ps10_s_mn, cclinpts}. Record per-model outcome:
-   - mismatch → match
-   - mismatch → mismatch (value improved)
-   - mismatch → path_syntax_error (count as INFLUX — charged against 30% alias-AD budget)
-   - no change
-2. **WS2 #1279:** Fix robustlp `defobj(i)` scalar-equation widening in `src/ir/normalize.py`. The emitter currently emits `defobj(i)` as a domain-indexed equation when the AD treats it as scalar — fix the normalize pass to either consistently widen or consistently narrow.
-3. **Tier 0 + Tier 1 canary + full 54-set golden-file regression.**
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 6 Prompt: Checkpoint 1 + WS2 Batch 2 Continue (#1276, #1281)
-
-**Branch:** `sprint25-day6-checkpoint1`.
-
-**Objective:** **Checkpoint 1** — evaluate Phase 2 GO/CONDITIONAL/NO-GO. Continue Batch 2 with #1276 and #1281 using shared `_DeclaredSymbolTracker` helper.
-
-**Tasks to Complete (~5–7 hours):**
-
-1. **Run full pipeline retest:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m). Record Translate / Solve / Match / error-category counts.
-2. **Evaluate Checkpoint 1 criteria** (see `PLAN.md` §Checkpoint 1 table):
-
-| Criterion | Day 6 value | GO threshold | Status |
-|---|---|---|---|
-| Tier 0 (dispatch) | | Identical | |
-| Tier 1 regressions | | 0 (GO) / ≤1 (COND) / >1 (NO-GO) | |
-| Pattern A ≥50% improved | | ≥3 of 6 (GO) / ≥1 (COND) / 0 (NO-GO) | |
-| Cumulative Match Δ | | ≥+3 (GO) / ≥+1 (COND) / <0 (NO-GO) | |
-| Tests | | All pass | |
-| path_syntax_error | | ≤10 (GO) / ≤11 (COND) / >11 (NO-GO) | |
-
-3. **Document decision** in `SPRINT_LOG.md` Day 6 entry. If NO-GO: revert Phase 2 PRs; plan Day 7 as root-cause investigation.
-4. **WS2 Batch 2:** Implement shared `_DeclaredSymbolTracker` helper. Fix #1276 (fawley duplicate `.fx`) + #1281 (lmp2 duplicate Parameter).
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 7 Prompt: WS1 Phase 3 Start (Pattern C) + WS2 #1292
-
-**Branch:** `sprint25-day7-pattern-c`.
-
-**Objective:** Extend `_alias_match` for `IndexOffset.base` (Pattern C). Land short WS2 fix #1292 turkpow line-wrap.
-
-**Prerequisites:**
-- Read `../DESIGN_ALIAS_AD_ROLLOUT.md` §Phase 3.
-- Key source: `src/ad/derivative_rules.py:304–307` (`_alias_match`).
-
-**Tasks to Complete (~4–5 hours):**
-
-1. **WS1 Phase 3:** Extend `_alias_match` to handle `IndexOffset` vs plain-string cases via `_same_root_set(expr_idx.base, wrt_idx, aliases)`. Target models: polygon, himmel16 (#1143, #1146).
-2. **WS1:** Validate polygon, himmel16 translate → compile → solve. Measure Solve/Match delta.
-3. **WS2 #1292:** Fix turkpow `stat_zt` 144k-char single-line emission — add line-wrapping in the emitter for `sameas()` Cartesian-product expansions when line length exceeds ~1000 chars.
-4. **Tier 0 + Tier 1 canary.**
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 8 Prompt: WS1 Phase 3 Continue + WS2 #1278 (twocge tautology)
-
-**Branch:** `sprint25-day8-pattern-c-plus-1278`.
-
-**Objective:** Re-validate #1277 (partially subsumed by Pattern C). Fix #1278 (twocge `ord(r) <> ord(r)` tautology).
-
-**Tasks to Complete (~4–5 hours):**
-
-1. **WS1:** Re-translate twocge after Pattern C landing. Verify #1277 `stat_tz` offset-alias correctness; if still broken, file a narrow follow-up issue.
-2. **WS2 #1278:** Fix tautology substitution bug in `src/kkt/stationarity.py`. The stationarity emitter substitutes `ord(r) <> ord(r)` (always false) instead of `ord(r) <> ord(rp)` (the alias-correct form). Identify the substitution site; fix + unit test.
-3. **Tier 0 + Tier 1 canary + 54-set golden-file regression.**
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 9 Prompt: Gate 3 + WS2 Batch 3 Completion (#1290, #1291)
-
-**Branch:** `sprint25-day9-batch3-complete`.
-
-**Objective:** Evaluate Gate 3; complete Batch 3 with #1290 (ferts identifier length) + #1291 (clearlak statement ordering).
-
-**Tasks to Complete (~4–5 hours):**
-
-1. **Gate 3 evaluation:** Pattern C target (polygon, himmel16) improves ≥50% OR Pattern A not regressed AND #1277 resolved → GO to Phase 4.
-2. **WS2 #1290:** Fix ferts multiplier-name 67-char length violation. Add a synthetic-hash-shortening pass in the emitter.
-3. **WS2 #1291:** Fix clearlak statement ordering — hoist `sum(leaf, ...)` AFTER `leaf(n) = yes$(...)` initialization, not before. Deterministic per 3-seed verification per Task 5.
-4. **Run full 54-set golden-file regression.**
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 10 Prompt: Checkpoint 2 + WS1 Phase 4 Start
-
-**Branch:** `sprint25-day10-checkpoint2`.
-
-**Objective:** **Checkpoint 2** — evaluate Phase 4 scope. Begin Pattern E routing if GO (#1141, #1144, #1147).
-
-**Tasks to Complete (~5–7 hours):**
-
-1. **Full pipeline retest** (~2h15m).
-2. **Evaluate Checkpoint 2 criteria** (see `PLAN.md` §Checkpoint 2 table):
-
-| Criterion | Day 10 value | GO threshold | Status |
-|---|---|---|---|
-| Match | | ≥60 (GO) / ≥58 (COND) / <55 (NO-GO) | |
-| Solve | | ≥102 (GO) / ≥100 (COND) / <99 (NO-GO) | |
-| path_syntax_error | | ≤7 (GO) / ≤9 (COND) / >11 (NO-GO) | |
-| model_infeasible | | ≤7 (GO) / ≤8 (COND) / >8 (NO-GO) | |
-| Canaries (Tier 0+1) | | All match (GO) / ≤1 regression (COND) | |
-| Tests | | All pass | |
-
-3. **GO → Phase 4:** Route #1141 (kand: multi-solve driver? re-verify after Sprint 24 gate extension), #1144 (launch rechecked), #1147 (camshape — re-verify post-Pattern-A).
-4. **CONDITIONAL → Phase 4 cleanup-only.**
-5. **NO-GO → lock main; Day 11 reverts.**
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 11 Prompt: WS4 Small Priorities (#1270 + #1271)
-
-**Branch:** `sprint25-day11-small-priorities`.
-
-**Objective:** Land the #1270 multi-solve gate extension and the #1271 dispatcher refactor.
-
-**Prerequisites:**
-- Read `docs/planning/EPIC_4/SPRINT_25/DESIGN_SMALL_PRIORITIES.md`.
-- Key sources: `src/validation/driver.py:151–225` (#1270), `src/emit/original_symbols.py::emit_pre_solve_param_assignments` (line ~3271, nested `_loop_tree_to_gams_subst_dispatch`).
-
-**Tasks to Complete (~7.5–9.5 hours — may spill to Day 12 buffer):**
-
-1. **#1270 (3.5–4.5h):** Implement Approach A cross-reference in `_collect_top_level_marginals_with_param_feedback`. Fixture matrix (per `DESIGN_SMALL_PRIORITIES.md` fixture table — only F1 should flag):
-   - F1 saras-style feedback (MUST flag).
-   - F2 post-solve reporting (MUST NOT flag).
-   - F3 multi-stage display (MUST NOT flag).
-   - F4 partssupply-style `var.l` (MUST NOT flag).
-   - Canaries: gussrisk / sparta (MUST NOT flag — currently matching).
-2. **#1271 (4–5h):** Unify signature `_loop_tree_to_gams(node, *, token_subst=None)`. Remove nested `_loop_tree_to_gams_subst_dispatch`. Byte-diff regression — enumerate the 135 currently-translating models from the frozen baseline status JSON:
-
-   ```bash
-TRANSLATING=$(python - <<'PY'
-import json
-from pathlib import Path
-data = json.loads(Path('data/gamslib/gamslib_status.json').read_text())
-print(' '.join(e['model_id'] for e in data['models']
-               if (e.get('nlp2mcp_translate') or {}).get('status') == 'success'))
-PY
-)
-mkdir -p /tmp/pre /tmp/post
-for m in $TRANSLATING; do
-  PYTHONHASHSEED=0 python -m src.cli data/gamslib/raw/$m.gms -o /tmp/pre/${m}.gms --skip-convexity-check
-done
-# apply refactor
-for m in $TRANSLATING; do
-  PYTHONHASHSEED=0 python -m src.cli data/gamslib/raw/$m.gms -o /tmp/post/${m}.gms --skip-convexity-check
-done
-diff -r /tmp/pre /tmp/post  # MUST be empty
-   ```
-
-**Quality Checks:** `make typecheck && make lint && make format && make test`.
-
----
-
-## Day 12 Prompt: Buffer / Overflow / Sprint-Close Prep
-
-**Branch:** `sprint25-day12-buffer`.
-
-**Objective:** Absorb slippage; optional Priority 5 contingency; file Sprint 26 issues.
-
-**Tasks to Complete (~3–6 hours):**
-
-1. **Buffer:** Close any Phase 4 / Batch 3 / Day 11 tail.
-2. **Stretch (optional, only if slack):** Per Task 8 contingency, implement Option 1 short-circuit in `src/ad/index_mapping.py::enumerate_equation_instances` (with supporting behavior in `resolve_set_members` + static `SetMembershipTest` failure path in `src/ir/condition_eval.py`). Target: unblock srpchase (+1 Solve) and possibly iswnm (+1 Solve). Effort 4–6h; do NOT land unless schedule has ≥4h clear headroom.
-3. **File Sprint 26 carryforward issues** (label `sprint-26`):
-   - Translation timeouts: 4 of 5 hard timeouts (iswnm, sarf, mexls, nebrazil) unless Option 1 landed today.
-   - `mine` `internal_error`.
-   - Any Pattern E issue not resolved (#1141, #1144, #1147 if Phase 4 didn't land).
-4. **Update `KNOWN_UNKNOWNS.md`** with end-of-sprint discoveries.
-
-**Quality Checks:** Skip unless `.py` touched.
-
----
-
-## Day 13 Prompt: Final Pipeline Retest
-
-**Branch:** `sprint25-day13-retest`.
-
-**Objective:** Definitive pipeline metrics per PR6.
-
-**Tasks to Complete (~3–4 hours):**
-
-1. **Full pipeline:** `.venv/bin/python scripts/gamslib/run_full_test.py --quiet` (~2h15m).
-2. **Record final metrics:** Parse / Translate / Solve / Match + 4 `outcome_category` counts.
-3. **Cross-check against `PLAN.md` §Sprint 25 Targets.**
-4. **Error-influx accounting (per PR7 + PR10 re-calibrated):**
-   - Alias-AD gross fixes vs new errors. Check against 30% budget.
-   - Emitter-recovered gross fixes vs new errors. Check against 80–100% budget.
-5. **Commit updated `data/gamslib/gamslib_status.json`** (and note that `.gms` emitted artifacts remain advisory-only until PR12 fully stabilizes per BASELINE_METRICS.md §6).
-
-**Quality Checks:** Skip unless `.py` touched.
-
----
-
-## Day 14 Prompt: Sprint Close + Retrospective
-
-**Branch:** `sprint25-day14-retro`.
-
-**Objective:** Write retrospective, update CHANGELOG + PROJECT_PLAN, file Sprint 26 recommendations.
-
-**Prerequisites:**
-- Read `docs/planning/EPIC_4/SPRINT_24/SPRINT_RETROSPECTIVE.md` as template.
-
-**Tasks to Complete (~3–4 hours):**
-
-1. **Write `docs/planning/EPIC_4/SPRINT_25/SPRINT_RETROSPECTIVE.md`** using Sprint 24 template:
-   - Metrics delta against Sprint 25 Targets.
-   - Acceptance criteria pass/fail (X of 8).
-   - Went well / what could be improved.
-   - PR10 re-calibration outcome (did the 30% / 80–100% split hold?).
-   - New recommendations (PR16+) for Sprint 26.
-2. **Update `CHANGELOG.md`** Sprint 25 Summary (mirror Sprint 24's format).
-3. **Update `PROJECT_PLAN.md` Rolling KPIs.**
-4. **File Sprint 26 recommendations** — translation timeouts, Pattern E remainders, any new discoveries.
-
-**Quality Checks:** Skip unless `.py` touched.
-
----
-
-## Reference: Tier 1 Canary Command
-
-```bash
-# Run before any WS1 PR merges — expect zero diffs from golden files
-for m in dispatch quocge partssupply prolog sparta gussrisk ps2_f ps3_f ship splcge paklive; do
   diff /tmp/sprint25-golden/${m}_mcp.gms \
     <(python -m src.cli data/gamslib/raw/$m.gms -o /dev/stdout --skip-convexity-check 2>/dev/null) \
     && echo "✅ $m" || echo "❌ $m REGRESSED"

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -19,7 +19,7 @@ Days 0–5 have been executed. PR links:
 - **Day 2** — WS1 Phase 1 Start + WS2 Batch 1 Start (#1275 presolve paths; trace instrumentation) → **PR #1302 (merged)**.
 - **Day 3** — WS1 Phase 1 Prototype + #1280 (unquoted UEL dots; `_partial_collapse_sum` multi-index mechanical port) → **PR #1303 (merged)**.
 - **Day 4** — WS1 Phase 1 Complete + WS2 Batch 2.5 (#1289 ganges calibration stripping) → **PR #1304 (merged)**.
-- **Day 5** — **Pattern A Investigation (pivot day)** — evidence-driven examination of qabel/abel/launch concluded none exhibit Pattern A. Launch has Pattern C phantom offsets in KKT stationarity; qabel/abel AD is byte-correct. → **PR #1305 (in flight)**; deliverable `DAY5_PATTERN_A_INVESTIGATION.md`.
+- **Day 5** — **Pattern A Investigation (pivot day)** — evidence-driven examination of qabel/abel/launch concluded none exhibit Pattern A. Launch has Pattern C phantom offsets in KKT stationarity; qabel/abel AD is byte-correct. → **PR #1305**; deliverable `DAY5_PATTERN_A_INVESTIGATION.md`.
 
 The Day 5 pivot DROPS the originally-planned Phase 2 broader Pattern A rollout and replaces it with Pattern C work (Days 6–7) plus a cohort sanity sweep and qabel/abel PATH-solve reassessment (Days 7–8). See `../PLAN.md` §"Day 5 Pivot" for full rationale.
 

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -84,7 +84,11 @@ Original Day 0–5 prompts are preserved in git history at `docs/planning/EPIC_4
 **Tasks to Complete (~5–7 hours):**
 
 1. **Full 54-set golden-file regression with Day 6 prototype.** Enumerate matching models from the frozen baseline status JSON, then diff each (see `../PLAN.md` and the Sprint 24 prompts for the standard incantation). Expected 0 regressions; if regressions appear, classify by whether they involve alias-of-IndexOffset patterns — that tells you whether to narrow the Pattern C gate or widen it.
-2. **Full launch re-validation:** Translate launch fresh → `gams /tmp/launch_mcp.gms action=c` (compile-only) → PATH solve. Measure rel_diff against the baseline NLP solution. Document in `DAY7_COHORT_SWEEP.md`. If rel_diff materially improves (e.g., 0.17 → <0.01), mark launch as a Match candidate for Day 14 pipeline retest.
+2. **Full launch re-validation.** Translate launch fresh. Then run two separate GAMS invocations:
+   - First, a compile-only check: `gams /tmp/launch_mcp.gms action=c` — this verifies the emitted MCP parses and symbols resolve, but does NOT attempt a solve.
+   - Second, a full PATH solve: invoke GAMS without `action=c` (or with `action=ce` for compile+execute) so PATH actually runs and produces a solution. Measure rel_diff against the baseline NLP solution.
+
+   Document both steps in `DAY7_COHORT_SWEEP.md`. If rel_diff materially improves (e.g., 0.17 → <0.01), mark launch as a Match candidate for Day 14 pipeline retest.
 3. **Pattern A cohort sanity sweep** — for each of the 6 models in #1138, #1139, #1140, #1142, #1145, #1150:
    - Map the GH issue to the concrete model name (check `AUDIT_ALIAS_AD_CARRYFORWARD.md` §Pattern A rows).
    - Run `SPRINT25_DAY2_DEBUG=1 .venv/bin/python -m src.cli data/gamslib/raw/<model>.gms -o /tmp/sprint25-day7/<model>_mcp.gms --skip-convexity-check --quiet 2> /tmp/sprint25-day7/<model>_trace.stderr`.

--- a/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md
@@ -53,16 +53,19 @@ Original Day 0–5 prompts are preserved in the file history of `docs/planning/E
 2. **Reproduce minimally.** Add a new test in `tests/unit/kkt/test_pattern_c_alias_offset_gate.py`:
    - Build a synthetic IR mirroring `dweight(s).. weight(s) =e= sum(ss$ge(ss,s), iweight(ss) + pweight(ss)) + ...` — alias `ss` over `s`, conditional sum, no IndexOffset on `s`.
    - Assemble KKT stationarity for the equation.
-   - Assert the emitted `stat_iweight` body has NO `s+N`/`s-N` terms (only the identity alias case, i.e. a single `sum(ss, ...)` with `nu_dweight(s)`).
-   - Verify the test FAILS against current main (documents the bug) and will PASS against the prototype.
+   - Assert the emitted `stat_iweight` body has NO `s+N`/`s-N` terms. After the prototype lands, a single identity-offset `sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s))` term will remain; that term still exhibits the Day-5 Bug #2 (`mis-scoped $(ge(ss, s))` condition inside a `sum(ss, ...)` whose multiplier doesn't depend on `ss`) and is deliberately OUT OF SCOPE for Day 6 — see task 9 below.
+   - Verify the test FAILS against current main (documents Bug #1 — the phantom offsets) and will PASS against the prototype. The test should NOT over-specify the residual `sum(ss, ...)` multiplier argument, since Bug #2's fix may later change it.
 3. **Prototype the gate.** Two-sided approach:
    - Check the equation IR for actual `IndexOffset` nodes on the alias's base set before enumerating ±N offsets. If the body contains no IndexOffset on `s` (or whatever the alias base set is), skip ±N enumeration entirely.
    - If IndexOffsets do exist, preserve the current enumeration logic (so models like twocge #1277 aren't broken — see Day 10 for post-Pattern-C twocge re-validation).
-4. **Verify launch translates correctly.** Translate launch (`python -m src.cli data/gamslib/raw/launch.gms -o /tmp/launch_mcp.gms --skip-convexity-check`) and inspect `stat_iweight` — should now have only `iwf(s) * nu_diweight(s) + sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s))`.
+4. **Verify launch translates correctly.** Translate launch (`python -m src.cli data/gamslib/raw/launch.gms -o /tmp/launch_mcp.gms --skip-convexity-check`) and inspect `stat_iweight`:
+   - **Must hold post-prototype:** `iwf(s) * nu_diweight(s)` remains intact; ALL four phantom-offset `nu_dweight(s±N)` terms are gone; a single identity-offset alias-sum term remains.
+   - **Still-present Day-5 Bug #2 (expected and out of scope today):** the residual alias-sum term is `sum(ss, ((-1) * 1$(ge(ss,s))) * nu_dweight(s))` — note the multiplier `nu_dweight(s)` does NOT depend on the summed index `ss`, so the `sum` degenerates into a spurious `card(ss-satisfying-ge)` factor. This mis-scoped condition is a separate defect from phantom-offset enumeration and is tracked via task 9.
 5. **Tier 0 dispatch canary:** `diff /tmp/sprint25-golden/dispatch_mcp.gms <(python -m src.cli data/gamslib/raw/dispatch.gms -o /dev/stdout --skip-convexity-check)` — MUST be empty.
 6. **Tier 1 canary:** run the Reference command at the bottom of this file on quocge, partssupply, prolog, sparta, gussrisk, ps2_f, ps3_f, ship, splcge, paklive. MUST match golden.
 7. **Do NOT run full 54-set regression today** — defer to Day 7 to isolate the prototype failure surface. A mid-prototype regression on a Tier 2 model is easier to triage on Day 7 when we also have the cohort-sweep data.
-8. **File a new GH issue** `pattern_c_phantom_offset_stat_iweight` — title "Pattern C: KKT stationarity emits phantom ±N offsets on alias-only conditional sums (launch)"; body references `DAY5_PATTERN_A_INVESTIGATION.md`.
+8. **File a new GH issue** `pattern_c_phantom_offset_stat_iweight` — title "Pattern C: KKT stationarity emits phantom ±N offsets on alias-only conditional sums (launch)"; body references `DAY5_PATTERN_A_INVESTIGATION.md` §Bug #1.
+9. **File a separate GH issue** `pattern_c_mis_scoped_alias_condition` — title "Pattern C Bug #2: KKT stationarity mis-scopes `$(ge(ss, s))` condition inside `sum(ss, ...)` where the multiplier is not indexed by `ss`"; body references `DAY5_PATTERN_A_INVESTIGATION.md` §Bug #2 and links to the Day 6 PR as the landing point for Bug #1. Target Sprint 25 Day 13 buffer or Sprint 26 carryforward depending on schedule.
 
 **Quality Checks:** `make typecheck && make lint && make format && make test`.
 


### PR DESCRIPTION
## Summary

Started as an investigation-only PR capturing the Day 5 evidence-driven
trace of the three Phase 1 rel_diff-mismatch targets (qabel, abel,
launch) under `SPRINT25_DAY2_DEBUG=1`. Has since grown to include the
post-pivot **Sprint 25 plan rewrite**: `PLAN.md` and `prompts/PLAN_PROMPTS.md`
are both revised to reflect the Day 5 findings (drop Phase 2 broader
Pattern A rollout, move Pattern C earlier to Days 6–7, add cohort sanity
sweep + qabel/abel PATH-solve reassessment, extend sprint by 1 day).

Docs added / revised:
- `docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md` (NEW) — investigation evidence.
- `docs/planning/EPIC_4/SPRINT_25/PLAN.md` (REVISED) — Day 5+ pivot, Gate 1/Checkpoint 2 restructured, targets recalibrated (Match ≥56, Solve ≥100).
- `docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md` (REVISED) — Days 0–5 marked COMPLETED with PR links; Days 6–15 self-contained prompts matching the new plan.

No code changes. Documentation only.

## Findings

**None of qabel, abel, launch has a Pattern A bug.** Day 3's mechanical port of Sprint 24's `_find_var_indices_in_body` recovery into `_partial_collapse_sum` was the right defensive change for future alias-of-outer-domain shapes, but it doesn't fire on any of the three Phase 1 targets — their bodies already reference the sum's own index names.

**qabel, abel** — AD criterion derivative is byte-for-byte correct. The emitted form matches the expected symmetric-quadratic derivative:

```gams
0.5 * (sum(np__, (x(np__,k) - xtilde(np__,k)) * w(n, np__, k))
     + sum(n__,  (x(n__,k)  - xtilde(n__,k))  * w(n__, n, k)))
```

The `stat_x` non-criterion terms involving `nu_stateq(n, k-1)$(ord(k) > 1)` may be correct under the emitter's declaration convention (`nu_stateq(n, k)` indexed by pre-shift k while the formal stateq domain is `(n, k+1)`) — can't verify at `action=c`; full PATH solve needed (Day 8 task).

**launch** — `stat_iweight` emits phantom `nu_dweight(s+1), (s+2), (s-1), (s-2)` terms with NO corresponding source (`dweight(s)` has one alias + one conditional sum, no IndexOffset). Each clause also has a mis-scoped `$(ge(ss, s))` inside an outer `sum(ss, ...)` where `ss` isn't referenced in the body. Two separate bugs: Bug #1 = phantom offsets (Pattern C, Day 6 target), Bug #2 = mis-scoped condition (separate follow-up per the Day 6 prompt).

## Gate decision

Phase 2 in its originally-scoped shape (broader Pattern A rollout across the corpus) is **halted**. The Phase 1 hypothesis doesn't match the actual bug surface in any of the three target models, so scaling the same approach wouldn't help the broader corpus either. The PLAN.md revision in this PR formalizes the drop and replaces Phase 2 with Pattern C (Days 6–7) + cohort sanity sweep (Day 7) + qabel/abel PATH-solve reassessment (Day 8).

## Recommended Day 6+ plan (in the revised PLAN.md)

1. **Day 6** — Pivot to Pattern C in `src/kkt/stationarity.py`. Reproduce launch's `stat_iweight` phantom-offset generation minimally. Prototype a gate that only emits IndexOffset-style enumeration when the source has an actual IndexOffset. File follow-up issue for Bug #2 (mis-scoped condition).
2. **Day 7** — Validate on launch + 54-model regression sweep. Pattern A cohort sanity sweep on the 6 other candidate models (#1138, #1139, #1140, #1142, #1145, #1150) → `DAY7_COHORT_SWEEP.md`.
3. **Day 8** — Re-evaluate qabel/abel with a full PATH solve (not `action=c`). If rel_diff persists, classify as nonconvex-solver noise vs. stateq-convention bug. Start WS2 Batch 2 (#1279 robustlp).
4. **Days 9–11** — WS2 Batch 2 (#1276, #1281, #1292) + Batch 3 (#1277 post-Pattern-C, #1278, #1290, #1291) + Checkpoint 2.
5. **Day 12** — WS4 small priorities (#1270 multi-solve gate, #1271 dispatcher refactor).
6. **Days 13–15** — Buffer / final pipeline retest / retrospective.

Sprint extended from Day 14 → Day 15 close.

## Why merge this PR

- Pins the investigation evidence to version control so the finding doesn't evaporate if the sprint redirects.
- Locks in the post-pivot plan so Day 6's execution prompt has a stable PLAN.md reference.
- Lets Day 6+ start on an updated baseline without the original Phase 2 assumptions still in the official plan.

## Test plan

- [x] No code changes → no tests needed
- [x] Traces at `/tmp/sprint25-day5/{qabel,abel,launch}_trace.stderr` (231k / 3k / 21k lines) reproducible via `SPRINT25_DAY2_DEBUG=1 .venv/bin/python -m src.cli data/gamslib/raw/<model>.gms -o /tmp/.../<model>_mcp.gms --skip-convexity-check --quiet 2> /tmp/.../<model>_trace.stderr`
- [x] Emitter output at `/tmp/sprint25-day5/{qabel,abel,launch}_mcp.gms`