### PR TITLE
Sprint 25: Fix #1280 — refresh stale mathopt4_mcp.gms + add UEL-quoting test

### DIFF
--- a/data/gamslib/mcp/mathopt4_mcp.gms
+++ b/data/gamslib/mcp/mathopt4_mcp.gms
@@ -25,7 +25,7 @@ Parameters
     report(row,*)
 ;
 
-Set nlp2mcp_uel_registry / x1.l, x1_0, x2.l, x2_0 /;
+Set nlp2mcp_uel_registry / 'x1.l', 'x1_0', 'x2.l', 'x2_0' /;
 
 * ============================================
 * Variables (Primal + Multipliers)

--- a/docs/issues/completed/ISSUE_1280_emitter-nlp2mcp-uel-registry-unquoted-dotted-elements.md
+++ b/docs/issues/completed/ISSUE_1280_emitter-nlp2mcp-uel-registry-unquoted-dotted-elements.md
@@ -1,10 +1,10 @@
 # Emitter: `nlp2mcp_uel_registry` Emits Unquoted UELs With Dots
 
 **GitHub Issue:** [#1280](https://github.com/jeffreyhorn/nlp2mcp/issues/1280)
-**Status:** OPEN — Deferred to Sprint 25
+**Status:** RESOLVED — fixed 2026-04-30 (the emitter fix had landed in an earlier commit; this PR refreshes the stale checked-in `mathopt4_mcp.gms` artifact and adds an integration regression test).
 **Severity:** Medium — Compile-time syntax error risk depending on GAMS version; silent misinterpretation risk otherwise
 **Date:** 2026-04-19
-**Last Updated:** 2026-04-19
+**Last Updated:** 2026-04-30
 **Affected Models:** `mathopt4` (observed); any model whose symbol set feeds the UEL registry with attribute-access forms (`<sym>.<attr>`)
 **Labels:** `sprint-25`
 
@@ -92,3 +92,56 @@ After fix:
 - `src/emit/*.py` — `nlp2mcp_uel_registry` declaration emission
 - `tests/unit/emit/` — new test asserting dotted UELs are quoted
 - `data/gamslib/mcp/mathopt4_mcp.gms` — reference artifact (regenerated after fix)
+
+---
+
+## Resolution (2026-04-30)
+
+### What was found
+
+The emitter-side fix had ALREADY landed in an earlier commit (the
+`_sanitize_uel_element` helper at `src/emit/original_symbols.py:351` and
+its application at `src/emit/emit_gams.py:1289`). Re-emitting
+`data/gamslib/raw/mathopt4.gms` from the live emitter produces the
+correctly-quoted form:
+
+```gams
+Set nlp2mcp_uel_registry / 'x1.l', 'x1_0', 'x2.l', 'x2_0' /;
+```
+
+However, the **checked-in artifact** (`data/gamslib/mcp/mathopt4_mcp.gms`)
+was stale and still showed the unquoted form (`x1.l, x2.l`). It dated
+from before the emitter fix landed and was never refreshed.
+
+### What was changed
+
+1. **Refreshed `data/gamslib/mcp/mathopt4_mcp.gms`** — re-emitted from
+   the live emitter to mirror the fixed quoting behavior. 1-line diff:
+   the registry declaration now reads
+   `Set nlp2mcp_uel_registry / 'x1.l', 'x1_0', 'x2.l', 'x2_0' /;`.
+
+2. **Added integration test** (`tests/integration/emit/test_mathopt4_uel_registry_quoting.py`)
+   covering 2 cases:
+   - Dotted attribute labels (`x1.l`, `x2.l`) are emitted single-quoted.
+   - Plain labels (`x1_0`) are quoted but NOT double-quoted (`''x1_0''`).
+
+### Audit (per the issue's audit task)
+
+Searched all `data/gamslib/mcp/*.gms` artifacts for unquoted dotted
+UELs. Only `mathopt4_mcp.gms` was affected; all other models'
+`nlp2mcp_uel_registry` declarations were already correct (either no
+dots, or already single-quoted).
+
+### Verification
+
+- **Buggy form** (`Set nlp2mcp_uel_registry / x1.l, x2.l /;`) — confirmed
+  GAMS rejects with `$161 Conflicting dimensions in element` on the
+  current GAMS 53.1.0 runtime.
+- **Fixed form** (`Set nlp2mcp_uel_registry / 'x1.l', 'x2.l' /;`) —
+  compiles cleanly, no syntax errors.
+- Sanitizer unit test (`test_original_symbols.py:3324+`) covers
+  `_sanitize_uel_element` directly.
+- New integration test verifies the emitter calls the sanitizer
+  correctly end-to-end on the `mathopt4` corpus.
+- Quality gate clean: `make typecheck && make lint && make format &&
+  make test` (**4,677 passed**, 10 skipped, 1 xfailed).

--- a/tests/integration/emit/test_mathopt4_uel_registry_quoting.py
+++ b/tests/integration/emit/test_mathopt4_uel_registry_quoting.py
@@ -1,0 +1,113 @@
+"""Sprint 25 / #1280: mathopt4 corpus regression for `nlp2mcp_uel_registry`
+quoting of attribute-access labels.
+
+When the UEL registry includes attribute-access labels like `x1.l` /
+`x2.l` (produced by zero-filtered parameter lookups in `mathopt4`),
+GAMS must see them as **single-quoted literals**:
+
+```gams
+Set nlp2mcp_uel_registry / 'x1.l', 'x2.l' /;
+```
+
+The unquoted form `x1.l, x2.l` is interpreted by GAMS as a 2-tuple
+notation (`x1.l` = element `x1` paired with element `l`), which:
+- on newer GAMS versions, raises `$161 Conflicting dimensions in
+  element` because the set is declared 1-D, OR
+- on older versions, silently truncates the UEL to the first
+  component, producing wrong downstream attribute lookups.
+
+`_sanitize_uel_element` (in `src/emit/original_symbols.py`) handles
+the quoting; this test verifies that the emitter actually CALLS it
+end-to-end on `mathopt4`'s registry.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _high_recursion_limit():
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(50000)
+    try:
+        yield
+    finally:
+        sys.setrecursionlimit(old)
+
+
+def _emit_mcp_for(gms_path: str) -> str:
+    from src.ad.constraint_jacobian import compute_constraint_jacobian
+    from src.ad.gradient import compute_objective_gradient
+    from src.emit.emit_gams import emit_gams_mcp
+    from src.ir.normalize import normalize_model
+    from src.ir.parser import parse_model_file
+    from src.kkt.assemble import assemble_kkt_system
+
+    model = parse_model_file(gms_path)
+    normalize_model(model)
+    j_eq, j_ineq = compute_constraint_jacobian(model)
+    grad = compute_objective_gradient(model)
+    kkt = assemble_kkt_system(model, grad, j_eq, j_ineq)
+    return emit_gams_mcp(kkt)
+
+
+@pytest.mark.integration
+def test_mathopt4_uel_registry_quotes_dotted_labels():
+    """`mathopt4`'s `nlp2mcp_uel_registry` must single-quote attribute
+    labels (`x1.l`, `x2.l`). Unquoted, GAMS rejects with `$161
+    Conflicting dimensions` (newer versions) or silently truncates
+    (older versions).
+    """
+    src = "data/gamslib/raw/mathopt4.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/mathopt4.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+
+    # Find the UEL registry declaration line.
+    registry_match = re.search(r"Set\s+nlp2mcp_uel_registry\s*/(.*?)/;", output, re.DOTALL)
+    assert (
+        registry_match is not None
+    ), "Expected `Set nlp2mcp_uel_registry / ... /;` declaration in MCP."
+    registry_body = registry_match.group(1)
+
+    # `x1.l` and `x2.l` MUST appear as `'x1.l'` and `'x2.l'`.
+    assert (
+        "'x1.l'" in registry_body
+    ), f"Expected `'x1.l'` (quoted) in UEL registry. Body:\n{registry_body}"
+    assert (
+        "'x2.l'" in registry_body
+    ), f"Expected `'x2.l'` (quoted) in UEL registry. Body:\n{registry_body}"
+
+    # Unquoted forms must NOT appear.
+    assert not re.search(
+        r"(?<!')x1\.l(?!')", registry_body
+    ), f"UEL registry must not contain unquoted `x1.l`. Body:\n{registry_body}"
+    assert not re.search(
+        r"(?<!')x2\.l(?!')", registry_body
+    ), f"UEL registry must not contain unquoted `x2.l`. Body:\n{registry_body}"
+
+
+@pytest.mark.integration
+def test_mathopt4_uel_registry_does_not_double_quote_plain_labels():
+    """Plain labels (no dots) like `x1_0` should be quoted by the
+    sanitizer (consistent quoting style) but should NOT be
+    double-quoted (e.g., `''x1_0''`).
+    """
+    src = "data/gamslib/raw/mathopt4.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/mathopt4.gms is gitignored on this runner.")
+
+    output = _emit_mcp_for(src)
+    registry_match = re.search(r"Set\s+nlp2mcp_uel_registry\s*/(.*?)/;", output, re.DOTALL)
+    assert registry_match is not None
+    registry_body = registry_match.group(1)
+
+    # `x1_0` should appear as `'x1_0'`, NOT as `''x1_0''`.
+    assert "'x1_0'" in registry_body
+    assert "''x1_0''" not in registry_body


### PR DESCRIPTION
## Summary

Closes the long-standing #1280 (UEL registry unquoted dotted labels). The **emitter-side fix had already landed** in an earlier commit (`_sanitize_uel_element` at `src/emit/original_symbols.py:351`, applied at `src/emit/emit_gams.py:1289`); only the stale checked-in artifact and a missing integration regression test remained.

## Changes

1. **`data/gamslib/mcp/mathopt4_mcp.gms`** — refreshed from the live emitter. 1-line diff: registry declaration now reads
   ```gams
   Set nlp2mcp_uel_registry / 'x1.l', 'x1_0', 'x2.l', 'x2_0' /;
   ```
   instead of the unquoted form that GAMS 53.1.0 rejects with `$161 Conflicting dimensions in element`.

2. **`tests/integration/emit/test_mathopt4_uel_registry_quoting.py`** (new) — 2 integration tests:
   - Dotted attribute labels (`x1.l`, `x2.l`) are emitted single-quoted.
   - Plain labels (`x1_0`) are quoted but NOT double-quoted.

3. **`docs/issues/completed/ISSUE_1280_emitter-nlp2mcp-uel-registry-unquoted-dotted-elements.md`** — moved from `docs/issues/` with a "Resolution (2026-04-30)" section.

## Audit

Searched all `data/gamslib/mcp/*.gms` for unquoted dotted UELs. **Only `mathopt4_mcp.gms` was affected.** All other models' `nlp2mcp_uel_registry` declarations were already correct.

## Verification

- **Buggy form** (`Set ... / x1.l, x2.l /;`) — confirmed GAMS rejects with `$161 Conflicting dimensions`.
- **Fixed form** (`Set ... / 'x1.l', 'x2.l' /;`) — compiles cleanly.
- Existing unit tests for `_sanitize_uel_element` (`tests/unit/emit/test_original_symbols.py:3324+`) still pass.
- Quality gate clean: `make typecheck && make lint && make format && make test` (**4,677 passed**, 10 skipped, 1 xfailed).

## Test plan

- [x] Re-emitted `mathopt4` shows quoted UELs in `nlp2mcp_uel_registry`
- [x] Re-emitted `mathopt4` compiles cleanly with GAMS 53.1.0 (no `\$161`)
- [x] Existing `_sanitize_uel_element` unit tests still pass
- [x] New integration test passes
- [x] Full suite passes
- [x] Audit of all other corpus artifacts shows no other affected models

## Closes

Closes #1280 (was already closed when the emitter fix landed; this PR refreshes the stale artifact and adds the missing regression test).