### PR TITLE
Sprint 27 Day 2: mark COMPLETE (PR #1414 merged)

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -120,7 +120,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 - [x] launch byte-stable vs Sprint 26 final emit (per KU 4.2). ✅
 - [x] PR19 target list widened to 30 models per Task 5. ✅ (Day 0, PR #1413 merged)
 - [x] All 4 Phase 0 KUs 1.1–1.4 ✅ VERIFIED (1.3 moved from INCOMPLETE on Day 1).
-- [ ] **Remaining: open the P1 #1398 PR** (PR14: 9 regenerated `_mcp.gms` in diff; PR20: cross-ref `DAY0_ANCHOR_SCRATCH_NOTES.md` + `PRIORITY_1_ANCHOR_MAPPING.md` §4; PR23 N/A).
+- [x] **P1 #1398 PR opened + merged** — PR #1414 (PR14: 9 regenerated `_mcp.gms` in diff; PR20: cross-ref `DAY0_ANCHOR_SCRATCH_NOTES.md` + `PRIORITY_1_ANCHOR_MAPPING.md` §4; PR23 N/A). **Merged to main 2026-06-03 (`853000ef`).** Priority 1 COMPLETE.
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -118,7 +118,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | Buffer | 1h | |
 
 **P1 success criteria:**
-- [x] 15 #1398-affected models recover to Day 0 baseline buckets (✅ no regressions): qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from timeout). **Caveat:** dinam/gangesx/turkpow remain at path_syntax_error — their Pattern C emit is now correct, but they carry **pre-existing non-#1398 errors** (various GAMS compile errors in other equations, model-dependent — dinam `$140`/`$171`, turkpow `$170`/`$171`, gangesx `$145`/`$149`/`$300`; turkpow byte-identical to baseline, dinam −2 errors). These are NOT #1398 recoveries → **file as Sprint 28 candidates**.
+- [x] 15 #1398-affected models recover to Day 0 baseline buckets (✅ no regressions): qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from timeout). **Caveat:** dinam/gangesx/turkpow remain at path_syntax_error — their Pattern C emit is now correct, but they carry **pre-existing non-#1398 errors** (GAMS compile errors in other equations, model-dependent — dinam `$140/$141/$171/$257`, turkpow `$141/$149/$170/$171/$257`, gangesx `$141/$145/$149/$257/$300`; turkpow byte-identical to baseline, dinam −2 errors; full enumeration in SPRINT_LOG Day 2). These are NOT #1398 recoveries → **file as Sprint 28 candidates**.
 - [x] launch byte-stable vs Sprint 26 final emit (per KU 4.2). ✅
 - [x] PR19 target list widened to 30 models per Task 5. ✅ (Day 0, PR #1413 merged)
 - [x] All 4 Phase 0 KUs 1.1–1.4 ✅ VERIFIED (1.3 moved from INCOMPLETE on Day 1).

--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -103,7 +103,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | Run pipeline tests + bucket-provenance check for affected models | 2h | ✅ DONE — qdemo7 → `compare_match`; egypt/ferts/shale/srpchase → `path_solve_license`; ganges → `path_syntax_error` (from timeout); dinam/gangesx/turkpow → `path_syntax_error` (residual pre-existing, non-#1398); sambal/qsambal/harker → compare_mismatch; tfordy/sroute → path_solve_license |
 | Tier 0/1 byte-stability verification (regenerate all 11 Tier 0/1 canaries + `launch` byte-stability anchor, diff vs main) | 1h | ✅ DONE (carryforward) — all 11 canaries + launch byte-identical. `launch` is PR19 pattern-c but still byte-checked here as the #1379 anchor |
 | Author PR description (PR14 reaffirmation + PR20 Phase 0 acceptance-gate cross-reference) | 2h | Regenerated `.gms` diffs included in PR; PR description cross-references `PRIORITY_1_ANCHOR_MAPPING.md` §4 anchor-by-anchor hand-derived KKT shapes. PR23 not applicable — pure `src/kkt/stationarity.py` change, no workflow/CI files touched |
-| Open PR; respond to first review iteration | 3h | |
+| Open PR; respond to first review iteration | 3h | ✅ DONE — PR #1414 opened, one review round (ferts §4.2 header consistency), merged to main `853000ef` |
 
 ### Day 3 (~8h) — P2 Phase 0 transition (P1 PR review + merge done early in Day 2)
 
@@ -118,7 +118,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | Buffer | 1h | |
 
 **P1 success criteria:**
-- [x] 15 #1398-affected models recover to Day 0 baseline buckets (✅ no regressions): qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from timeout). **Caveat:** dinam/gangesx/turkpow remain at path_syntax_error — their Pattern C emit is now correct, but they carry **pre-existing non-#1398 errors** ($140/$170/$171 in other equations; turkpow byte-identical to baseline, dinam −2 errors). These are NOT #1398 recoveries → **file as Sprint 28 candidates**.
+- [x] 15 #1398-affected models recover to Day 0 baseline buckets (✅ no regressions): qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from timeout). **Caveat:** dinam/gangesx/turkpow remain at path_syntax_error — their Pattern C emit is now correct, but they carry **pre-existing non-#1398 errors** (various GAMS compile errors in other equations, model-dependent — dinam `$140`/`$171`, turkpow `$170`/`$171`, gangesx `$145`/`$149`/`$300`; turkpow byte-identical to baseline, dinam −2 errors). These are NOT #1398 recoveries → **file as Sprint 28 candidates**.
 - [x] launch byte-stable vs Sprint 26 final emit (per KU 4.2). ✅
 - [x] PR19 target list widened to 30 models per Task 5. ✅ (Day 0, PR #1413 merged)
 - [x] All 4 Phase 0 KUs 1.1–1.4 ✅ VERIFIED (1.3 moved from INCOMPLETE on Day 1).
@@ -300,7 +300,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | **Final pipeline retest** under 3 `PYTHONHASHSEED` values (PR12 determinism guard) | 3h | Determinism acceptance criterion verification |
 | Author Sprint 27 SPRINT_LOG.md final-day entry: headline metrics, bucket-provenance Sprint 26 final → Sprint 27 final, per-priority deliverables | 2h | |
 | Author Sprint 27 SPRINT_RETROSPECTIVE.md (mirror Sprint 26 retrospective structure: What Went Well / What We'd Do Differently / Sprint 28 Recommendations / KU Coverage Summary) | 2h | |
-| Buffer / Sprint 28 carryforward filings (issues that REPLANned or didn't fit budget) | 0.5h | Includes: #1385 cross-terms + #1393+#1335 (P3 re-plan); **dinam/gangesx/turkpow residual non-#1398 path_syntax_error** (Day 2 finding — `$140`/`$170`/`$171` in non-Pattern-C equations; #1398 emit is correct but these models carry independent errors) |
+| Buffer / Sprint 28 carryforward filings (issues that REPLANned or didn't fit budget) | 0.5h | Includes: #1385 cross-terms + #1393+#1335 (P3 re-plan); **dinam/gangesx/turkpow residual non-#1398 path_syntax_error** (Day 2 finding — pre-existing GAMS errors in non-Pattern-C equations, model-dependent codes; #1398 emit is correct but these models carry independent errors) |
 
 **Day 13 success criteria:**
 - [ ] All Sprint 27 acceptance criteria met OR explicitly carried forward to Sprint 28 with formal Phase 0 filing.

--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -105,12 +105,14 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | Author PR description (PR14 reaffirmation + PR20 Phase 0 acceptance-gate cross-reference) | 2h | Regenerated `.gms` diffs included in PR; PR description cross-references `PRIORITY_1_ANCHOR_MAPPING.md` §4 anchor-by-anchor hand-derived KKT shapes. PR23 not applicable — pure `src/kkt/stationarity.py` change, no workflow/CI files touched |
 | Open PR; respond to first review iteration | 3h | |
 
-### Day 3 (~8h) — PR review iteration + merge + transition
+### Day 3 (~8h) — P2 Phase 0 transition (P1 PR review + merge done early in Day 2)
+
+> ℹ️ **The P1 #1398 PR review iteration + merge happened early** — PR #1414 was opened, reviewed, and **merged to main (`853000ef`)** during the Day 2 compressed timeline, so the first two rows below are already ✅ DONE. Day 3's live work is the PR19-CI verification + the P2 #1381 Phase 0 start.
 
 | Task | Effort | Notes |
 |---|---|---|
-| PR review iteration (target: ≤ 2 rounds; PR14 + PR20 disclosures pre-filled so reviewer can verify regenerated `.gms` against hand-derived KKT directly) | 3h | |
-| Merge PR | 0.5h | |
+| PR review iteration (target: ≤ 2 rounds; PR14 + PR20 disclosures pre-filled so reviewer can verify regenerated `.gms` against hand-derived KKT directly) | 3h | ✅ DONE — PR #1414 (one round: ferts §4.2 header consistency) |
+| Merge PR | 0.5h | ✅ DONE — merged to main `853000ef` (2026-06-03) |
 | Verify PR19 widening CI fires correctly on the merged commit | 0.5h | Per Task 5 §7 PR-runtime projection |
 | Start P2 Phase 0 hand-derivation for camcge `nu_ieq` cross-term (per `PROJECT_PLAN.md` Priority 2) | 3h | KU 2.1 still 🔍 INCOMPLETE; Day 0 PR19 widening Day 4 P2 commits gated on this |
 | Buffer | 1h | |

--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -95,7 +95,7 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 
 ### Day 2 (~10h) — Full regression + PR open
 
-> ✅ **Carryforward done (2026-06-03):** the regeneration, bucket-provenance, Tier 0/1 byte-stability, and the `PRIORITY_1_ANCHOR_MAPPING.md` §4.2/§4.4 grep-spec correction are **already complete** on branch `planning/sprint27-day1-p1` (commit `4de59037`); see SPRINT_LOG Day 2. **Only the PR-open + review iteration remain.** Provenance result: **qdemo7 → compare_match** (the +1 Solve/Match anchor); egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from translate_timeout); **dinam/gangesx/turkpow stay at path_syntax_error from PRE-EXISTING non-#1398 errors** (turkpow byte-identical to baseline; dinam has fewer errors) → Sprint 28 candidates. **No regressions.**
+> ✅ **DAY 2 COMPLETE (2026-06-03) — Priority 1 #1398 merged.** Regeneration, bucket-provenance, Tier 0/1 byte-stability, the `PRIORITY_1_ANCHOR_MAPPING.md` §4.2/§4.4 grep-spec correction, **and the PR (PR #1414, opened + reviewed + MERGED to main `853000ef`)** are all done; see SPRINT_LOG Day 2. Provenance result: **qdemo7 → compare_match** (the +1 Solve/Match anchor); egypt/ferts/shale/srpchase → path_solve_license; ganges → path_syntax_error (from translate_timeout); **dinam/gangesx/turkpow stay at path_syntax_error from PRE-EXISTING non-#1398 errors** (turkpow byte-identical to baseline; dinam has fewer errors) → Sprint 28 candidates. **No regressions.**
 
 | Task | Effort | Notes |
 |---|---|---|

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -159,7 +159,7 @@ _(no emit-affecting changes in range)_
 | fawley | path_syntax_error | path_syntax_error | folded into #1356 (P5), not P1 |
 | launch | compare_mismatch | compare_mismatch | byte-identical (KU 4.2 anchor; #1378 target) |
 
-**No regressions** — every model is at its Day 0 bucket or better. The #1398 fix fully clears the Pattern C over-reach; dinam/gangesx/turkpow's residual `path_syntax_error` is **pre-existing** (independent `$140`/`$170`/`$171` errors in non-Pattern-C equations — turkpow byte-identical to baseline confirms it; dinam has *fewer* errors than baseline). Those residuals are out of #1398 scope (Sprint 28 candidates).
+**No regressions** — every model is at its Day 0 bucket or better. The #1398 fix fully clears the Pattern C over-reach; dinam/gangesx/turkpow's residual `path_syntax_error` is **pre-existing** — independent GAMS compile errors in non-Pattern-C equations, with **model-dependent** codes (not a shared set): dinam `$140`/`$141`/`$171`, turkpow `$141`/`$149`/`$170`/`$171`, gangesx `$141`/`$145`/`$149`/`$300` (all `+$257`). turkpow is byte-identical to baseline (confirms pre-existing); dinam has *fewer* errors than baseline. Out of #1398 scope (Sprint 28 candidates).
 
 ### KUs verified
 - KU 1.3 ✅ (Day 1). Bucket-provenance confirms the Day 0 recovery projections (§2 acceptance): qdemo7 → compare_match; egypt/ferts/shale → path_solve_license.
@@ -167,7 +167,7 @@ _(no emit-affecting changes in range)_
 ### Carryforward to Day 3
 - ✅ P1 #1398 PR opened + merged (PR #1414, merge `853000ef`). One review comment (ferts §4.2 header consistency) addressed.
 - Day 3: verify PR19 widening CI fired correctly on the merged commit; start P2 #1381 Phase 0 hand-derivation (camcge `nu_ieq` cross-term).
-- **Sprint 28 candidate filed:** dinam/gangesx/turkpow residual (non-#1398) path_syntax_error — `$140`/`$170`/`$171` in non-Pattern-C equations (recorded in PLAN.md §13 Day 13 carryforward).
+- **Sprint 28 candidate filed:** dinam/gangesx/turkpow residual (non-#1398) path_syntax_error — pre-existing GAMS errors in non-Pattern-C equations, **model-dependent** (union across the group: `$140`/`$141`/`$145`/`$149`/`$170`/`$171`/`$257`/`$300`; no single model has them all) (recorded in PLAN.md §13 Day 13 carryforward).
 
 ### PR opened
 - **PR #1414** — "Sprint 27 P1: #1398 Phase A gate tightening (qdemo7 → compare_match; no regressions)". PR14: 9 regenerated `_mcp.gms` in diff. PR20: `DAY0_ANCHOR_SCRATCH_NOTES.md` hand-derivations + `PRIORITY_1_ANCHOR_MAPPING.md` §4 (§4.2/§4.4 corrected). PR23 N/A. **MERGED to main 2026-06-03 (`853000ef`).**

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -134,7 +134,7 @@ _(no emit-affecting changes in range)_
 ## Day 2 — Priority 1 full regression + PR open
 
 **Date:** 2026-06-03
-**Status:** 🟡 IN PROGRESS — full regression + bucket-provenance + doc-spec fix DONE; PR opening pending
+**Status:** 🟢 COMPLETE — full regression + bucket-provenance + doc-spec fix + **PR #1414 opened, reviewed, and MERGED** (merge `853000ef`, 2026-06-03)
 **Hours budgeted:** ≤ 10
 **Hours actual:** ~3 (carryforward portion)
 
@@ -165,11 +165,12 @@ _(no emit-affecting changes in range)_
 - KU 1.3 ✅ (Day 1). Bucket-provenance confirms the Day 0 recovery projections (§2 acceptance): qdemo7 → compare_match; egypt/ferts/shale → path_solve_license.
 
 ### Carryforward to Day 3
-- **Open the P1 #1398 PR** (PR14: the 9 regenerated `_mcp.gms` in the diff; PR20: cross-reference `DAY0_ANCHOR_SCRATCH_NOTES.md` hand-derivations + `PRIORITY_1_ANCHOR_MAPPING.md` §4; PR23 N/A — pure `src/kkt/stationarity.py`). Branch `planning/sprint27-day1-p1`.
-- File Sprint 28 candidates for dinam/gangesx/turkpow residual (non-#1398) path_syntax_error.
+- ✅ P1 #1398 PR opened + merged (PR #1414, merge `853000ef`). One review comment (ferts §4.2 header consistency) addressed.
+- Day 3: verify PR19 widening CI fired correctly on the merged commit; start P2 #1381 Phase 0 hand-derivation (camcge `nu_ieq` cross-term).
+- **Sprint 28 candidate filed:** dinam/gangesx/turkpow residual (non-#1398) path_syntax_error — `$140`/`$170`/`$171` in non-Pattern-C equations (recorded in PLAN.md §13 Day 13 carryforward).
 
 ### PR opened
-- _(pending — see Carryforward; the diff + provenance are ready)_
+- **PR #1414** — "Sprint 27 P1: #1398 Phase A gate tightening (qdemo7 → compare_match; no regressions)". PR14: 9 regenerated `_mcp.gms` in diff. PR20: `DAY0_ANCHOR_SCRATCH_NOTES.md` hand-derivations + `PRIORITY_1_ANCHOR_MAPPING.md` §4 (§4.2/§4.4 corrected). PR23 N/A. **MERGED to main 2026-06-03 (`853000ef`).**
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -151,7 +151,7 @@ _(no emit-affecting changes in range)_
 | shale | path_syntax_error | path_solve_license | ✅ recovered → license |
 | srpchase | translate_timeout | path_solve_license | ✅ now translates → license |
 | ganges | translate_timeout | path_syntax_error | ✅ recovered from timeout (residual non-#1398 syntax) |
-| dinam | path_syntax_error | path_syntax_error | emit corrected (−2 `$149` errors vs git baseline); residual $140/$171 pre-existing |
+| dinam | path_syntax_error | path_syntax_error | emit corrected (−2 `$149` errors vs git baseline); residual `$140/$141/$171/$257` pre-existing |
 | gangesx | path_syntax_error | path_syntax_error | emit corrected; residual errors pre-existing |
 | turkpow | path_syntax_error | path_syntax_error | byte-identical to baseline — path_syntax_error entirely pre-existing |
 | sambal/qsambal/harker | compare_mismatch | compare_mismatch | unchanged (correct; pre-existing numerics) |
@@ -159,7 +159,7 @@ _(no emit-affecting changes in range)_
 | fawley | path_syntax_error | path_syntax_error | folded into #1356 (P5), not P1 |
 | launch | compare_mismatch | compare_mismatch | byte-identical (KU 4.2 anchor; #1378 target) |
 
-**No regressions** — every model is at its Day 0 bucket or better. The #1398 fix fully clears the Pattern C over-reach; dinam/gangesx/turkpow's residual `path_syntax_error` is **pre-existing** — independent GAMS compile errors in non-Pattern-C equations, with **model-dependent** codes (not a shared set): dinam `$140`/`$141`/`$171`, turkpow `$141`/`$149`/`$170`/`$171`, gangesx `$141`/`$145`/`$149`/`$300` (all `+$257`). turkpow is byte-identical to baseline (confirms pre-existing); dinam has *fewer* errors than baseline. Out of #1398 scope (Sprint 28 candidates).
+**No regressions** — every model is at its Day 0 bucket or better. The #1398 fix fully clears the Pattern C over-reach; dinam/gangesx/turkpow's residual `path_syntax_error` is **pre-existing** — independent GAMS compile errors in non-Pattern-C equations, with **model-dependent** codes (not a shared set): dinam `$140/$141/$171/$257`, turkpow `$141/$149/$170/$171/$257`, gangesx `$141/$145/$149/$257/$300`. turkpow is byte-identical to baseline (confirms pre-existing); dinam has *fewer* errors than baseline. Out of #1398 scope (Sprint 28 candidates).
 
 ### KUs verified
 - KU 1.3 ✅ (Day 1). Bucket-provenance confirms the Day 0 recovery projections (§2 acceptance): qdemo7 → compare_match; egypt/ferts/shale → path_solve_license.

--- a/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
@@ -110,9 +110,9 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 1. ✅ DONE (carryforward). Regenerate `*_mcp.gms` for all 15 #1398-affected models + launch (`run_full_test.py --model <name>`). 9 artifacts changed; 6 affected + launch + 11 canaries byte-identical.
 2. ✅ DONE (carryforward). Bucket-provenance (Day 0 → Day 2): qdemo7 → `compare_match`; egypt/ferts/shale/srpchase → `path_solve_license`; ganges → `path_syntax_error` (recovered from translate_timeout); sambal/qsambal/harker → compare_mismatch; tfordy/sroute → path_solve_license; **dinam/gangesx/turkpow → `path_syntax_error` (residual PRE-EXISTING non-#1398 errors — turkpow byte-identical to baseline, dinam −2 errors; file as Sprint 28 candidates)**; launch byte-stable. **No regressions.**
 3. ✅ DONE (carryforward). Tier 0/1 byte-stability — all 11 canaries + `launch` byte-identical vs main (zero diffs).
-4. Author PR description: **PR14 disclosure** (list regenerated `.gms` files via PR22 audit-script invocation) + **PR20 Phase 0 cross-reference** (cite `PRIORITY_1_ANCHOR_MAPPING.md` §4 anchor-by-anchor hand-derived KKT shapes; reviewer checks regenerated `.gms` matches the hand-derived shape for each of the 8 anchors). PR23 self-review NOT required — pure `src/kkt/stationarity.py` change, no workflow/CI files touched.
-5. Open PR. Respond to first review iteration.
-6. EOD quality gate + SPRINT_LOG.md Day 2 entry.
+4. ✅ DONE (PR #1414). Authored PR description: **PR14 disclosure** (9 regenerated `.gms` files in diff) + **PR20 Phase 0 cross-reference** (`PRIORITY_1_ANCHOR_MAPPING.md` §4 anchor-by-anchor hand-derived KKT shapes). PR23 N/A — pure `src/kkt/stationarity.py` change.
+5. ✅ DONE. PR #1414 opened; one review comment (ferts §4.2 header consistency) addressed; **merged to main (`853000ef`)**.
+6. ✅ DONE. Quality gate green (`make test` → 4737 passed, 10 skipped, 1 xfailed); SPRINT_LOG Day 2 entry recorded.
 
 **Success criteria (Day 2):**
 - [x] 15 #1398-affected models at Day 0 baseline buckets or better — **no regressions** (qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license). dinam/gangesx/turkpow stay at path_syntax_error from pre-existing non-#1398 errors → Sprint 28 candidates.
@@ -125,7 +125,7 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 ## Day 3 Prompt — Priority 1 merge + Priority 2 Phase 0 start (~8h)
 
-**Context:** Iterate Priority 1 PR to merge. Verify PR19 widening fires correctly on the merged commit. Start Priority 2 #1381 Phase 0 hand-derivation for camcge `nu_ieq`.
+**Context:** Verify PR19 widening fires correctly on the merged commit. Start Priority 2 #1381 Phase 0 hand-derivation for camcge `nu_ieq`. (**Priority 1 #1398 already merged early** — PR #1414 → main `853000ef`, 2026-06-03 — so the "iterate + merge" tasks below are ✅ DONE; Day 3's live work is tasks 3–6.)
 
 **Read first:**
 - `docs/planning/EPIC_4/SPRINT_27/PLAN.md` §5 "Day 3" + §6 "Day 4"
@@ -134,18 +134,18 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 **Tasks:**
 
-1. PR review iteration on Priority 1 PR (target: ≤ 2 rounds; the PR description's PR14 regenerated-`.gms` list + PR20 anchor-by-anchor Phase 0 cross-reference are pre-filled so the reviewer can verify each artifact against the hand-derived KKT directly).
-2. Merge Priority 1 PR.
-3. Verify PR19 widening CI fires correctly: trigger a no-op PR on the new widened target list; expect ~37s steady-state runtime per `PR19_WIDENING_DESIGN.md` §7 projection.
+1. ✅ DONE. PR review iteration on Priority 1 PR #1414 (one round: ferts §4.2 header consistency).
+2. ✅ DONE. Priority 1 PR #1414 merged to main (`853000ef`).
+3. Verify PR19 widening CI fires correctly: trigger a no-op PR on the new widened target list; expect ~36s steady-state runtime per `PR19_WIDENING_DESIGN.md` §7 projection.
 4. **Start Priority 2 Phase 0** — hand-derive KKT for camcge `nu_ieq` cross-term. Recorded in scratch notes. Identify cesam2 as second-anchor model (same Phase C-derived shape per `PROJECT_PLAN.md` Priority 2).
 5. Update KNOWN_UNKNOWNS.md: KU 1.3 ✅ VERIFIED (gate predicate fires only on launch-shape); KU 1.1, 1.2, 1.4 already verified at prep.
 6. SPRINT_LOG.md Day 3 entry. Update sprint cumulative metrics: Solve / Match unchanged but P1 unblocks Day 5 retest.
 
 **Success criteria (Day 3):**
-- [ ] Priority 1 PR merged to main.
+- [x] Priority 1 PR merged to main (PR #1414, `853000ef`).
 - [ ] PR19 widening verified on a follow-up no-op PR.
 - [ ] camcge Phase 0 hand-derivation complete.
-- [ ] KU 1.3 ✅ VERIFIED.
+- [x] KU 1.3 ✅ VERIFIED (Day 1).
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
@@ -98,7 +98,7 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 **Context:** Land the tightened predicate. Regenerate all 15 #1398-affected models + launch. Verify bucket-provenance recovery (qdemo7 → compare_match, etc.). Open PR with **PR14 reaffirmation + PR20 Phase 0 cross-reference** (the predicate change is in `src/kkt/stationarity.py` — pure `src/` change, so PR23 does NOT apply per `CONTRIBUTING.md` §"CI Workflow PR Checklist (PR23, ...)" §"Scope").
 
-> ✅ **Tasks 1–3 + 6 already complete (2026-06-03 carryforward, branch `planning/sprint27-day1-p1`, commit `4de59037`)** — regeneration, bucket-provenance, Tier 0/1 byte-stability, and the §4.2/§4.4 grep-spec correction are done (see SPRINT_LOG Day 2). **Only tasks 4–5 (author + open the PR) remain.** Note: `PRIORITY_1_ANCHOR_MAPPING.md` §4.2 (ferts) + §4.4 (ganges) grep specs were CORRECTED on Day 2 — they had documented the buggy gate-mangled baseline; use the corrected source-order specs. (qdemo7 §4.1 was already correct.)
+> ✅ **DAY 2 COMPLETE (2026-06-03).** All tasks done: regeneration, bucket-provenance, Tier 0/1 byte-stability, the §4.2/§4.4 grep-spec correction (carryforward commit `4de59037`), and **PR #1414 opened, reviewed, and MERGED to main (`853000ef`)** — Priority 1 #1398 landed. Note for reference: `PRIORITY_1_ANCHOR_MAPPING.md` §4.2 (ferts) + §4.4 (ganges) grep specs were corrected (they had documented the buggy gate-mangled baseline; qdemo7 §4.1 was already correct).
 
 **Read first:**
 - `docs/planning/EPIC_4/SPRINT_27/PLAN.md` §5 "Day 2"
@@ -118,8 +118,8 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 - [x] 15 #1398-affected models at Day 0 baseline buckets or better — **no regressions** (qdemo7 → compare_match; egypt/ferts/shale/srpchase → path_solve_license). dinam/gangesx/turkpow stay at path_syntax_error from pre-existing non-#1398 errors → Sprint 28 candidates.
 - [x] launch byte-stable.
 - [x] Tier 0/1 canaries byte-stable (zero diffs on non-affected models).
-- [ ] **PR open with PR14 + PR20 Phase 0 disclosures (PR23 not applicable to this `src/`-only PR).** ← remaining
-- [ ] First review iteration responded to. ← remaining
+- [x] PR open with PR14 + PR20 Phase 0 disclosures (PR23 not applicable to this `src/`-only PR) — **PR #1414**.
+- [x] First review iteration responded to (ferts §4.2 header consistency) — **PR #1414 MERGED to main (`853000ef`)**.
 
 ---
 


### PR DESCRIPTION
## Sprint 27 Day 2 — mark COMPLETE (docs-only)

Day 2 (Priority 1 #1398) is fully done — PR #1414 was opened, the one review comment (ferts §4.2 header consistency) was addressed, and it was **merged to main (`853000ef`)**. This PR just syncs the planning records, which on `main` still said "Day 2 IN PROGRESS / PR opening pending."

- `SPRINT_LOG.md` Day 2: status 🟡 IN PROGRESS → 🟢 COMPLETE; PR-opened + carryforward lines updated with the merge.
- `PLAN.md` §5 Day 2: final P1 success criterion checked.
- `prompts/PLAN_PROMPTS.md` Day 2: "only tasks 4–5 remain" banner → DAY 2 COMPLETE; last two success criteria checked.

Docs-only; no `make` checks required. No `src`/CI changes (PR23 N/A).
