### PR TITLE
Sprint 25 Day 13: buffer + Sprint 26 carryforward issue filing

### DIFF
--- a/docs/issues/ISSUE_1354_camcge-phantom-indexoffset-stationarity-141.md
+++ b/docs/issues/ISSUE_1354_camcge-phantom-indexoffset-stationarity-141.md
@@ -1,0 +1,102 @@
+# camcge: PATH $141 on Phantom IndexOffset `nu_ieq(i±N)` / `nu_actp(i±N)` References in Stationarity
+
+**GitHub Issue:** [#1354](https://github.com/jeffreyhorn/nlp2mcp/issues/1354)
+**Status:** OPEN — Sprint 26 carryforward (filed Sprint 25 Day 13)
+**Severity:** Medium — model translates cleanly but PATH compilation fails with `Compilation error(s)`; user gets no MCP solution
+**Date:** 2026-05-05
+**Last Updated:** 2026-05-05
+**Affected Models:** camcge (confirmed); likely related to #1355 (cesam2) — same Pattern C variant family
+
+---
+
+## Problem Summary
+
+camcge translate succeeds (post-#1245), but the emitted MCP fails GAMS compilation with **3 `$141` errors** ("Symbol declared but no values have been assigned"). All three originate in stationarity equations that emit per-offset enumerations of `nu_<eq>(i±N)` for offsets that the source equation never actually realizes.
+
+Pre-Sprint-25 baseline: `path_solve_terminated` (translate failed). Post-Sprint-25 (Day 11 retest): `path_syntax_error` — one of the four bucket additions during Sprint 25 (see SPRINT_LOG.md Day 11 §"Revised Checkpoint 2 evaluation").
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/camcge.gms \
+  -o /tmp/camcge_mcp.gms --skip-convexity-check --quiet
+gams /tmp/camcge_mcp.gms lo=2
+
+# *** Error 141 in /tmp/camcge_mcp.gms (lines 525, 543, 557, 744, 747)
+# *** Status: Compilation error(s)
+```
+
+---
+
+## Buggy Emit — `stat_dk(i)` (line 525)
+
+```gams
+stat_dk(i).. pk(i) * nu_prodinv(i) + ((-1) * imat(i,i)) * nu_ieq(i)
+  + (((-1) * imat(i-1,i)) * nu_ieq(i-1))$(ord(i) > 1)
+  + (((-1) * imat(i+6,i)) * nu_ieq(i+6))$(ord(i) <= card(i) - 6)
+  + (((-1) * imat(i+3,i)) * nu_ieq(i+3))$(ord(i) <= card(i) - 3)
+  + (((-1) * imat(i+4,i)) * nu_ieq(i+4))$(ord(i) <= card(i) - 4)
+  + ... (i±N for N = 1..10) ...
+  =E= 0;
+```
+
+`nu_ieq` is the multiplier for the `ieq` equation. The source `ieq(i)` only references `imat(i,i)` (the diagonal) — so `nu_ieq(i+1)`, `nu_ieq(i-7)`, etc. are referenced by stationarity but never **defined** by any equation declaration, triggering `$141`.
+
+`stat_dst(i)` and `stat_p(i)` exhibit the same shape on `nu_prodinv(i±N)`, `nu_actp(i±N)`, `nu_pkdef(i±N)`. `stat_xd(i)` (line 557) similarly references `nu_inteq(i±N)` for offsets that `inteq(i).. =e= io(i,i) * x(i) ...` never realizes.
+
+---
+
+## Likely Root Cause
+
+This is the **launch-shaped phantom-offset enumeration** (see `docs/planning/EPIC_4/SPRINT_25/DAY5_PATTERN_A_INVESTIGATION.md`) appearing on a CGE model. Day 6 PR #1308 narrowed the Pattern C gate (`src/kkt/stationarity.py`) to launch's specific shape (alias-conditional `$ge(ss, s)` sums); camcge's `imat(i,j)` is also alias-shaped (the second `j` index gets unified with `i` and then enumerated ±N), but the gate did not catch it because the source body has no `$ge(...)`-type alias-conditional guard — it has plain `imat(i,j)` SAM-coefficient references.
+
+In other words: the AD layer is treating the second index of `imat(i,j)` as an alias of `i` and then exploding the assembly into a per-offset `nu_<eq>(i+N)` enumeration where, for each N, only one offset is actually present in the source equation.
+
+---
+
+## Where to Fix
+
+`src/kkt/stationarity.py` — generalize the Pattern C gate to detect plain-alias enumeration (no `$cond` filter required) and consolidate the per-offset emission into a single domain-scoped sum:
+
+```gams
+sum(j$(domain_filter), imat(j,i) * nu_ieq(j))
+```
+
+scoped to the equation's declared domain.
+
+Care is needed not to regress the working Day 6 launch fix (`#1306` / `#1307`) or the Tier 0/1 canary set (which currently emits these structures byte-identically to baseline for non-affected models like quocge / prolog / irscge — verified by Day 7 cohort sweep at `DAY7_COHORT_SWEEP.md` Task 1, 54/54 PASS).
+
+---
+
+## Tests to Add
+
+- **Unit test** in `tests/unit/kkt/`: minimal `ModelIR` with a scalar / indexed equation `ieq(i).. = imat(i,i) * dk(i)`, with `dk` declared on `(i,)` and `imat(i,j)` declared on `(i,j)`. Assert that `stat_dk(i)` body has no `nu_ieq(i±N)` references for `N != 0`, OR consolidates them into a single domain-scoped sum.
+- **Integration test** in `tests/integration/emit/`: assert camcge's emitted `stat_dk` / `stat_dst` / `stat_p` / `stat_xd` have no `nu_<eq>(i+N)$(ord(i) <= card(i) - N)` substring for `N >= 1`.
+- **Pipeline check**: after fix, camcge moves out of `path_syntax_error` (likely into `model_infeasible` per #1330 / #1324, or solves directly).
+
+---
+
+## Files Involved
+
+- `src/kkt/stationarity.py` — Pattern C gate (the launch-shaped narrowing was added in PR #1308; needs widening)
+- `src/ad/constraint_jacobian.py` — alias unification path that produces the per-offset enumeration
+- `data/gamslib/raw/camcge.gms` — primary integration test source
+- `data/gamslib/mcp/camcge_mcp.gms` — current buggy emit (regenerated each run)
+
+---
+
+## Estimated Effort
+
+**6–10h** for the gate generalization itself, plus a corpus regression sweep across the 54-model matching set (the Pattern C gate broadening risks regressions on any alias-shaped sum; expect to run the byte-diff harness from `DAY7_COHORT_SWEEP.md` Task 1 before/after).
+
+---
+
+## Related
+
+- **#1245** (CLOSED) — unblocked translate; surfaced this issue.
+- **#871, #1320, #1322** (camcge stationarity fixes — none addressed phantom IndexOffset).
+- **#1306 / #1307** — Pattern C Bug #1 / Bug #2 on launch (same shape family, narrower fingerprint).
+- **#1330 / #1324** — other open camcge issues (different bucket: `model_infeasible` and div-by-zero).
+- **#1355** (cesam2) — same Pattern C variant family on `nu_COLSUM(i±N)` in `stat_tsam`.

--- a/docs/issues/ISSUE_1355_cesam2-phantom-indexoffset-nu-colsum-141.md
+++ b/docs/issues/ISSUE_1355_cesam2-phantom-indexoffset-nu-colsum-141.md
@@ -1,0 +1,100 @@
+# cesam2: PATH $141 on Phantom IndexOffset `nu_COLSUM(i±N)` References in `stat_tsam` Stationarity
+
+**GitHub Issue:** [#1355](https://github.com/jeffreyhorn/nlp2mcp/issues/1355)
+**Status:** OPEN — Sprint 26 carryforward (filed Sprint 25 Day 13)
+**Severity:** Medium — model translates cleanly post-Sprint-25 SetMembershipTest fixes but PATH compilation fails; user gets no MCP solution
+**Date:** 2026-05-05
+**Last Updated:** 2026-05-05
+**Affected Models:** cesam2 (confirmed); same Pattern C variant family as #1354 (camcge)
+
+---
+
+## Problem Summary
+
+cesam2 translate succeeds (post-#1338, post-#1342, post-#1344 SetMembershipTest fixes), but the emitted MCP fails GAMS compilation with **`$141`** ("Symbol declared but no values have been assigned") on `nu_COLSUM(i±N)` references inside `$(jj(i±N))` guards in the assembled `stat_tsam(i,j)` stationarity equation.
+
+Pre-Sprint-25 baseline: `path_solve_terminated` (translate failed). Post-Sprint-25 (Day 11 retest): `path_syntax_error` — one of the four bucket additions during Sprint 25 (see SPRINT_LOG.md Day 11 §"Revised Checkpoint 2 evaluation").
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/cesam2.gms \
+  -o /tmp/cesam2_mcp.gms --skip-convexity-check --quiet
+gams /tmp/cesam2_mcp.gms lo=2
+
+# *** Error 141 in /tmp/cesam2_mcp.gms (line 207, line 414)
+# *** Status: Compilation error(s)
+```
+
+---
+
+## Buggy Emit — `stat_tsam(i,j)` (line 300, condensed)
+
+```gams
+stat_tsam(i,j).. (nu_ROWSUM(i)$(ii(i))
+  + (nu_COLSUM(i)$(jj(i)))$(... 10 sameas conjunctions ...)
+  + (((nu_COLSUM(i+7)$(jj(i+7)))$(ord(i) <= card(i) - 7))$(ord(j) = 7))$(...)
+  + (((nu_COLSUM(i+1)$(jj(i+1)))$(ord(i) <= card(i) - 1))$(ord(j) = 1))$(...)
+  + (((nu_COLSUM(i-9)$(jj(i-9)))$(ord(i) > 9))$(ord(j) = 9))$(...)
+  + ... (i±N for N = 1..9, gated by ord(j) = N) ...
+  ) =E= 0;
+```
+
+The `nu_COLSUM(i+7)`, `nu_COLSUM(i-9)`, etc. references are emitted for offsets the `i` set never realizes for those `j` ranges, triggering `$141`. The triple-nested `$cond` guards (column-offset bound + row-offset bound + per-`sameas` matrix-block guard) are correct in spirit — they encode the SAM block structure — but the multiplier `nu_COLSUM(i+N)` is referenced at indices outside `nu_COLSUM`'s declared domain, which GAMS rejects regardless of whether the guard would mask it at runtime.
+
+---
+
+## Likely Root Cause
+
+Same Pattern C family as **#1354 (camcge)**: per-offset `nu_<eq>(i±N)` enumeration in stationarity where the source SAM-balance equation `tsam(i,j)` uses `sameas`-conditional aliases that the AD layer expands into per-offset terms instead of a single domain-scoped sum.
+
+The `sameas('ACT', 'CAP')`-style guards in cesam2's source SAM block are decomposed into per-`(row,col)` pairs by the AD layer, and each pair gets a literal `i+N` IndexOffset emission rather than a sum-over-`j$(jj(j) and sameas(...))` consolidation.
+
+---
+
+## Where to Fix
+
+`src/kkt/stationarity.py` — same broadening as **#1354**: detect plain-alias enumeration (no `$cond` filter required, and additionally allow `sameas`-decomposed shapes) and consolidate per-offset emission into a single domain-scoped sum:
+
+```gams
+sum(j$(jj(j) and sameas_block_filter(i,j)),
+    nu_COLSUM(j))
+```
+
+scoped to the equation's declared domain.
+
+The Pattern C gate currently only fires for the launch-specific `$ge(ss, s)` shape; needs to also fire for plain `imat(i,j)`-style alias-only references (#1354) and `sameas`-decomposed SAM-block references (this issue).
+
+---
+
+## Tests to Add
+
+- **Unit test** in `tests/unit/kkt/`: minimal `ModelIR` with a scalar SAM-balance equation `tsam(i,j).. ROWSUM(i) - sum(jp$(jj(jp) and sameas(jp, j)), COLSUM(jp)) =e= 0`. Assert that `stat_tsam(i,j)` body has no `nu_COLSUM(i+N)$(jj(i+N))` references for `N != 0`.
+- **Integration test** in `tests/integration/emit/`: assert cesam2's emitted `stat_tsam(i,j)` has no `nu_COLSUM(i+N)` substring for `N >= 1`.
+- **Pipeline check**: after fix, cesam2 moves out of `path_syntax_error`. Open question whether it then surfaces #1041 (MCP pair empty equation, separate root cause) — verify post-fix.
+
+---
+
+## Files Involved
+
+- `src/kkt/stationarity.py` — Pattern C gate (needs `sameas`-aware widening)
+- `src/ad/constraint_jacobian.py` — alias unification path producing the per-offset enumeration
+- `src/ir/condition_eval.py` — `sameas` evaluator (no fix needed; mentioned for context)
+- `data/gamslib/raw/cesam2.gms` — primary integration test source
+- `data/gamslib/mcp/cesam2_mcp.gms` — current buggy emit
+
+---
+
+## Estimated Effort
+
+**4–8h** if the fix lands as part of #1354 (likely the same code path, plus a `sameas`-block helper). Standalone effort would be ~6–10h.
+
+---
+
+## Related
+
+- **#1041** (cesam2: MCP pair empty equation — separate bug, also open).
+- **#1338, #1342, #1344** (cesam2 SetMembershipTest fixes that unblocked translate).
+- **#1354** (camcge — same Pattern C variant family, simpler shape; fix likely shared).

--- a/docs/issues/ISSUE_1356_fawley-stationarity-domain-violations-171.md
+++ b/docs/issues/ISSUE_1356_fawley-stationarity-domain-violations-171.md
@@ -1,0 +1,89 @@
+# fawley: PATH $171 Domain Violations in Stationarity (Post-#1276 Fix Bucket Transfer)
+
+**GitHub Issue:** [#1356](https://github.com/jeffreyhorn/nlp2mcp/issues/1356)
+**Status:** OPEN — Sprint 26 carryforward (filed Sprint 25 Day 13)
+**Severity:** Medium — model translates cleanly post-Sprint-25 fixes but PATH compilation fails with 3 `$171` errors
+**Date:** 2026-05-05
+**Last Updated:** 2026-05-05
+**Affected Models:** fawley (confirmed); root cause not yet localized — may share family with #1357 (otpop)
+
+---
+
+## Problem Summary
+
+After Sprint 25 closed #1276 (duplicate `.fx` emission), #1133 (empty mbal SetMembershipTest), and #1130 (table column alignment), the Day 11 retest shows fawley moved from `model_infeasible` to **`path_syntax_error`** — the emitted MCP now fails GAMS compilation with **3 `$171`** ("Domain violation for set") errors plus a downstream `$141`.
+
+One of the four bucket additions during Sprint 25 (see SPRINT_LOG.md Day 11 §"Revised Checkpoint 2 evaluation").
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/fawley.gms \
+  -o /tmp/fawley_mcp.gms --skip-convexity-check --quiet
+gams /tmp/fawley_mcp.gms lo=2
+
+# *** Error 171 in /tmp/fawley_mcp.gms (line 273 ×2, line 315)
+# *** Error 257 (cascade)
+# *** Error 141 in /tmp/fawley_mcp.gms (line 381)
+# *** Status: Compilation error(s)
+```
+
+---
+
+## Diagnostic
+
+GAMS error `$171` means a stationarity equation references a variable / parameter at an index outside the declared domain. Possible mechanisms:
+
+1. `nu_<eq>(i)` with `i` taken from a superset (subset/superset domain confusion — same shape as the otpop issue #1175 that closed earlier).
+2. An IndexOffset (`i+N`) that lands outside the multiplier's declared subset domain.
+3. Aliased index mis-binding in the stationarity assembly path.
+
+Without a deeper inspection of lines 273 / 315 of the emitted `fawley_mcp.gms` and a hand-trace back to which source equation produced them, the root cause is not yet localized — Sprint 26 should start with the `.lst`-line cross-reference.
+
+---
+
+## Where to Investigate (Sprint 26 Day 0 / 1)
+
+1. Open `/tmp/fawley_mcp.gms` (regenerate per "Reproduction" above) and inspect lines 273 and 315.
+2. Match each violating reference back to its source equation in `data/gamslib/raw/fawley.gms`.
+3. Determine whether the violation is:
+   - **Pattern C variant** (likely shared with #1354 / #1355 — phantom IndexOffset onto a multiplier's subset domain).
+   - **Subset-superset confusion** (similar to closed #1175 otpop, which was Sprint 23/24 work — may indicate a regression).
+   - **Domain-widening misalignment** (the multiplier's `declaration_domain` machinery from #1327 may be misaligned for fawley).
+
+---
+
+## Tests to Add
+
+- **Integration test** in `tests/integration/emit/`: assert fawley's emitted MCP compiles cleanly under GAMS `lo=2` (or, more narrowly, asserts no `$171` substring in the `.lst` file). Currently no such regression test exists.
+- Once root cause is identified, add a unit test in `tests/unit/kkt/` against the specific stationarity assembly path.
+
+---
+
+## Files Involved (preliminary — pending Sprint 26 root-cause)
+
+- `src/kkt/stationarity.py` — likely
+- `src/kkt/complementarity.py` — possible (if `multiplier_domain_widenings` arity mismatch)
+- `data/gamslib/raw/fawley.gms` — source
+- `data/gamslib/mcp/fawley_mcp.gms` — current buggy emit
+
+---
+
+## Estimated Effort
+
+**4–8h** for diagnosis (line-by-line cross-reference + minimal repro extraction), then variable depending on root cause:
+- If shared with **#1354 / #1355** (Pattern C variant): subsumed by that fix.
+- If new: standalone ~6–10h.
+
+---
+
+## Related
+
+- **#1276** (duplicate fx emission — CLOSED Sprint 25)
+- **#1130** (table column alignment — CLOSED earlier)
+- **#1133** (empty mbal SetMembershipTest — CLOSED earlier)
+- **#1175** (otpop subset-superset domain violation — CLOSED; same `$171` shape, predecessor)
+- **#1354 / #1355** (camcge / cesam2 phantom IndexOffset — possible shared Pattern C variant)
+- **#1357** (otpop `$171` — also in the four-bucket-additions cohort; possibly same root cause)

--- a/docs/issues/ISSUE_1357_otpop-stationarity-domain-violations-171.md
+++ b/docs/issues/ISSUE_1357_otpop-stationarity-domain-violations-171.md
@@ -1,0 +1,95 @@
+# otpop: PATH $171 Domain Violations in Stationarity (Sprint 25 Bucket Transfer)
+
+**GitHub Issue:** [#1357](https://github.com/jeffreyhorn/nlp2mcp/issues/1357)
+**Status:** OPEN — Sprint 26 carryforward (filed Sprint 25 Day 13). Possibly subsumed by **#1334**.
+**Severity:** Medium — model translates cleanly but PATH compilation fails with multiple `$171` errors
+**Date:** 2026-05-05
+**Last Updated:** 2026-05-05
+**Affected Models:** otpop (confirmed)
+
+---
+
+## Problem Summary
+
+After the Sprint 25 wave of otpop fixes (#1232, #1234, #1175, #1178, #1326, #783, #915, plus the Day 12 multi-solve gate #1270 which correctly excluded otpop), the Day 11 retest shows otpop moved from `path_solve_terminated` / `model_infeasible` (depending on era) to **`path_syntax_error`** — the emitted MCP now fails GAMS compilation with **`$171`** ("Domain violation for set") errors at multiple sites.
+
+One of the four bucket additions during Sprint 25 (see SPRINT_LOG.md Day 11 §"Revised Checkpoint 2 evaluation").
+
+---
+
+## Reproduction
+
+```bash
+.venv/bin/python -m src.cli data/gamslib/raw/otpop.gms \
+  -o /tmp/otpop_mcp.gms --skip-convexity-check --quiet
+gams /tmp/otpop_mcp.gms lo=2
+
+# *** Error 171 in /tmp/otpop_mcp.gms (line 217 ×2, line 247)
+# *** Status: Compilation error(s)
+```
+
+---
+
+## Diagnostic / Possible Subsumption
+
+The `$171` errors at lines 217 / 247 of the emitted `otpop_mcp.gms` strongly suggest a residual of either:
+
+1. **#1334** — "AD: scalar-constraint stationarity wraps Jacobian terms in spurious Sum when ParamRef domain is a strict subset of equation domain". This issue is open and explicitly lists otpop as the confirmed affected model. The `$171` shape is consistent with the spurious `sum(t__, ...)` over a parameter's declared `t` domain when the equation is over the superset `tt` — GAMS rejects the mismatched domain reference.
+
+2. A new variant of #1175 (subset-superset domain violation in stationarity, CLOSED in Sprint 24). If the closed fix was incomplete or partially regressed by a later Sprint 25 change, this would manifest as a fresh `$171` at related sites.
+
+**Sprint 26 Day 0 action:** verify whether the current `$171` errors at lines 217 / 247 are the same `_replace_indices_in_expr` ParamRef-substitution bug that #1334 documents. If yes, **close this issue as a duplicate of #1334** after the Sprint 26 Day 0 evidence-gathering. If no, this is a new variant requiring its own root cause.
+
+---
+
+## Where to Investigate
+
+1. Open `/tmp/otpop_mcp.gms` (regenerate per "Reproduction") and inspect lines 217 and 247.
+2. Match each violating reference back to its source equation in `data/gamslib/raw/otpop.gms`.
+3. Compare against the buggy emit shape documented in `docs/issues/ISSUE_1334_ad-scalar-constraint-spurious-sum-on-subset-param-domain.md` §"Buggy Emit (otpop)".
+4. If the shape matches (`sum(t__, ...)` over a parameter's declared subset domain): subsumed by #1334.
+5. If it doesn't: file as a new variant and identify the differing assembly path.
+
+---
+
+## Tests to Add
+
+- **Integration test** in `tests/integration/emit/`: assert otpop's emitted MCP compiles cleanly under GAMS `lo=2`. Currently no such regression test exists.
+- If subsumed by #1334: the test under that issue (asserting `stat_x(tt)` and `stat_p(tt)` have no `sum(t__, ...)` substring) should also cover lines 217 / 247.
+
+---
+
+## Files Involved (preliminary)
+
+- `src/kkt/stationarity.py:2295–2479` — `_replace_indices_in_expr` (ParamRef branch — the suspected #1334 site)
+- `src/kkt/stationarity.py:5279–5310` — `_add_jacobian_transpose_terms_scalar` (the spurious `Sum` wrap site)
+- `data/gamslib/raw/otpop.gms` — source
+- `data/gamslib/mcp/otpop_mcp.gms` — current buggy emit
+
+---
+
+## Estimated Effort
+
+- **1–2h** for the Sprint 26 Day 0 subsumption check (if confirmed duplicate of #1334, just close).
+- If new: **4–8h** for diagnosis + fix.
+
+---
+
+## Related otpop history (all CLOSED Sprint 23–25)
+
+- #783 (parser: equation attribute assignment)
+- #915 (MCP pair unmatched for fixed-var subsets)
+- #1175 (subset-superset domain violation in stationarity — same shape family as this issue)
+- #1178 (malformed index expressions $145/$148)
+- #1232 (stat_d unmatched)
+- #1234 (locally infeasible after pairing)
+- #1270 (multi-solve gate — correctly excluded otpop in Sprint 25 Day 12)
+- #1326 (gtm tangentially related)
+
+---
+
+## Related open issues
+
+- **#1334** (AD: scalar-constraint stationarity spurious Sum on subset ParamRef domain) — likely subsumes this issue.
+- **#1335** (AD: missing dzdef/dp cross-term in stat_p) — different bug, also affects otpop's solve correctness; orthogonal to this `$171` issue but on the same model.
+- **#1356** (fawley `$171` — also in the four-bucket-additions cohort).

--- a/docs/planning/EPIC_4/SPRINT_25/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/KNOWN_UNKNOWNS.md
@@ -62,16 +62,18 @@ This document identifies assumptions and unknowns for Sprint 25 **before** imple
 
 ## Summary Statistics
 
-**Total Unknowns:** 27
+**Total Unknowns:** 27 prep + 4 end-of-sprint = **31**
 
-**By Priority:**
+The Priority / Category breakdowns below cover only the 27 prep-time unknowns (Categories 1–6) — those drove the Sprint 25 prep budget allocation. The 4 end-of-sprint discoveries (KU-33..KU-36) were surfaced during execution and are tracked separately in §"End-of-Sprint Discoveries" toward the bottom of this document; they do not have a Priority assignment because they don't drive prep work for Sprint 25 — they are inputs to Sprint 26 prep instead.
+
+**By Priority** (prep unknowns only):
 
 - Critical: 7 (26%)
 - High: 11 (41%)
 - Medium: 7 (26%)
 - Low: 2 (7%)
 
-**By Category:**
+**By Category** (prep unknowns only):
 
 - Category 1 (Alias-AD Carryforward): 8 unknowns
 - Category 2 (Emitter / Stationarity Backlog): 6 unknowns
@@ -80,7 +82,9 @@ This document identifies assumptions and unknowns for Sprint 25 **before** imple
 - Category 5 (Translation Timeout — Algorithmic): 4 unknowns
 - Category 6 (Pipeline Retest + Determinism): 3 unknowns
 
-**Estimated Research Time:** 18–27 hours (spread across prep Tasks 2–10; see `PREP_PLAN.md` §Prep Task Overview for per-task budgets).
+**End-of-Sprint Discoveries** (KU-33..KU-36, surfaced during Sprint 25 execution; see §"End-of-Sprint Discoveries"): 4 unknowns. These feed into Sprint 26 prep rather than Sprint 25 prep tasks.
+
+**Estimated Research Time:** 18–27 hours for the 27 prep-time unknowns (spread across prep Tasks 2–10; see `PREP_PLAN.md` §Prep Task Overview for per-task budgets). End-of-sprint discoveries do not consume Sprint 25 budget.
 
 Note: the per-unknown `Estimated Research Time` fields in the detail sections below are work-item estimates used to scope individual investigations, not an additive total — multiple unknowns are verified in parallel within a single prep task (e.g., Task 2 covers 7 unknowns in one code-audit pass). The authoritative scheduling budget is the per-task total in PREP_PLAN.md.
 
@@ -1814,7 +1818,7 @@ This table shows which Sprint 25 prep tasks verify which unknowns. Prep Task 11 
 | Task 10: Design Byte-Stability Test Infrastructure (PR12) | 6.2 | Seed-set sample-size analysis |
 | Task 11: Plan Sprint 25 Detailed Schedule | 6.3 (+ integrates all others) | Influx budget calibration + sprint schedule |
 
-**Coverage:** All 27 unknowns are assigned to at least one prep task. Most Critical and High-priority unknowns are assigned to the same task that will act on the findings (e.g., Task 2 audits alias-AD AND its findings drive Task 6's rollout design).
+**Coverage:** All 27 prep-time unknowns are assigned to at least one prep task. Most Critical and High-priority unknowns are assigned to the same task that will act on the findings (e.g., Task 2 audits alias-AD AND its findings drive Task 6's rollout design). The 4 end-of-sprint discoveries (KU-33..KU-36) are tracked in §"End-of-Sprint Discoveries" and feed into Sprint 26 prep instead.
 
 **Deferred from Sprint 24** (now carried as Sprint 25 KUs):
 

--- a/docs/planning/EPIC_4/SPRINT_25/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_25/KNOWN_UNKNOWNS.md
@@ -1724,6 +1724,58 @@ _Add unknowns discovered during Sprint 25 execution here, then categorize post-s
 
 ---
 
+## End-of-Sprint Discoveries (KU-33 .. KU-36)
+
+Surfaced during Sprint 25 execution and Day 13 buffer review. Carried forward to Sprint 26.
+
+### KU-33: Pattern C generalizes beyond launch — `nu_<eq>(i±N)` phantom-offset enumeration appears on at least 4 CGE / SAM-balance models
+
+**Surfaced:** Day 13 (filing carryforward issues #1354 camcge, #1355 cesam2, #1356 fawley, #1357 otpop)
+
+**Discovery:** The Day 6 Pattern C gate (PR #1308) was scoped to launch's specific `$ge(ss, s)`-conditional alias sum. Day 13 inspection of the four new `path_syntax_error` models revealed the same phantom-offset enumeration pattern (`nu_ieq(i±N)`, `nu_COLSUM(i±N)`, etc.) emitted on stationarity equations whose source bodies have **no** alias-conditional guard — they have plain `imat(i,j)` SAM-coefficient references where the AD layer is unifying `j` with `i` and then enumerating ±N.
+
+**Sprint 26 implication:** The Pattern C gate needs to be widened to detect plain-alias enumeration (no `$cond` filter required) and consolidate into a single `sum(j$(...), imat(j,i) * nu_<eq>(j))` term scoped to the equation's declared domain. Likely unblocks #1354, #1355, and possibly #1356 / #1357 if the \$171 errors share the same root cause. Estimated value: 2–4 path_syntax_error → solve.
+
+**Status:** 🔍 INCOMPLETE — Sprint 26 root-cause investigation needed before estimating fix scope.
+
+---
+
+### KU-34: Bucket churn dominates Sprint 25 path_syntax_error metric — Day 0 baseline counts conflate translate-failures with solve-failures
+
+**Surfaced:** Day 11 retest analysis (`SPRINT_LOG.md` §"Revised Checkpoint 2 evaluation")
+
+**Discovery:** Sprint 25's `path_syntax_error` count moved 11 → 12 net, but the underlying composition changed substantially: 3 baseline syntax-error models (`clearlak`, `ferts`, `mathopt4`) were resolved during the sprint, while 4 new ones appeared (`camcge`, `cesam2`, `fawley`, `otpop`). The metric measures "models that reached PATH and failed compilation" — when a sprint fixes upstream translate failures, those models surface in the syntax-error bucket as a side effect, even if the sprint also closed the syntax-error issues that were blocking the original residents.
+
+**Sprint 26 implication:** Sprint metrics should track **bucket transitions** (where did each model come from? where did it go?) rather than just net counts. A "−3 / +4 = +1 net" looks like regression but is actually three closed bugs plus four new (transferred-bucket) ones. The Sprint 26 baseline should explicitly tag each of the 12 current `path_syntax_error` entries with its Sprint 24 bucket so progress is attributable.
+
+**Status:** 🔍 INCOMPLETE — Sprint 26 prep should add a "bucket provenance" column to `BASELINE_METRICS.md`.
+
+---
+
+### KU-35: Day 12 multi-solve gate Approach A correctly excludes display-only post-solve patterns — but the over-approximation is wider than documented
+
+**Surfaced:** Day 12 PR #1353 review iterations (Copilot comments 3185118502, 3185118515, 3185184392)
+
+**Discovery:** The original PR description framed `top_level_marginal_reads` as recording only `.m` reads; review surfaced that the parser hook actually captures **every** `bound_scalar` / `bound_indexed` attr (`.l`, `.lo`, `.up`, `.m`, ...), and the gate is the single point of truth that filters to `attr == "m"` AND `sym ∈ equation_names`. The over-approximation also extends to attribute reads inside the LHS `$cond` of `conditional_assign_general` — `p(i)$(eq.m(i) > 0) = ...` reads `eq.m` from a guard, not the RHS, but is still recorded.
+
+**Sprint 26 implication:** When the gate is extended (e.g., to handle additional driver shapes), the implementation should keep the parser-side capture wide and only narrow at the gate. A future "tighten the parser hook to RHS-only" optimization would re-introduce the asymmetry the review caught. Document this in the gate's docstring as an architectural invariant before any future contributor narrows it.
+
+**Status:** ✅ VERIFIED — captured in `_record_top_level_marginal_reads` docstring (PR #1353 final commit `3ed64c6e`).
+
+---
+
+### KU-36: `_loop_tree_to_gams` substitution coverage was incomplete pre-PR-#1353 — silent on bare-ID loop headers
+
+**Surfaced:** Day 12 PR #1353 review iteration (Copilot comment 3189656041)
+
+**Discovery:** The dispatcher refactor unified the substituting and non-substituting paths via `token_subst: Mapping[str, str] | None = None`. Initial implementation forwarded `token_subst` through `_loop_tree_to_gams` recursive calls but missed the raw `Token(type='ID')` children used for `leading_id` / `filter_id` in `_emit_loop_node` (filtered/indexed loop variants). Review caught it before merge — substitution was incomplete for `loop(i$ACTIVE, ...)`-style headers, contradicting the docstring's "applied at every ID emission" claim.
+
+**Sprint 26 implication:** Any future loop-header parsing changes (e.g., adding a new `loop_stmt_*` variant to the grammar) must explicitly handle `token_subst` for any new `Token(type='ID')` extraction sites. The defensive `_id_text` helper in `_emit_loop_node` is the canonical pattern; the test `test_emit_loop_node_substitutes_leading_and_filter_id` pins the contract.
+
+**Status:** ✅ VERIFIED — fix in `_emit_loop_node` plus regression test landed in `3ed64c6e` (PR #1353 final commit).
+
+---
+
 ## Next Steps
 
 1. **Prep Task 2 (Audit Alias-AD Carryforward)** — verifies Unknowns 1.1, 1.2, 1.3, 1.4, 1.6, 1.7, 1.8
@@ -1774,5 +1826,6 @@ This table shows which Sprint 25 prep tasks verify which unknowns. Prep Task 11 
 ---
 
 **Document Created:** 2026-04-19
-**Total Unknowns:** 27
+**Last Updated:** 2026-05-05 (Day 13 — added end-of-sprint discoveries KU-33..KU-36)
+**Total Unknowns:** 27 prep + 4 end-of-sprint = 31
 **Sprint 24 Carryforward:** 4 KUs (KU-29 → 3.1/3.2, KU-30 → 4.1/4.2, KU-32 → 1.5, KU-13/17 → 1.2)

--- a/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
@@ -226,13 +226,17 @@ No open Batch 3 / WS4 tail. Batch 3 (#1290 ferts, #1291 clearlak) closed Day 11;
 
 #### Sprint 26 carryforward issues filed (Task 5)
 
-| # | Title | Bucket |
+5 issues filed during Day 13; one was discovered to duplicate an existing pre-Sprint-25 tracker and was closed:
+
+| # | Title | Bucket / Disposition |
 |---|---|---|
-| [#1354](https://github.com/jeffreyhorn/nlp2mcp/issues/1354) | camcge: PATH \$141 on phantom IndexOffset `nu_ieq(i±N)` / `nu_actp(i±N)` | path_syntax_error (Pattern C variant) |
-| [#1355](https://github.com/jeffreyhorn/nlp2mcp/issues/1355) | cesam2: PATH \$141 on phantom IndexOffset `nu_COLSUM(i±N)` in `stat_tsam` | path_syntax_error (Pattern C variant) |
-| [#1356](https://github.com/jeffreyhorn/nlp2mcp/issues/1356) | fawley: PATH \$171 domain violations in stationarity (post-#1276 fx fix bucket transfer) | path_syntax_error |
-| [#1357](https://github.com/jeffreyhorn/nlp2mcp/issues/1357) | otpop: PATH \$171 domain violations in stationarity (Sprint 25 bucket transfer) | path_syntax_error (likely subsumed by #1334) |
-| ~~#1358~~ | ~~mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))"~~ — **closed as duplicate of [#1224](https://github.com/jeffreyhorn/nlp2mcp/issues/1224)** (existing tracker since Sprint 23, now `sprint-26`-labeled). Doc lives at `docs/issues/ISSUE_1224_mine-paramref-index-offset-unsupported.md`. |
+| [#1354](https://github.com/jeffreyhorn/nlp2mcp/issues/1354) | camcge: PATH \$141 on phantom IndexOffset `nu_ieq(i±N)` / `nu_actp(i±N)` | path_syntax_error (Pattern C variant) — OPEN |
+| [#1355](https://github.com/jeffreyhorn/nlp2mcp/issues/1355) | cesam2: PATH \$141 on phantom IndexOffset `nu_COLSUM(i±N)` in `stat_tsam` | path_syntax_error (Pattern C variant) — OPEN |
+| [#1356](https://github.com/jeffreyhorn/nlp2mcp/issues/1356) | fawley: PATH \$171 domain violations in stationarity (post-#1276 fx fix bucket transfer) | path_syntax_error — OPEN |
+| [#1357](https://github.com/jeffreyhorn/nlp2mcp/issues/1357) | otpop: PATH \$171 domain violations in stationarity (Sprint 25 bucket transfer) | path_syntax_error (likely subsumed by #1334) — OPEN |
+| ~~[#1358](https://github.com/jeffreyhorn/nlp2mcp/issues/1358)~~ | ~~mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))"~~ | **CLOSED as duplicate of [#1224](https://github.com/jeffreyhorn/nlp2mcp/issues/1224)** (pre-existing tracker since Sprint 23; now `sprint-26`-labeled). Doc at `docs/issues/ISSUE_1224_mine-paramref-index-offset-unsupported.md`. |
+
+**Filed:** 5. **Net-new open after dedup:** 4 (#1354–#1357). The mine bug is still tracked — via the older #1224 instead of the new #1358.
 
 #### Existing carryforward issues labeled `sprint-26` (no close+refile)
 
@@ -247,7 +251,7 @@ Per Day 13 prompt Task 5, original Pattern A Phase 2 cohort issues were left **o
 | Translation internal_error | #1224 (mine ParamRef IndexOffset — pre-existing, supersedes the closed #1358 duplicate) |
 | AD residuals from Day 11 fixes | #1334 (scalar-constraint stationarity spurious Sum), #1335 (missing dzdef/dp cross-term in stat_p) |
 
-Total Sprint 26 backlog: **4 new (#1354–#1357) + 19 carryforward (incl. #1224) = 23 issues** under `sprint-26` label.
+**Total Sprint 26 backlog (open issues under `sprint-26` label): 23.** Composition: 4 net-new from Day 13 (#1354–#1357) + 19 pre-existing carryforward (incl. #1224, which now covers the mine bug originally re-filed as #1358 before dedup). The Day 13 *filing* count was 5; the *open-after-dedup* count is 4.
 
 #### Quality checks
 

--- a/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
@@ -165,3 +165,95 @@ Per the literal Checkpoint 2 rule (any NO-GO criterion → NO-GO overall), the f
 - Phase E (Pattern E routing — #1141, #1144, #1147) is **cancelled** per the literal NO-GO routing.
 
 ---
+
+### Day 12 — WS4 Small Priorities (#1270, #1271)
+
+**Status:** COMPLETE (2026-05-05)
+**Branch:** `sprint25-day12-small-priorities`
+**PR:** [#1353](https://github.com/jeffreyhorn/nlp2mcp/pull/1353) — MERGED at `6d8ae6b7`
+
+| Task | Status |
+|---|---|
+| #1270 multi-solve gate Approach A (cross-reference) — saras-style top-level `eq.m` reads | ✅ New IR field `top_level_marginal_reads` + transitive closure helper `_params_referenced_in_any_constraint_body` + cross-reference filter in `scan_multi_solve_driver` |
+| #1271 dispatcher refactor — collapse `_loop_tree_to_gams_subst_dispatch` into `_loop_tree_to_gams(node, *, token_subst=None)` | ✅ ~140 LOC removed; byte-diff verified 0 diffs across all 141 currently-translating models |
+| Tests added (4 in `test_driver.py` F1–F4 + integration test for synthetic saras CLI exit-4) | ✅ 4,733 passed, 10 skipped, 2 xfailed |
+| `make typecheck && make lint && make format && make test` | ✅ Pass (one xdist-flaky `test_rocket_expr_bound_emitted` passes in isolation, unrelated to either WS4 change) |
+
+#### Verification — corpus
+
+| Model | declared | solves | margs | is_driver | Notes |
+|---|---|---|---|---|---|
+| saras | 2 | 2 | calibuc.m, calibul.m | **TRUE** | Target — primal/dual driver. Translate now raises `MultiSolveDriverError`. |
+| gussrisk, sparta, partssupply, ibm1, imsl, otpop, turkey | — | — | — | False | Single-model + multi-model regression canaries; correctly excluded by transitive cross-ref + `var.l` vs `eq.m` distinction (Approach A). |
+
+#### PR review iterations
+
+Five rounds of Copilot review comments addressed across commits `ddb37e2b`, `0a608357`, `282386df`, `3ed64c6e`:
+
+- Docstring direction inversion in `_params_referenced_in_any_constraint_body` (Q reads P, not P reads Q)
+- Scope-neutral `MultiSolveDriverError` message (top-level + in-loop both possible now)
+- `CaseInsensitiveDict` redundant lowercase-set comprehension
+- Broadened parser hook to record all `bound_scalar`/`bound_indexed` attrs (not just `.m`) — gate is single point of truth
+- `dollar_cond` / `dollar_cond_paren` `children[1]` was the DOLLAR token, not RHS (fixed for non-substituting branch)
+- Synthetic test fixtures aligned with real grammar shape (DOLLAR token between LHS and RHS)
+- `_emit_loop_node` threading `token_subst` through nested loops + raw `Token('ID')` for `leading_id`/`filter_id`
+- Compound-LHS paren-wrap for `dollar_cond_paren` non-substituting branch
+- Docstring clarification that `$cond` reads in `conditional_assign_general` are intentionally captured
+
+#### Notes
+
+- `data/gamslib/gamslib_status.json` saras entry left for the Day 14 pipeline retest. The translate stage now raises `MultiSolveDriverError`, which the batch pipeline records as `translate.status = failure / category = internal_error` with the multi-solve message — matching how decomp / danwolfe are tracked.
+- Closed #1270 and #1271 via `df79a2d6`; issue docs moved to `docs/issues/completed/`.
+
+---
+
+### Day 13 — Buffer + Sprint 26 Carryforward Issue Filing
+
+**Status:** COMPLETE (2026-05-05)
+**Branch:** `sprint25-day13-buffer`
+
+#### Routing
+
+Per `prompts/PLAN_PROMPTS.md` §"Day 13 Prompt", optional Phase E + Option 1 short-circuit + qabel/abel fix were all skipped:
+
+- **Phase E (Tasks 2–3):** Cancelled per the literal Checkpoint 2 NO-GO routing on `path_syntax_error` (12 vs ≤11 threshold). The CONDITIONAL GO recommendation in §"Revised Checkpoint 2" did not override the formal NO-GO; PLAN.md §"Day 13" routing is unambiguous.
+- **Option 1 short-circuit (Task 3):** Requires "≥4h clear headroom" — Day 13 is buffer day; deferred to Sprint 26 algorithmic timeout workstream.
+- **qabel/abel narrow fix (Task 4):** Day 8 reassessment located the real bug as `#1311` (AD criterion's u-quadratic gradient dropped to `Const(0.0)` when sum index is a subset of the variable's domain). #1311 is **CLOSED** — fix already landed during the sprint. No Day 13 action.
+
+#### Buffer (Task 1)
+
+No open Batch 3 / WS4 tail. Batch 3 (#1290 ferts, #1291 clearlak) closed Day 11; WS4 (#1270, #1271) closed Day 12.
+
+#### Sprint 26 carryforward issues filed (Task 5)
+
+| # | Title | Bucket |
+|---|---|---|
+| [#1354](https://github.com/jeffreyhorn/nlp2mcp/issues/1354) | camcge: PATH \$141 on phantom IndexOffset `nu_ieq(i±N)` / `nu_actp(i±N)` | path_syntax_error (Pattern C variant) |
+| [#1355](https://github.com/jeffreyhorn/nlp2mcp/issues/1355) | cesam2: PATH \$141 on phantom IndexOffset `nu_COLSUM(i±N)` in `stat_tsam` | path_syntax_error (Pattern C variant) |
+| [#1356](https://github.com/jeffreyhorn/nlp2mcp/issues/1356) | fawley: PATH \$171 domain violations in stationarity (post-#1276 fx fix bucket transfer) | path_syntax_error |
+| [#1357](https://github.com/jeffreyhorn/nlp2mcp/issues/1357) | otpop: PATH \$171 domain violations in stationarity (Sprint 25 bucket transfer) | path_syntax_error (likely subsumed by #1334) |
+| [#1358](https://github.com/jeffreyhorn/nlp2mcp/issues/1358) | mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))" + SetMembershipTest non-static | internal_error |
+
+#### Existing carryforward issues labeled `sprint-26` (no close+refile)
+
+Per Day 13 prompt Task 5, original Pattern A Phase 2 cohort issues were left **open** with the existing rel_diff data attached, rather than closed-and-refiled per Day 7 cohort sweep. Reclassification (per `DAY7_COHORT_SWEEP.md` §"Classification Table") will happen during Sprint 26 Day 0 prep where it can be reviewed against fresh evidence.
+
+| Category | Issues |
+|---|---|
+| Pattern A cohort (Day 7 sweep classified as not-Pattern-A) | #1138, #1139, #1140, #1142, #1145, #1150 |
+| Pattern E (Phase E cancelled, carryforward) | #1141, #1144, #1147 |
+| Pattern C launch (Bug #1 / Bug #2) | #1306, #1307 |
+| Translation timeouts | #885 (sarf), #931 (iswnm), #932 (nebrazil), #1185 (mexls), #1228 (iswnm second variant) |
+| AD residuals from Day 11 fixes | #1334 (scalar-constraint stationarity spurious Sum), #1335 (missing dzdef/dp cross-term in stat_p) |
+
+Total Sprint 26 backlog: **5 new + 18 carryforward = 23 issues** under `sprint-26` label.
+
+#### Quality checks
+
+Skipped per Day 13 prompt: no `.py` modified (this entry is docs-only).
+
+#### KNOWN_UNKNOWNS.md update
+
+End-of-sprint discoveries appended (KU-33..KU-36 — see `KNOWN_UNKNOWNS.md` §"End-of-Sprint Discoveries").
+
+---

--- a/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_25/SPRINT_LOG.md
@@ -232,7 +232,7 @@ No open Batch 3 / WS4 tail. Batch 3 (#1290 ferts, #1291 clearlak) closed Day 11;
 | [#1355](https://github.com/jeffreyhorn/nlp2mcp/issues/1355) | cesam2: PATH \$141 on phantom IndexOffset `nu_COLSUM(i±N)` in `stat_tsam` | path_syntax_error (Pattern C variant) |
 | [#1356](https://github.com/jeffreyhorn/nlp2mcp/issues/1356) | fawley: PATH \$171 domain violations in stationarity (post-#1276 fx fix bucket transfer) | path_syntax_error |
 | [#1357](https://github.com/jeffreyhorn/nlp2mcp/issues/1357) | otpop: PATH \$171 domain violations in stationarity (Sprint 25 bucket transfer) | path_syntax_error (likely subsumed by #1334) |
-| [#1358](https://github.com/jeffreyhorn/nlp2mcp/issues/1358) | mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))" + SetMembershipTest non-static | internal_error |
+| ~~#1358~~ | ~~mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))"~~ — **closed as duplicate of [#1224](https://github.com/jeffreyhorn/nlp2mcp/issues/1224)** (existing tracker since Sprint 23, now `sprint-26`-labeled). Doc lives at `docs/issues/ISSUE_1224_mine-paramref-index-offset-unsupported.md`. |
 
 #### Existing carryforward issues labeled `sprint-26` (no close+refile)
 
@@ -244,9 +244,10 @@ Per Day 13 prompt Task 5, original Pattern A Phase 2 cohort issues were left **o
 | Pattern E (Phase E cancelled, carryforward) | #1141, #1144, #1147 |
 | Pattern C launch (Bug #1 / Bug #2) | #1306, #1307 |
 | Translation timeouts | #885 (sarf), #931 (iswnm), #932 (nebrazil), #1185 (mexls), #1228 (iswnm second variant) |
+| Translation internal_error | #1224 (mine ParamRef IndexOffset — pre-existing, supersedes the closed #1358 duplicate) |
 | AD residuals from Day 11 fixes | #1334 (scalar-constraint stationarity spurious Sum), #1335 (missing dzdef/dp cross-term in stat_p) |
 
-Total Sprint 26 backlog: **5 new + 18 carryforward = 23 issues** under `sprint-26` label.
+Total Sprint 26 backlog: **4 new (#1354–#1357) + 19 carryforward (incl. #1224) = 23 issues** under `sprint-26` label.
 
 #### Quality checks
 


### PR DESCRIPTION
## Summary

Per [`docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md` §Day 13](../../docs/planning/EPIC_4/SPRINT_25/prompts/PLAN_PROMPTS.md). Docs-only — no `.py` modified, quality checks skipped per Day 13 prompt.

### Routing decisions (skipped optionals)

- **Phase E (Tasks 2–3):** Cancelled per the literal Checkpoint 2 NO-GO routing on `path_syntax_error` (12 vs ≤11 threshold). The CONDITIONAL GO recommendation in Day 11 §"Revised Checkpoint 2" did not override the formal NO-GO; PLAN.md §"Day 13" routing is unambiguous.
- **Option 1 short-circuit (Task 3):** Requires "≥4h clear headroom" — buffer day; deferred to Sprint 26 algorithmic timeout workstream.
- **qabel/abel narrow fix (Task 4):** Day 8 reassessment located the real bug as #1311 (AD u-quadratic gradient dropped to `Const(0.0)` when sum index is a subset of variable's domain). #1311 is **CLOSED** — fix already landed during the sprint.

### Buffer (Task 1)

No open Batch 3 / WS4 tail. Batch 3 (#1290 ferts, #1291 clearlak) closed Day 11; WS4 (#1270, #1271) closed Day 12.

### Sprint 26 carryforward issues filed (Task 5)

5 new issues with `sprint-26` label:

| # | Title |
|---|---|
| #1354 | camcge: PATH \$141 on phantom IndexOffset `nu_ieq(i±N)` / `nu_actp(i±N)` |
| #1355 | cesam2: PATH \$141 on phantom IndexOffset `nu_COLSUM(i±N)` in `stat_tsam` |
| #1356 | fawley: PATH \$171 domain violations in stationarity (post-#1276 bucket transfer) |
| #1357 | otpop: PATH \$171 domain violations in stationarity (Sprint 25 bucket transfer) |
| #1358 | mine: translate fails — "Complex offset expressions not yet supported: ParamRef(li(k))" + SetMembershipTest non-static |

18 existing carryforward issues labeled `sprint-26` (left **open** with rel_diff data attached — close+refile per Day 7 cohort sweep deferred to Sprint 26 Day 0 prep where reclassification can be reviewed against fresh evidence):

- Pattern A cohort: #1138, #1139, #1140, #1142, #1145, #1150
- Phase E (cancelled, carryforward): #1141, #1144, #1147
- Pattern C launch: #1306, #1307
- Translation timeouts: #885, #931, #932, #1185, #1228
- AD residuals from Day 11 fixes: #1334, #1335

**Total Sprint 26 backlog:** 5 new + 18 carryforward = 23 issues.

### SPRINT_LOG.md additions

- **Day 12 entry** (was missing — PR #1353 merged at `6d8ae6b7` but SPRINT_LOG had no entry yet). Includes corpus verification table, summary of the five PR-review iteration commits, and notes on saras `gamslib_status.json` pending Day 14 retest.
- **Day 13 entry** with the routing rationale, filed-issue index, and pointer to KNOWN_UNKNOWNS.md §"End-of-Sprint Discoveries".

### KNOWN_UNKNOWNS.md additions

New §"End-of-Sprint Discoveries" with KU-33..KU-36:

- **KU-33** Pattern C generalizes beyond launch — phantom IndexOffset enumeration on at least 4 CGE/SAM-balance models
- **KU-34** Bucket churn dominates Sprint 25 path_syntax_error metric — metric should track bucket transitions, not net counts
- **KU-35** Day 12 multi-solve gate over-approximation is wider than the PR framing; verified via parser hook + docstring update
- **KU-36** `_loop_tree_to_gams` substitution coverage was incomplete pre-PR-#1353 — silent on bare-ID loop headers; verified by regression test

## Test plan

- [x] `make test` skipped per Day 13 prompt (no `.py` modified)
- [x] `gh issue list --label sprint-26` returns 23 issues (5 new + 18 carryforward)
- [x] `gh issue view <N>` for new issues #1354..#1358 confirms titles + bodies
- [x] SPRINT_LOG.md §"Day 12" + §"Day 13" entries render correctly
- [x] KNOWN_UNKNOWNS.md §"End-of-Sprint Discoveries" KU-33..KU-36 render correctly