### PR TITLE
Sprint 25 Day 9: WS2 Batch 2 complete (#1276 fawley .fx dedup, #1281 lmp2 Parameter dedup, #1292 turkpow line wrap)

### DIFF
--- a/docs/issues/ISSUE_1315_lmp2-multi-solve-set-assignment-not-extracted.md
+++ b/docs/issues/ISSUE_1315_lmp2-multi-solve-set-assignment-not-extracted.md
@@ -1,0 +1,101 @@
+# lmp2: Dynamic-subset SET assignments inside multi-solve loops are not extracted into MCP pre-solve
+
+**GitHub Issue:** [#1315](https://github.com/jeffreyhorn/nlp2mcp/issues/1315)
+**Status:** OPEN
+**Severity:** Medium-High — blocks lmp2 compile (Error 66) even after #1281's Parameter-redefinition fix
+**Discovered:** Sprint 25 Day 9 (PR #1314, post-#1281 verification)
+**Affected Models:** lmp2 (observed); other multi-solve models with dynamic-subset assignments inside the solve-loop body may share the same shape
+
+---
+
+## Problem Summary
+
+`emit_pre_solve_param_assignments` extracts PARAMETER assignments from the body of solve-containing loops (issue #1101/#1102), but it does NOT extract SET assignments — even though dynamic subsets like `m(mm)` are computed inside the same loop body and required for the MCP to compile.
+
+For lmp2, the source has:
+
+```gams
+Set
+   m(mm) 'constraints'
+   n(nn) 'variables'
+   ...
+
+loop(c,
+   m(mm)   = ord(mm) <= cases(c,'m');
+   n(nn)   = ord(nn) <= cases(c,'n');
+   ...
+   solve lmp2 minimizing obj using nlp;
+);
+```
+
+The MCP emitter:
+- Auto-populates `n(nn) = yes;` (line 30 of `lmp2_mcp.gms`) because `n` is referenced in stat_x's domain guard.
+- Does NOT populate `m(mm) = ...` even though `m` is used in `comp_Constraints(m)`, `stat_x`'s `sum(m, ...)`, and the model's equation domain — leaving `m` empty at solve time.
+
+Result: GAMS rejects with `Error 66 equation stat_x.. symbol "m" has no values assigned`.
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/lmp2.gms -o /tmp/lmp2_mcp.gms --skip-convexity-check --quiet
+gams /tmp/lmp2_mcp.gms action=c lo=2
+
+# Output:
+#   159  Solve mcp_model using MCP;
+# ****                           $66,256
+# ****  66  Use of a symbol that has not been defined or assigned
+# **** 256  Error(s) in analyzing solve statement.
+# **** The following MCP errors were detected in model mcp_model:
+# ****  66 equation stat_x.. symbol "m" has no values assigned
+```
+
+Confirm the missing assignment by inspecting the MCP:
+
+```bash
+grep -nE "^m\(mm\)\s*=|^n\(nn\)\s*=" /tmp/lmp2_mcp.gms
+# 30:n(nn) = yes;
+# (no m(mm) line)
+```
+
+## Likely Root Cause
+
+Two independent code paths handle dynamic-subset assignments:
+
+1. **`src/emit/emit_gams.py`** auto-populates dynamic subsets that appear in stationarity domain guards (`n(nn)` is in `stat_x(nn)$(n(nn))`). This is what produces the `n(nn) = yes;` line. It does NOT cover subsets referenced only in equation bodies/domains (like `m`).
+2. **`src/emit/original_symbols.py::emit_pre_solve_param_assignments`** extracts assignments from solve-loop bodies. Per its `_ASSIGN_TYPES = {"assign", "conditional_assign_general"}` filter and `if name not in param_names: continue` check at line 3308, it ONLY considers parameter assignments — set assignments are silently skipped.
+
+The fix needs to extend either:
+- Path (1) to cover dynamic subsets used in equation domains (not just stationarity guards), or
+- Path (2) to also extract dynamic-subset assignments when the subset appears in any equation in the MCP.
+
+Approach (2) is more aligned with the existing pre-solve-extraction flow. The change: in `emit_pre_solve_param_assignments`, expand the `name not in param_names` filter to also accept set names whose set is dynamic (has a parent domain) and is referenced by a model equation.
+
+## Candidate Fix Approaches
+
+1. **Extend pre-solve extraction to include dynamic-subset assignments.** Add a new `set_names_to_extract` set computed from `model_ir.sets` (those with non-empty `domain` and used in any equation domain), and accept assignments whose LHS matches one of those names. Then emit the assignment text verbatim with the loop-index substituted (same mechanism as the existing parameter path).
+2. **Extend the auto-populate path** to scan equation domains (not just stationarity guards) for dynamic-subset references and emit `subset(parent) = yes;` for the full parent set.
+
+Approach (1) preserves the source semantics more faithfully (the actual conditional `m(mm) = ord(mm) <= cases(c, 'm')` propagates with the loop-index substituted to a specific case). Approach (2) gives a wider, possibly over-eager subset (`m = full mm`).
+
+Recommend (1) for correctness; (2) is the fallback if (1) turns out to be too invasive.
+
+## Expected Impact
+
+Direct: lmp2's compile error 66 disappears; lmp2 either solves (matching #1281's expected progression from `path_solve_terminated` → some actual solve result) or hits its next latent bug.
+
+Same shape may also affect other multi-solve loop models (need a corpus audit alongside the fix).
+
+## Files
+
+- `src/emit/original_symbols.py::emit_pre_solve_param_assignments` (likely fix site for approach 1).
+- `src/emit/emit_gams.py` (auto-populate path; alternative fix site for approach 2).
+- `data/gamslib/raw/lmp2.gms` — primary repro corpus.
+
+## Related
+
+- `#1281` (resolved Sprint 25 Day 9): the redundant `Parameter A/b/cc` declarations were the SECOND blocker on lmp2; this is the THIRD.
+- `#1243` (lmp2: runtime division by zero in stat_y) — distinct downstream issue.
+
+## Status
+
+Open. Filed during Sprint 25 Day 9 (PR #1314). Targeting Sprint 26 carryforward.

--- a/docs/issues/ISSUE_1316_turkpow-table-data-mis-emission-on-empty-cells.md
+++ b/docs/issues/ISSUE_1316_turkpow-table-data-mis-emission-on-empty-cells.md
@@ -1,0 +1,87 @@
+# turkpow: Table-data emission produces spurious entries when source rows have empty cells / `+inf` values
+
+**GitHub Issue:** [#1316](https://github.com/jeffreyhorn/nlp2mcp/issues/1316)
+**Status:** OPEN
+**Severity:** High — blocks turkpow compile (Error 170 cascade) even after #1292's line-wrap fix
+**Discovered:** Sprint 25 Day 9 (PR #1314, post-#1292 verification)
+**Affected Models:** turkpow (observed); other models with table-data rows that have empty cells or `+inf` values may share the same shape
+
+---
+
+## Problem Summary
+
+The emitter mis-handles table data when source rows have empty cells (interpreted by GAMS as "no value, default zero") or use `+inf` for unbounded columns. The result is a Parameter declaration whose data block contains BOTH the correct row-by-column entries AND spurious entries that conflate values from other rows as labels.
+
+For turkpow, the source `Table mdatat(m,labels)` includes:
+
+```gams
+Table mdatat(m,labels) 'data for thermal plants'
+             initcap  avail      opcost  opcost-g   capcost  capcost-g     life  maxcap
+*               (mw)           (mill tl       (%)  (mill tl        (%)  (years)    (mw)
+   gas-t         120     .8         1.7     -.005       2.5                  30    +inf
+   oil           847     .9         1.1     -.005       4.5       -.01       30    +inf
+   lignite-1     960     .8          .6     -.005       5         -.01       30
+   lignite-2             .8          .2     -.005       7         -.01       30    2500
+   lignite-3             .8          .2     -.005       7         -.01       30    3500
+   nuclear               .8          .3     -.005       9         -.02       30    +inf;
+```
+
+The emitted Parameter block contains correct entries (e.g., `'lignite-3'.avail 0.8`, `'lignite-3'.opcost 0.2`, ..., `'lignite-3'.maxcap 3500`) PLUS spurious extras like `'lignite-3'.'.9' 0.8`, `'lignite-3'.initcap 0.3`, `'lignite-3'.'-.005' -0.005`, `'lignite-3'.'4.5' 9`, `'lignite-3'.'-.01' -0.02`, `'lignite-3'.'30' 30`, `'lignite-3'.'inf' inf`.
+
+The spurious labels are VALUES from neighboring rows being mis-attributed as labels.
+
+GAMS then rejects with cascading `Error 170 (Domain violation)` — the labels `.9`, `4.5`, `-.005`, etc. aren't in the `labels` set declaration.
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/turkpow.gms -o /tmp/turkpow_mcp.gms --skip-convexity-check --quiet
+gams /tmp/turkpow_mcp.gms action=c lo=2 2>&1 | grep -B 1 "\$170\|Error 170" | head -20
+
+# Inspect the spurious entries:
+grep "lignite-3" /tmp/turkpow_mcp.gms | head -3
+```
+
+## Likely Root Cause
+
+The table parser appears to associate values across row boundaries when:
+- A source row has empty cells (e.g., `lignite-1`'s `maxcap` column is empty).
+- A source row uses `+inf` (which the parser may handle as a special token).
+- Adjacent rows have varying cardinalities of populated columns.
+
+The result is that values from earlier rows leak into later rows' data dict — but the LABEL slot is wrongly populated with another row's VALUE (e.g., `'lignite-3'.'.9'` where `.9` is `oil`'s `avail` value).
+
+Likely fix sites:
+- `src/ir/parser.py` (table parsing — where row × column data is collected).
+- `src/emit/original_symbols.py::emit_original_parameters` (data emission — where the dict is serialised; the `_expand_table_key` helper at line ~957 may be the smoking gun).
+
+The issue is consistent with prior table-parsing bugs (e.g., #1007 zero-filtering, #913 last-write-wins dedup): table data with non-rectangular row shapes triggers known-fragile code paths.
+
+## Candidate Fix Approaches
+
+1. **Audit `_expand_table_key`** for handling of empty cells and `inf` literals. Specifically, ensure that an empty cell is NOT promoted to a string key in adjacent rows. Add a unit test that mirrors turkpow's "lignite-3 with empty initcap" shape.
+2. **Audit the table-row tokenization** in the parser. The source row `lignite-3 .8 .2 -.005 7 -.01 30 3500` has 8 values for 8 labels, plus a leading `lignite-3` row label. If the parser is splitting by whitespace AND treating `.9` (from a previous row's column) as a continuation of the current row, the boundary is wrong.
+3. **Filter post-parse:** strip Parameter values whose key contains any element NOT in the parameter's declared label set. This is a defensive emitter-level filter; it doesn't fix the parser bug but makes the emission compile.
+
+Approach (3) is the safest immediate fix; (1) and (2) are the structural fix.
+
+## Expected Impact
+
+Direct: turkpow's MCP compiles cleanly post-fix; turkpow either solves (matching its Sprint 25 Priority 2 recovered-translate target) or hits its next latent bug.
+
+Same shape may affect other models with non-rectangular table data (e.g., models with optional columns or `+inf` values). Need a corpus audit during the fix.
+
+## Files
+
+- `src/ir/parser.py` (table-row tokenization; likely root cause).
+- `src/emit/original_symbols.py::emit_original_parameters` and `_expand_table_key` (data emission; possible defensive filter site).
+- `data/gamslib/raw/turkpow.gms` — primary repro corpus.
+
+## Related
+
+- `#1292` (resolved Sprint 25 Day 9): the 144,628-char `stat_zt` line-wrap was the FIRST blocker on turkpow; this is the SECOND.
+- `#1007` (table data zero-filtering label-drop) — same general code area.
+
+## Status
+
+Open. Filed during Sprint 25 Day 9 (PR #1314). Targeting Sprint 26 carryforward.

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -1168,9 +1168,22 @@ def emit_gams_mcp(
     # Compute model-relevant params early so emit_original_parameters can
     # keep loop-initialized parameters that are used in model equations (#1182)
     model_relevant_params = _collect_model_relevant_params(kkt.model_ir)
-    params_code = emit_original_parameters(
-        kkt.model_ir, kkt.param_domain_widenings, model_relevant_params
+    # Issue #1281: capture the set of parameter names that
+    # `emit_original_parameters` actually declares so we can suppress
+    # redundant supplemental `Parameter X(domain);` declarations
+    # downstream in `emit_pre_solve_param_assignments`. Without this,
+    # lmp2's `Parameter A(mm,nn);` etc. were emitted twice (once here,
+    # once in the pre-solve block) and triggered a GAMS
+    # symbol-redefinition compile error.
+    _params_result = emit_original_parameters(
+        kkt.model_ir,
+        kkt.param_domain_widenings,
+        model_relevant_params,
+        return_declared_names=True,
     )
+    # mypy can't narrow `str | tuple[...]` from the kwarg flag — assert here.
+    assert isinstance(_params_result, tuple)
+    params_code, declared_param_names = _params_result
     if params_code:
         sections.append(params_code)
         sections.append("")
@@ -1328,7 +1341,12 @@ def emit_gams_mcp(
 
     # Issue #1101/#1102: Emit pre-solve parameter assignments from solve-containing
     # loops (e.g., p(i) = pt(i,'1') from multi-solve loop models)
-    pre_solve_code = emit_pre_solve_param_assignments(kkt.model_ir)
+    # Issue #1281: pass declared_param_names so we suppress duplicate
+    # `Parameter X(domain);` declarations for symbols already in the upper
+    # Parameters block.
+    pre_solve_code = emit_pre_solve_param_assignments(
+        kkt.model_ir, already_declared_params=declared_param_names
+    )
     if pre_solve_code:
         sections.append(pre_solve_code)
         sections.append("")
@@ -2412,6 +2430,23 @@ def emit_gams_mcp(
                 fx_lines.append(f"{var_name}.fx({idx_str}) = {val_str};")
 
     if fx_lines:
+        # Issue #1276: deduplicate `.fx` lines. Several upstream paths (sections
+        # 2/2b/2c, 3/3a/3b, 4, 5, ...) can append the SAME `nu_X.fx(domain) =
+        # 0;` line for the same multiplier when an equation matches multiple
+        # classification predicates (e.g., explicit condition + head-domain
+        # offset). GAMS treats duplicate `.fx` assignments as last-write-wins,
+        # so the result is semantically correct but the artifact is noisy and
+        # the duplicates make auditing harder. A line-level dedup is safe here
+        # because every `.fx` line in `fx_lines` is fully self-contained and
+        # the order of fixations is irrelevant (each one is an independent
+        # constraint on its own multiplier).
+        seen_fx_lines: set[str] = set()
+        deduped_fx_lines: list[str] = []
+        for line in fx_lines:
+            if line in seen_fx_lines:
+                continue
+            seen_fx_lines.add(line)
+            deduped_fx_lines.append(line)
         if add_comments:
             sections.append("* ============================================")
             sections.append("* Fix inactive variable instances")
@@ -2420,7 +2455,7 @@ def emit_gams_mcp(
             sections.append("* Variables whose paired MCP equation is conditioned must be")
             sections.append("* fixed for excluded instances to satisfy MCP matching.")
             sections.append("")
-        sections.extend(fx_lines)
+        sections.extend(deduped_fx_lines)
         sections.append("")
 
     # Issue #1133: Fix equality multipliers for empty equation instances.

--- a/src/emit/emit_gams.py
+++ b/src/emit/emit_gams.py
@@ -1183,7 +1183,10 @@ def emit_gams_mcp(
     )
     # mypy can't narrow `str | tuple[...]` from the kwarg flag — assert here.
     assert isinstance(_params_result, tuple)
-    params_code, declared_param_names = _params_result
+    # `declared_symbol_names` (not `declared_param_names`) because
+    # `emit_original_parameters` populates the set with names from BOTH the
+    # Parameters block AND the Scalars block (per its docstring).
+    params_code, declared_symbol_names = _params_result
     if params_code:
         sections.append(params_code)
         sections.append("")
@@ -1341,11 +1344,11 @@ def emit_gams_mcp(
 
     # Issue #1101/#1102: Emit pre-solve parameter assignments from solve-containing
     # loops (e.g., p(i) = pt(i,'1') from multi-solve loop models)
-    # Issue #1281: pass declared_param_names so we suppress duplicate
+    # Issue #1281: pass declared_symbol_names so we suppress duplicate
     # `Parameter X(domain);` declarations for symbols already in the upper
-    # Parameters block.
+    # Parameters/Scalars blocks (case-insensitive).
     pre_solve_code = emit_pre_solve_param_assignments(
-        kkt.model_ir, already_declared_params=declared_param_names
+        kkt.model_ir, already_declared_symbols=declared_symbol_names
     )
     if pre_solve_code:
         sections.append(pre_solve_code)

--- a/src/emit/equations.py
+++ b/src/emit/equations.py
@@ -345,20 +345,43 @@ _GAMS_LINE_WRAP_TARGET = 10000
 
 
 def _wrap_long_equation_line(eq_str: str) -> str:
-    """Insert newlines at natural operator boundaries when an equation line
-    exceeds GAMS's 80,000-char input limit.
+    """Best-effort wrap of equation lines that exceed GAMS's 80,000-char
+    input limit.
 
-    Splits at top-level boolean and arithmetic operators in priority order
-    (`or`, `and`, `+`, `-`) so the resulting chunks stay below
-    ``_GAMS_LINE_WRAP_TARGET`` characters. Splits use plain newlines (no
-    indentation); GAMS treats whitespace inside expressions and conditions
-    as transparent, so the wrapped form is semantically identical to the
-    single-line form.
+    Behavior — explicitly best-effort, NOT a strict per-line bound:
 
-    The function is a no-op for lines under
-    ``_GAMS_LINE_WRAP_THRESHOLD``, so common-case equations (which are far
-    below the threshold) are unaffected and Tier 0/1 canaries remain
-    byte-identical.
+    - For lines at or below ``_GAMS_LINE_WRAP_THRESHOLD`` (60,000 chars),
+      this function is a no-op. Common-case equations are unchanged and
+      Tier 0/1 canaries remain byte-identical.
+    - For lines above the threshold, we plain-string-split on spaced
+      operator tokens in priority order (`" or "`, `" and "`, `" + "`,
+      `" - "`) and greedily accumulate chunks until adding the next chunk
+      would exceed ``_GAMS_LINE_WRAP_TARGET`` (10,000 chars), at which
+      point we emit a newline and start a fresh continuation line.
+
+    Limitations of the plain-string split:
+
+    - Operator detection does NOT understand nesting or quoting: an
+      occurrence of `" or "` inside a string literal or a comment would
+      be treated the same as a top-level operator. In practice the
+      emitter doesn't produce literals containing those tokens, so this
+      hasn't bitten any model in the corpus, but it's a correctness
+      caveat.
+    - The wrap target is per-chunk, not per-line: a single un-splittable
+      chunk longer than ``_GAMS_LINE_WRAP_TARGET`` will exceed the
+      target. As a safety net we additionally guarantee that no chunk
+      exceeds GAMS's 80,000-char hard limit (`_GAMS_HARD_LINE_LIMIT`
+      below). If a chunk would exceed the hard limit even after the
+      best-effort split, we fall through to the next operator priority;
+      if all four operators fail to bring every chunk under the hard
+      limit, we return the input unchanged and let GAMS surface the
+      length error rather than emit a wrap that we can't prove safe.
+
+    The function is conservative: a single equation that genuinely cannot
+    be split at any of the four operators stays unchanged. In the
+    `emit_equation_def` call path this hasn't been observed, because
+    every equation over the threshold so far (turkpow's `stat_zt`) has
+    `or`-joined `sameas(...)` clauses available as split points.
     """
     if len(eq_str) <= _GAMS_LINE_WRAP_THRESHOLD:
         return eq_str
@@ -390,17 +413,32 @@ def _wrap_long_equation_line(eq_str: str) -> str:
                 current = current + sep + chunk
         wrapped.append(current)
         result = "".join(wrapped)
-        # If the chosen separator produced any wrap (i.e., the line is
-        # actually shorter now), use it. Otherwise fall through and try the
-        # next separator.
-        if "\n" in result:
-            return result
+        # If the chosen separator didn't produce any wrap (string contains
+        # no occurrences of this operator), try the next priority operator.
+        if "\n" not in result:
+            continue
+        # Hard-limit safety: verify that every line in the result is under
+        # GAMS's 80,000-char input limit. If one chunk is itself too long
+        # for this operator to split (e.g., a single huge `sameas(...)`
+        # cluster joined only by `+`), skip to the next priority operator
+        # and try a finer-grained split rather than emit an output we
+        # can't prove safe.
+        if max((len(line) for line in result.split("\n")), default=0) >= _GAMS_HARD_LINE_LIMIT:
+            continue
+        return result
 
-    # No suitable split point — return as-is and let GAMS surface the
-    # length error. (In practice this never fires for the emit_equation_def
-    # call path: any equation hitting the threshold has at least one of
-    # the four boolean/arithmetic operators in it.)
+    # No suitable split point produced a wrap that fits under the hard
+    # limit — return as-is and let GAMS surface the length error. In
+    # practice this never fires for the `emit_equation_def` call path,
+    # because every equation hitting the threshold so far has at least
+    # one usable boolean/arithmetic operator at top level.
     return eq_str
+
+
+# GAMS's hard input-line limit. `_wrap_long_equation_line` uses this as a
+# safety bound to verify that a best-effort wrap result won't be rejected
+# by GAMS even if individual chunks exceed the soft `_GAMS_LINE_WRAP_TARGET`.
+_GAMS_HARD_LINE_LIMIT = 80000
 
 
 def _quote_expr_indices(expr: Expr) -> Expr:

--- a/src/emit/equations.py
+++ b/src/emit/equations.py
@@ -323,7 +323,84 @@ def emit_equation_def(
         else:
             eq_str = f"{eq_name}.. {lhs_gams} {rel_gams} {rhs_gams};"
 
+    # Issue #1292: GAMS rejects input lines longer than 80,000 characters
+    # with `Error 98: Non-blank character(s) beyond max input line length`.
+    # Some emitted equations (e.g., turkpow's `stat_zt`, where the AD layer
+    # enumerates a Cartesian product of `sameas(...)` clauses) easily exceed
+    # this — turkpow's pre-fix line was 144,628 chars. Wrap at natural
+    # operator boundaries when the line is over the threshold; GAMS accepts
+    # newlines anywhere a space would be valid.
+    eq_str = _wrap_long_equation_line(eq_str)
+
     return eq_str, aliases
+
+
+# Issue #1292: GAMS's input-line limit is 80,000 chars. We use a conservative
+# threshold of 60,000 so a wrapped line still fits even after small upstream
+# additions (e.g., comment annotations) that the emitter or downstream tools
+# might splice in. Each wrapped chunk targets ~10,000 chars, which keeps the
+# emission readable in editors and well below GAMS's hard limit.
+_GAMS_LINE_WRAP_THRESHOLD = 60000
+_GAMS_LINE_WRAP_TARGET = 10000
+
+
+def _wrap_long_equation_line(eq_str: str) -> str:
+    """Insert newlines at natural operator boundaries when an equation line
+    exceeds GAMS's 80,000-char input limit.
+
+    Splits at top-level boolean and arithmetic operators in priority order
+    (`or`, `and`, `+`, `-`) so the resulting chunks stay below
+    ``_GAMS_LINE_WRAP_TARGET`` characters. Splits use plain newlines (no
+    indentation); GAMS treats whitespace inside expressions and conditions
+    as transparent, so the wrapped form is semantically identical to the
+    single-line form.
+
+    The function is a no-op for lines under
+    ``_GAMS_LINE_WRAP_THRESHOLD``, so common-case equations (which are far
+    below the threshold) are unaffected and Tier 0/1 canaries remain
+    byte-identical.
+    """
+    if len(eq_str) <= _GAMS_LINE_WRAP_THRESHOLD:
+        return eq_str
+
+    # Try operators in priority order: `or` is the dominant join in
+    # sameas-Cartesian-product cases (turkpow); `and` and ±arithmetic are
+    # fallbacks for other shapes. Each separator is bracketed in spaces so
+    # we don't split inside identifiers (e.g., `sameas` contains no spaces).
+    for sep in (" or ", " and ", " + ", " - "):
+        chunks = eq_str.split(sep)
+        if len(chunks) <= 1:
+            continue
+
+        # Greedy: accumulate chunks into the current line until adding the
+        # next chunk would exceed `_GAMS_LINE_WRAP_TARGET`. Then start a
+        # new line with `\n` + the separator's leading content (e.g.,
+        # `\nor `).
+        wrapped: list[str] = []
+        current = chunks[0]
+        for chunk in chunks[1:]:
+            # +len(sep) for the separator we'd add between current and chunk.
+            if len(current) + len(sep) + len(chunk) > _GAMS_LINE_WRAP_TARGET:
+                # Emit the current line and start a fresh one. The newline
+                # replaces the leading space of `sep`, so we keep the
+                # operator (e.g., `or`) at the start of the next line.
+                wrapped.append(current + "\n" + sep.lstrip())
+                current = chunk
+            else:
+                current = current + sep + chunk
+        wrapped.append(current)
+        result = "".join(wrapped)
+        # If the chosen separator produced any wrap (i.e., the line is
+        # actually shorter now), use it. Otherwise fall through and try the
+        # next separator.
+        if "\n" in result:
+            return result
+
+    # No suitable split point — return as-is and let GAMS surface the
+    # length error. (In practice this never fires for the emit_equation_def
+    # call path: any equation hitting the threshold has at least one of
+    # the four boolean/arithmetic operators in it.)
+    return eq_str
 
 
 def _quote_expr_indices(expr: Expr) -> Expr:

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -838,7 +838,9 @@ def emit_original_parameters(
     model_ir: ModelIR,
     param_domain_widenings: dict[str, tuple[str, ...]] | None = None,
     model_relevant_params: set[str] | None = None,
-) -> str:
+    *,
+    return_declared_names: bool = False,
+) -> str | tuple[str, set[str]]:
     """Emit Parameters and Scalars with their data.
 
     Uses ParameterDef.domain and .values (Finding #3: actual IR fields).
@@ -852,9 +854,17 @@ def emit_original_parameters(
 
     Args:
         model_ir: Model IR containing parameter definitions
+        return_declared_names: When True, return a (gams_text, declared_names)
+            tuple instead of just `gams_text`. The `declared_names` set
+            contains the lowercase names of all parameters that this function
+            actually emitted in the Parameters block (post-filter); callers
+            can pass this to `emit_pre_solve_param_assignments` to suppress
+            redundant supplemental `Parameter X(domain);` declarations
+            (issue #1281). Defaults to False for backward compatibility.
 
     Returns:
-        GAMS Parameters and Scalars blocks as string
+        GAMS Parameters and Scalars blocks as string, or a tuple of
+        (string, declared_names_lowercase) if `return_declared_names=True`.
 
     Example output:
         Parameters
@@ -866,8 +876,9 @@ def emit_original_parameters(
             discount /0.95/
         ;
     """
+    declared_names: set[str] = set()
     if not model_ir.params:
-        return ""
+        return ("", declared_names) if return_declared_names else ""
 
     # Separate scalars (empty domain) from parameters
     scalars = {}
@@ -988,10 +999,12 @@ def emit_original_parameters(
                     # Emit parameter with data
                     data_str = ", ".join(data_parts)
                     lines.append(f"    {_quote_symbol(param_name)}({domain_str}) /{data_str}/")
+                    declared_names.add(param_name.lower())
                 else:
                     # All data entries were filtered out (e.g., all zeros) -
                     # emit declaration only, but track for explicit zero assignment
                     lines.append(f"    {_quote_symbol(param_name)}({domain_str})")
+                    declared_names.add(param_name.lower())
                     # Issue #871: When all values were zero and skipped by Issue #967,
                     # emit explicit "param(domain) = 0;" after the Parameters block
                     # to avoid $141. Only for model-relevant parameters to avoid
@@ -1022,6 +1035,7 @@ def emit_original_parameters(
                 quoted_domain = [_quote_symbol(d) for d in domain]
                 domain_str = ",".join(quoted_domain)
                 lines.append(f"    {_quote_symbol(param_name)}({domain_str})")
+                declared_names.add(param_name.lower())
         lines.append(";")
 
     # Issue #871: Emit explicit zero assignments for all-zero parameters
@@ -1074,9 +1088,11 @@ def emit_original_parameters(
                 # Scalars have values[()] = value (Finding #3)
                 value = scalar_def.values.get((), 0.0)
                 lines.append(f"    {scalar_name} /{_format_param_value(value)}/")
+                declared_names.add(scalar_name.lower())
             lines.append(";")
 
-    return "\n".join(lines)
+    gams_text = "\n".join(lines)
+    return (gams_text, declared_names) if return_declared_names else gams_text
 
 
 def collect_missing_param_labels(model_ir: ModelIR) -> set[str]:
@@ -3032,7 +3048,10 @@ def emit_loop_statements(model_ir: ModelIR) -> str:
     return "\n\n".join(lines)
 
 
-def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
+def emit_pre_solve_param_assignments(
+    model_ir: ModelIR,
+    already_declared_params: set[str] | None = None,
+) -> str:
     """Emit parameter assignments from before the first solve in solve-containing loops.
 
     Issue #1101/#1102: Multi-solve loops like ``loop(t, p(i) = pt(i,t); solve ...;)``
@@ -3043,6 +3062,15 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
 
     Args:
         model_ir: Model IR with loop_statements and sets
+        already_declared_params: Optional set of lowercase parameter names
+            already declared by `emit_original_parameters`. Issue #1281: any
+            param in this set is skipped from the supplemental
+            `Parameter X(domain);` declaration block emitted at the end of
+            this function, since GAMS treats a redeclaration as a symbol
+            redefinition error (e.g., `Parameter A(mm,nn);` after
+            `Parameters ... A(mm,nn) ...;` triggered a compile failure on
+            lmp2). Defaults to None for backward compatibility — callers
+            that don't pass this preserve the pre-#1281 behavior.
 
     Returns:
         GAMS assignment statements, or empty string if none found
@@ -3323,8 +3351,20 @@ def emit_pre_solve_param_assignments(model_ir: ModelIR) -> str:
 
     # Emit declarations for params that were skipped by Issue #917 logic
     # (no values, no expressions — only assigned inside solve loops)
+    # Issue #1281: skip params already declared by `emit_original_parameters`
+    # (the upstream Parameters block). Without this filter, lmp2's
+    # `Parameter A(mm,nn);` etc. were emitted twice — once in the upstream
+    # block (because `A` is model-relevant) and once here — and the second
+    # declaration triggered a GAMS symbol-redefinition compile error.
     decl_lines: list[str] = []
+    skip_lower = (
+        {p.lower() for p in already_declared_params}
+        if already_declared_params is not None
+        else set()
+    )
     for pname in sorted(emitted_params):
+        if pname.lower() in skip_lower:
+            continue
         pdef = model_ir.params.get(pname)
         if pdef and not pdef.values and not pdef.expressions and pdef.domain:
             domain_str = ",".join(pdef.domain)

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -856,15 +856,21 @@ def emit_original_parameters(
         model_ir: Model IR containing parameter definitions
         return_declared_names: When True, return a (gams_text, declared_names)
             tuple instead of just `gams_text`. The `declared_names` set
-            contains the lowercase names of all parameters that this function
-            actually emitted in the Parameters block (post-filter); callers
-            can pass this to `emit_pre_solve_param_assignments` to suppress
+            contains the lowercase names of all symbols that this function
+            actually emitted at top level — both Parameters (Parameters
+            block) and Scalars (Scalars block), post-filter. Callers can
+            pass this to `emit_pre_solve_param_assignments` to suppress
             redundant supplemental `Parameter X(domain);` declarations
-            (issue #1281). Defaults to False for backward compatibility.
+            (issue #1281). The set deliberately also covers scalar names
+            so that scalar-shaped declarations downstream of this call
+            don't redeclare them either. Defaults to False for backward
+            compatibility.
 
     Returns:
         GAMS Parameters and Scalars blocks as string, or a tuple of
         (string, declared_names_lowercase) if `return_declared_names=True`.
+        `declared_names_lowercase` includes BOTH parameter and scalar
+        names emitted by this function (per the kwarg description above).
 
     Example output:
         Parameters

--- a/src/emit/original_symbols.py
+++ b/src/emit/original_symbols.py
@@ -3056,7 +3056,7 @@ def emit_loop_statements(model_ir: ModelIR) -> str:
 
 def emit_pre_solve_param_assignments(
     model_ir: ModelIR,
-    already_declared_params: set[str] | None = None,
+    already_declared_symbols: set[str] | None = None,
 ) -> str:
     """Emit parameter assignments from before the first solve in solve-containing loops.
 
@@ -3068,15 +3068,17 @@ def emit_pre_solve_param_assignments(
 
     Args:
         model_ir: Model IR with loop_statements and sets
-        already_declared_params: Optional set of lowercase parameter names
-            already declared by `emit_original_parameters`. Issue #1281: any
-            param in this set is skipped from the supplemental
-            `Parameter X(domain);` declaration block emitted at the end of
-            this function, since GAMS treats a redeclaration as a symbol
-            redefinition error (e.g., `Parameter A(mm,nn);` after
-            `Parameters ... A(mm,nn) ...;` triggered a compile failure on
-            lmp2). Defaults to None for backward compatibility — callers
-            that don't pass this preserve the pre-#1281 behavior.
+        already_declared_symbols: Optional set of lowercase symbol names
+            already declared by `emit_original_parameters` — covers BOTH
+            Parameters-block and Scalars-block names (the upstream caller
+            passes the union). Issue #1281: any name in this set is
+            skipped from the supplemental `Parameter X(domain);`
+            declaration block emitted at the end of this function, since
+            GAMS treats a redeclaration as a symbol redefinition error
+            (e.g., `Parameter A(mm,nn);` after `Parameters ... A(mm,nn) ...;`
+            triggered a compile failure on lmp2). Defaults to None for
+            backward compatibility — callers that don't pass this preserve
+            the pre-#1281 behavior.
 
     Returns:
         GAMS assignment statements, or empty string if none found
@@ -3357,15 +3359,15 @@ def emit_pre_solve_param_assignments(
 
     # Emit declarations for params that were skipped by Issue #917 logic
     # (no values, no expressions — only assigned inside solve loops)
-    # Issue #1281: skip params already declared by `emit_original_parameters`
-    # (the upstream Parameters block). Without this filter, lmp2's
+    # Issue #1281: skip symbols already declared by `emit_original_parameters`
+    # (the upstream Parameters / Scalars blocks). Without this filter, lmp2's
     # `Parameter A(mm,nn);` etc. were emitted twice — once in the upstream
     # block (because `A` is model-relevant) and once here — and the second
     # declaration triggered a GAMS symbol-redefinition compile error.
     decl_lines: list[str] = []
     skip_lower = (
-        {p.lower() for p in already_declared_params}
-        if already_declared_params is not None
+        {s.lower() for s in already_declared_symbols}
+        if already_declared_symbols is not None
         else set()
     )
     for pname in sorted(emitted_params):

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -57,22 +57,33 @@ def detect_empty_equation_instances(
         Dict mapping equation name → set of empty instance tuples.
         Only includes equations that have at least one empty instance.
     """
-    # Clear module-level caches at the start of each top-level invocation.
-    # Without this, stale entries from a previous translation (e.g.,
-    # `_nonzero_cache[("ap", ("c",))]` populated by a test fixture with one
-    # `Parameter ap(c,p)` shape) bleed into a subsequent translation that
-    # declares the same parameter name with different values, causing
+    # Clear module-level caches when the model_ir identity changes. Both
+    # `_lowered_members_cache` (set name → resolved members) and
+    # `_nonzero_cache` (parameter name + eq-key tuple → nonzero entries)
+    # are keyed by name only, so stale entries from a previous translation
+    # would otherwise bleed into a subsequent translation that declares
+    # the same name with different values — causing
     # `detect_empty_equation_instances` to incorrectly flag instances as
     # empty (or miss legitimately empty ones).
     #
     # This was discovered Sprint 25 Day 9 when adding new
-    # `tests/unit/emit/test_batch2_emission_invariants.py` tests changed the
-    # xdist worker scheduling enough to expose the latent flake on
-    # `tests/unit/emit/test_empty_eq_fx_emission.py`. The caches are still
-    # useful within a single translation (one model, multiple equations),
-    # so we reset them at the function boundary rather than removing them.
-    _lowered_members_cache.clear()
-    _nonzero_cache.clear()
+    # `tests/unit/emit/test_batch2_emission_invariants.py` tests changed
+    # the xdist worker scheduling enough to expose the latent flake on
+    # `tests/unit/emit/test_empty_eq_fx_emission.py`.
+    #
+    # Keying the invalidation on `id(model_ir)` (rather than clearing on
+    # every call) preserves the caches' intra-translation utility:
+    # `emit_gams_mcp` calls this function twice per translation (once for
+    # equalities, once for inequalities) and benefits from cache reuse
+    # across those two calls. The id-comparison is sound because Python
+    # only reuses an id after the original object is garbage-collected,
+    # and the caller (`emit_gams_mcp`) holds a reference to `model_ir`
+    # throughout the translation.
+    global _last_model_ir_id
+    if _last_model_ir_id != id(model_ir):
+        _lowered_members_cache.clear()
+        _nonzero_cache.clear()
+        _last_model_ir_id = id(model_ir)
 
     result: dict[str, set[tuple[str, ...]]] = {}
 
@@ -540,6 +551,12 @@ def _param_ref_is_zero(
 
 # Cache for pre-indexed nonzero entries per parameter
 _nonzero_cache: dict[tuple[str, tuple[str, ...]], set[tuple[str, ...]]] = {}
+
+# Identity of the model_ir whose entries currently populate the two caches
+# above. `detect_empty_equation_instances` clears the caches when invoked
+# with a different model_ir id, preserving intra-translation cache reuse
+# while preventing cross-test/cross-translation leakage.
+_last_model_ir_id: int | None = None
 
 
 def _get_nonzero_index(

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -12,6 +12,8 @@ left as non-empty (safe default).
 
 from __future__ import annotations
 
+import weakref
+
 from src.ir.ast import (
     Binary,
     DollarConditional,
@@ -72,19 +74,23 @@ def detect_empty_equation_instances(
     # the xdist worker scheduling enough to expose the latent flake on
     # `tests/unit/emit/test_empty_eq_fx_emission.py`.
     #
-    # Keying the invalidation on `id(model_ir)` (rather than clearing on
-    # every call) preserves the caches' intra-translation utility:
-    # `emit_gams_mcp` calls this function twice per translation (once for
-    # equalities, once for inequalities) and benefits from cache reuse
-    # across those two calls. The id-comparison is sound because Python
-    # only reuses an id after the original object is garbage-collected,
-    # and the caller (`emit_gams_mcp`) holds a reference to `model_ir`
-    # throughout the translation.
-    global _last_model_ir_id
-    if _last_model_ir_id != id(model_ir):
+    # Track the last `model_ir` via a `weakref.ref` rather than `id()`.
+    # The weakref-based check is robust against `id` reuse after garbage
+    # collection: if the previous ModelIR has been GC'd, the weakref
+    # resolves to None and we treat that as "different model" and clear.
+    # If it's still alive, we compare via `is`, which is identity-stable
+    # for the lifetime of the reference. This preserves the caches'
+    # intra-translation utility — `emit_gams_mcp` calls this function
+    # twice per translation (equalities + inequalities) and both calls
+    # share cached results — while remaining correct even in long-lived
+    # processes (e.g., pytest-xdist workers running the full suite) where
+    # many short-lived ModelIRs would otherwise risk id collisions.
+    global _last_model_ir_ref
+    last_model = _last_model_ir_ref() if _last_model_ir_ref is not None else None
+    if last_model is not model_ir:
         _lowered_members_cache.clear()
         _nonzero_cache.clear()
-        _last_model_ir_id = id(model_ir)
+        _last_model_ir_ref = weakref.ref(model_ir)
 
     result: dict[str, set[tuple[str, ...]]] = {}
 
@@ -553,11 +559,15 @@ def _param_ref_is_zero(
 # Cache for pre-indexed nonzero entries per parameter
 _nonzero_cache: dict[tuple[str, tuple[str, ...]], set[tuple[str, ...]]] = {}
 
-# Identity of the model_ir whose entries currently populate the two caches
+# Weakref to the last `model_ir` whose entries populate the two caches
 # above. `detect_empty_equation_instances` clears the caches when invoked
-# with a different model_ir id, preserving intra-translation cache reuse
-# while preventing cross-test/cross-translation leakage.
-_last_model_ir_id: int | None = None
+# with a different `model_ir` (compared by `is` via the weakref's
+# referent), preserving intra-translation cache reuse while preventing
+# cross-test/cross-translation leakage. The weakref guards against
+# `id()` reuse after garbage collection — a real risk in long-lived
+# processes (e.g., pytest-xdist workers running the full suite) where
+# many short-lived ModelIRs would otherwise risk id collisions.
+_last_model_ir_ref: weakref.ref[ModelIR] | None = None
 
 
 def _get_nonzero_index(

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -57,6 +57,23 @@ def detect_empty_equation_instances(
         Dict mapping equation name → set of empty instance tuples.
         Only includes equations that have at least one empty instance.
     """
+    # Clear module-level caches at the start of each top-level invocation.
+    # Without this, stale entries from a previous translation (e.g.,
+    # `_nonzero_cache[("ap", ("c",))]` populated by a test fixture with one
+    # `Parameter ap(c,p)` shape) bleed into a subsequent translation that
+    # declares the same parameter name with different values, causing
+    # `detect_empty_equation_instances` to incorrectly flag instances as
+    # empty (or miss legitimately empty ones).
+    #
+    # This was discovered Sprint 25 Day 9 when adding new
+    # `tests/unit/emit/test_batch2_emission_invariants.py` tests changed the
+    # xdist worker scheduling enough to expose the latent flake on
+    # `tests/unit/emit/test_empty_eq_fx_emission.py`. The caches are still
+    # useful within a single translation (one model, multiple equations),
+    # so we reset them at the function boundary rather than removing them.
+    _lowered_members_cache.clear()
+    _nonzero_cache.clear()
+
     result: dict[str, set[tuple[str, ...]]] = {}
 
     eq_names = list(model_ir.equalities)

--- a/src/kkt/empty_equation_detector.py
+++ b/src/kkt/empty_equation_detector.py
@@ -57,12 +57,13 @@ def detect_empty_equation_instances(
         Dict mapping equation name → set of empty instance tuples.
         Only includes equations that have at least one empty instance.
     """
-    # Clear module-level caches when the model_ir identity changes. Both
-    # `_lowered_members_cache` (set name → resolved members) and
-    # `_nonzero_cache` (parameter name + eq-key tuple → nonzero entries)
-    # are keyed by name only, so stale entries from a previous translation
-    # would otherwise bleed into a subsequent translation that declares
-    # the same name with different values — causing
+    # Clear module-level caches when the model_ir identity changes. Neither
+    # `_lowered_members_cache` (keyed by set name → resolved members) nor
+    # `_nonzero_cache` (keyed by `(parameter name, eq-key tuple)` → nonzero
+    # entries) is keyed by model identity, so stale entries from a previous
+    # translation would otherwise bleed into a subsequent translation that
+    # declares the same parameter/set names (and, for `_nonzero_cache`,
+    # the same eq-key tuples) with different values — causing
     # `detect_empty_equation_instances` to incorrectly flag instances as
     # empty (or miss legitimately empty ones).
     #

--- a/tests/unit/emit/test_batch2_emission_invariants.py
+++ b/tests/unit/emit/test_batch2_emission_invariants.py
@@ -201,10 +201,27 @@ solve m using lp minimizing obj;
     finally:
         os.unlink(gms_path)
 
-    # Each emitted equation (stat_*, c, defobj) should fit on its own line —
-    # no wrap-induced newlines for short equations.
-    for line in output.splitlines():
-        if line.startswith(("stat_", "c(", "defobj")) and ".." in line:
-            assert not line.startswith(
-                "or "
-            ), f"Unexpected wrap continuation on a short equation: {line!r}"
+    lines = output.splitlines()
+
+    # Short equations must not trigger the line-wrap logic, so no line in
+    # the emitted output may begin with one of the wrap-continuation
+    # operators (`_wrap_long_equation_line` injects the operator at the
+    # start of each continuation chunk after a `\n`).
+    wrap_operator_prefixes = ("or ", "and ", "+ ", "- ")
+    continuation_lines = [line for line in lines if line.startswith(wrap_operator_prefixes)]
+    assert not continuation_lines, (
+        "Unexpected wrap-continuation line(s) for a short synthetic model: "
+        f"{continuation_lines!r}"
+    )
+
+    # Cross-check: each emitted equation definition must fit on a single
+    # line ending with `;` (not spilling across a continuation).
+    equation_lines = [
+        line for line in lines if line.startswith(("stat_", "c(", "defobj")) and ".." in line
+    ]
+    assert equation_lines, "Expected emitted equation definitions in output."
+    for line in equation_lines:
+        assert line.endswith(";"), (
+            "Short equation expected to remain on a single line ending with ';'; "
+            f"got line that doesn't end with ';': {line!r}"
+        )

--- a/tests/unit/emit/test_batch2_emission_invariants.py
+++ b/tests/unit/emit/test_batch2_emission_invariants.py
@@ -1,0 +1,210 @@
+"""Sprint 25 Day 9 (WS2 Batch 2 remainder): emission invariants for the
+three issues landed this day:
+
+- #1276 (fawley/springchain): `.fx` lines for inactive multipliers must
+  appear at most once per (multiplier, condition) pair, even when the
+  upstream classification has multiple paths fixing the same multiplier.
+- #1281 (lmp2): the supplemental `Parameter X(domain);` block emitted by
+  `emit_pre_solve_param_assignments` must not redeclare parameters that
+  the upstream `emit_original_parameters` block already declared.
+- #1292 (turkpow): equation lines longer than ~60,000 chars must be
+  wrapped at natural operator boundaries so GAMS doesn't reject them
+  with `Error 98: Non-blank character(s) beyond max input line length
+  (80000)`.
+
+Each test is structured to fail loudly on the pre-fix behavior and pass
+on the post-fix behavior. Where the bug surface needs the gamslib
+sources to reproduce (lmp2, turkpow), the test skips when the corpus
+isn't on the runner — mirroring other gamslib-skip tests in the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _high_recursion_limit():
+    """Save/restore the recursion limit (cli sets 50000 for nested GAMS)."""
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(50000)
+    try:
+        yield
+    finally:
+        sys.setrecursionlimit(old)
+
+
+def _emit_mcp_for(gms_path: str) -> str:
+    """Translate a .gms source through the full pipeline and return the
+    emitted MCP as a string.
+    """
+    from src.ad.constraint_jacobian import compute_constraint_jacobian
+    from src.ad.gradient import compute_objective_gradient
+    from src.emit.emit_gams import emit_gams_mcp
+    from src.ir.normalize import normalize_model
+    from src.ir.parser import parse_model_file
+    from src.kkt.assemble import assemble_kkt_system
+
+    model = parse_model_file(gms_path)
+    normalize_model(model)
+    j_eq, j_ineq = compute_constraint_jacobian(model)
+    grad = compute_objective_gradient(model)
+    kkt = assemble_kkt_system(model, grad, j_eq, j_ineq)
+    return emit_gams_mcp(kkt)
+
+
+@pytest.mark.unit
+def test_fawley_no_duplicate_nu_fx_lines():
+    """#1276: fawley's emitted `.fx` lines for `nu_pbal` and `nu_qsb` must
+    appear exactly once each. Pre-fix they appeared twice each because
+    multiple upstream classification predicates (sections 2/2b/2c, 3/3a,
+    etc. of the fix-inactive emission) emitted the same line.
+    """
+    src = "data/gamslib/raw/fawley.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/fawley.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+    fx_lines = [line for line in output.splitlines() if line.startswith("nu_")]
+    nu_pbal_fx = [line for line in fx_lines if line.startswith("nu_pbal.fx")]
+    nu_qsb_fx = [line for line in fx_lines if line.startswith("nu_qsb.fx")]
+
+    assert (
+        len(nu_pbal_fx) == 1
+    ), f"Expected exactly 1 nu_pbal.fx line; got {len(nu_pbal_fx)}: {nu_pbal_fx}"
+    assert (
+        len(nu_qsb_fx) == 1
+    ), f"Expected exactly 1 nu_qsb.fx line; got {len(nu_qsb_fx)}: {nu_qsb_fx}"
+
+
+@pytest.mark.unit
+def test_fix_inactive_block_has_no_duplicate_lines():
+    """Generalized #1276: across the entire emitted MCP, no `.fx` line
+    starting with `nu_`, `lam_`, `piL_`, or `piU_` should appear more than
+    once. The dedup logic in `emit_gams_mcp` makes this a strict invariant.
+    """
+    src = "data/gamslib/raw/fawley.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/fawley.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+    seen: dict[str, int] = {}
+    for line in output.splitlines():
+        if (
+            any(line.startswith(prefix) for prefix in ("nu_", "lam_", "piL_", "piU_"))
+            and ".fx" in line
+        ):
+            seen[line] = seen.get(line, 0) + 1
+
+    duplicates = {line: count for line, count in seen.items() if count > 1}
+    assert (
+        not duplicates
+    ), "Found duplicate multiplier `.fx` lines in fawley emission:\n" + "\n".join(
+        f"  ({c}×) {line}" for line, c in duplicates.items()
+    )
+
+
+@pytest.mark.unit
+def test_lmp2_no_duplicate_parameter_declarations():
+    """#1281: lmp2's supplemental `Parameter X(domain);` block must not
+    redeclare params already in the upstream `Parameters` block. Pre-fix
+    `A`, `b`, `cc` appeared in both blocks, triggering a GAMS Error 282
+    symbol-redefinition compile failure.
+    """
+    src = "data/gamslib/raw/lmp2.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/lmp2.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+
+    # Supplemental Parameter declarations are individual lines starting
+    # with "Parameter X(...);". The upstream block uses the plural
+    # "Parameters\n    X(...)" form, so they're easy to disambiguate.
+    individual_decls = [line for line in output.splitlines() if line.startswith("Parameter ")]
+    decl_names = [line.split()[1].split("(")[0].lower() for line in individual_decls]
+
+    # `f` is genuinely needed (not in upstream block — it's a loop-only
+    # parameter not referenced by any equation). `A`, `b`, `cc` MUST NOT
+    # appear here because they ARE in the upstream block (case-insensitive
+    # match: `A` upstream vs lowercase `a` here would still collide).
+    for forbidden in ("a", "b", "cc"):
+        assert forbidden not in decl_names, (
+            f"`{forbidden}` was redeclared in the supplemental Parameter "
+            f"block; pre-fix this triggered GAMS Error 282. Got "
+            f"individual decl names: {decl_names}"
+        )
+
+    assert "f" in decl_names, (
+        "`f` IS not in the upstream Parameters block (loop-only, not "
+        "model-relevant), so the supplemental block must still declare it. "
+        f"Got individual decl names: {decl_names}"
+    )
+
+
+@pytest.mark.unit
+def test_turkpow_max_line_length_under_gams_limit():
+    """#1292: turkpow's `stat_zt` equation pre-fix was 144,628 chars on a
+    single line, blowing past GAMS's 80,000-char input-line limit. The
+    line-wrapping fix splits at `or`/`and`/`+`/`-` operator boundaries
+    when a line exceeds the threshold; assert the resulting max line
+    length stays under 80,000.
+    """
+    src = "data/gamslib/raw/turkpow.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/turkpow.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+    max_line_len = max((len(line) for line in output.splitlines()), default=0)
+
+    assert max_line_len < 80000, (
+        f"Emitted line length {max_line_len} exceeds GAMS's 80,000-char "
+        "input limit; pre-#1292 turkpow had a 144,628-char `stat_zt` "
+        "line that triggered Error 98."
+    )
+    # Sanity: the wrap actually happened (some line had to be over the
+    # 60,000 threshold pre-wrap). Without this, a future change that
+    # silently bypasses the wrap path could pass the upper-bound check.
+    has_wrapped_chunk = any(len(line) > 5000 for line in output.splitlines())
+    assert has_wrapped_chunk, (
+        "Expected at least one wrapped chunk over 5,000 chars (turkpow's "
+        "stat_zt enumeration is large enough that the wrap should produce "
+        "10k-char chunks)."
+    )
+
+
+@pytest.mark.unit
+def test_short_equations_unchanged_by_wrap():
+    """The line-wrap path is a no-op for equations under the threshold.
+    Verify a small synthetic model emits without any wrap-induced
+    newlines mid-equation (i.e., each equation definition fits on one
+    line as before).
+    """
+    import tempfile
+
+    gams = """\
+Set i / 1*3 /;
+Variable obj, x(i);
+Equation defobj, c(i);
+defobj.. obj =e= sum(i, x(i));
+c(i).. x(i) =l= 10;
+Model m / defobj, c /;
+solve m using lp minimizing obj;
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".gms", delete=False) as f:
+        f.write(gams)
+        gms_path = f.name
+    try:
+        output = _emit_mcp_for(gms_path)
+    finally:
+        os.unlink(gms_path)
+
+    # Each emitted equation (stat_*, c, defobj) should fit on its own line —
+    # no wrap-induced newlines for short equations.
+    for line in output.splitlines():
+        if line.startswith(("stat_", "c(", "defobj")) and ".." in line:
+            assert not line.startswith(
+                "or "
+            ), f"Unexpected wrap continuation on a short equation: {line!r}"

--- a/tests/unit/emit/test_batch2_emission_invariants.py
+++ b/tests/unit/emit/test_batch2_emission_invariants.py
@@ -14,8 +14,17 @@ three issues landed this day:
 
 Each test is structured to fail loudly on the pre-fix behavior and pass
 on the post-fix behavior. Where the bug surface needs the gamslib
-sources to reproduce (lmp2, turkpow), the test skips when the corpus
-isn't on the runner — mirroring other gamslib-skip tests in the suite.
+sources to reproduce (fawley, lmp2, turkpow), the test skips when the
+corpus isn't on the runner — mirroring other gamslib-skip tests in
+the suite.
+
+Markers: per `pyproject.toml`, the `unit` marker means "fast unit tests
+with no I/O". The fawley/lmp2/turkpow tests below read
+`data/gamslib/raw/*.gms` and run the full translate pipeline, so they
+are marked `integration` (and turkpow is additionally `slow` because
+its translation alone takes ~9 min on a typical workstation). Only
+`test_short_equations_unchanged_by_wrap` is a pure in-memory synthetic
+test and keeps the `unit` marker.
 """
 
 from __future__ import annotations
@@ -56,7 +65,7 @@ def _emit_mcp_for(gms_path: str) -> str:
     return emit_gams_mcp(kkt)
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_fawley_no_duplicate_nu_fx_lines():
     """#1276: fawley's emitted `.fx` lines for `nu_pbal` and `nu_qsb` must
     appear exactly once each. Pre-fix they appeared twice each because
@@ -80,7 +89,7 @@ def test_fawley_no_duplicate_nu_fx_lines():
     ), f"Expected exactly 1 nu_qsb.fx line; got {len(nu_qsb_fx)}: {nu_qsb_fx}"
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_fix_inactive_block_has_no_duplicate_lines():
     """Generalized #1276: across the entire emitted MCP, no `.fx` line
     starting with `nu_`, `lam_`, `piL_`, or `piU_` should appear more than
@@ -107,7 +116,7 @@ def test_fix_inactive_block_has_no_duplicate_lines():
     )
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_lmp2_no_duplicate_parameter_declarations():
     """#1281: lmp2's supplemental `Parameter X(domain);` block must not
     redeclare params already in the upstream `Parameters` block. Pre-fix
@@ -144,7 +153,8 @@ def test_lmp2_no_duplicate_parameter_declarations():
     )
 
 
-@pytest.mark.unit
+@pytest.mark.integration
+@pytest.mark.slow
 def test_turkpow_max_line_length_under_gams_limit():
     """#1292: turkpow's `stat_zt` equation pre-fix was 144,628 chars on a
     single line, blowing past GAMS's 80,000-char input-line limit. The

--- a/tests/unit/emit/test_batch2_emission_invariants.py
+++ b/tests/unit/emit/test_batch2_emission_invariants.py
@@ -91,9 +91,18 @@ def test_fawley_no_duplicate_nu_fx_lines():
 
 @pytest.mark.integration
 def test_fix_inactive_block_has_no_duplicate_lines():
-    """Generalized #1276: across the entire emitted MCP, no `.fx` line
-    starting with `nu_`, `lam_`, `piL_`, or `piU_` should appear more than
-    once. The dedup logic in `emit_gams_mcp` makes this a strict invariant.
+    """Generalized #1276 regression: in the emitted MCP for fawley, no
+    multiplier `.fx` line starting with `nu_`, `lam_`, `piL_`, or `piU_`
+    should appear more than once.
+
+    Note: the #1276 dedup operates ONLY on the fix-inactive `fx_lines`
+    list inside `emit_gams_mcp`; other emission paths (e.g., the empty-
+    equation multiplier fixes appended to `sections` directly) are NOT
+    routed through that dedup. So this is a per-fawley test, not a
+    universal "no duplicate `.fx` line anywhere" invariant. Empirically
+    fawley exercises the dedup-relevant paths and has no overlap with
+    the empty-equation block, so the test is meaningful for that model
+    even though it doesn't generalize to a global invariant.
     """
     src = "data/gamslib/raw/fawley.gms"
     if not os.path.exists(src):


### PR DESCRIPTION
## Summary

Day 9 of Sprint 25 per the revised plan. Lands the three remaining WS2 Batch 2 fixes plus an unrelated latent-flake fix that surfaced when the new tests shifted xdist scheduling.

## Fixes

### #1276 — fawley emits duplicate `.fx` lines

**Root cause:** Multiple upstream classification predicates in `emit_gams_mcp`'s fix-inactive block (sections 2/2b/2c, 3/3a/3b, etc.) can append the same `nu_X.fx(domain) = 0;` line for the same multiplier when an equation matches multiple paths (explicit condition + head-domain offset, etc.).

**Fix:** Deduplicate `fx_lines` at the boundary before appending to `sections`. Each `.fx` line is fully self-contained and fixation order is irrelevant, so line-level dedup is safe.

**Effect:** fawley `nu_pbal.fx` / `nu_qsb.fx`: 4 lines → 2. Same fix also resolves the springchain duplicate noted in the issue body's "Related prior work".

### #1281 — lmp2 redeclares Parameter A/b/cc after the upstream Parameters block

**Root cause:** The supplemental `Parameter X(domain);` block in `emit_pre_solve_param_assignments` (issue #917 fallback) didn't check whether a parameter was already declared by `emit_original_parameters`. For lmp2 this caused `Parameter A(mm,nn);` etc. twice, triggering GAMS Error 282 (symbol redefinition; case-insensitive collision with `a`).

**Fix:** Thread a `declared_param_names: set[str]` from `emit_original_parameters` (new `return_declared_names=True` kwarg returning `(text, names)`) through `emit_pre_solve_param_assignments`'s new `already_declared_params` kwarg. The supplemental block skips already-declared names.

**Effect:** lmp2 post-fix emits only `Parameter f(p);` (genuinely new — `f` is loop-only and not model-relevant). Error 282 eliminated. The residual Error 66 on `m` set is an unrelated multi-solve dynamic-subset propagation bug, out of scope.

### #1292 — turkpow stat_zt is a single 144,628-char line

**Root cause:** GAMS rejects input lines over 80,000 chars (`Error 98`). turkpow's `stat_zt` enumerates a Cartesian product of `sameas(...)` clauses joined by `or`, totaling 144,628 chars on one line.

**Fix:** Post-process the assembled equation string in `emit_equation_def`. When length exceeds a 60,000-char threshold, wrap at natural operator boundaries (`or`, `and`, `+`, `-` in priority order). Each chunk targets ~10,000 chars. GAMS treats whitespace inside expressions as transparent so the wrap is semantically identical.

**Effect:** turkpow longest line: 144,628 → 9,991 chars. Common-case equations under the threshold are unaffected (Tier 0/1 canaries remain byte-identical). turkpow has separate pre-existing table-data domain violations that prevent full compile; those are out of #1292 scope.

## Latent flake fix

Adding the new test file (one test translates turkpow, ~9 min) shifted xdist worker scheduling enough to expose a pre-existing flake in `test_empty_equation_multiplier_fx_emitted`. Two module-level caches in `src/kkt/empty_equation_detector.py` (`_lowered_members_cache` and `_nonzero_cache`) were keyed by name only and leaked across tests in the same xdist worker. A previous test's `Parameter ap(c,p)` polluted the cache for our test's `ap(c,p)` (different values), causing `mbal('fuel')` to be incorrectly flagged as empty.

**Fix:** Clear both caches at the start of each top-level `detect_empty_equation_instances` call. Caches still useful within a single translation; reset at the function boundary.

## Test plan

- [x] 5 new unit tests in `tests/unit/emit/test_batch2_emission_invariants.py`.
- [x] Tier 0 + Tier 1 canary (11 models): byte-identical to pre-fix golden.
- [x] Full 54-set golden-file regression: 53 byte-identical, 1 expected-diff (springchain — duplicate `.fx` removed; still solves to NLP baseline correctly).
- [x] Full pytest: 4595 passed, 0 failed (the cache fix resolved the latent flake).
- [x] `make typecheck && make format && make lint` all green.