### PR TITLE
Sprint 27 Day 3: Priority 2 #1381 Phase 0 hand-derivations + PR19 CI verify

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_27/DAY3_P2_PHASE0_NOTES.md
+++ b/docs/planning/EPIC_4/SPRINT_27/DAY3_P2_PHASE0_NOTES.md
@@ -1,0 +1,124 @@
+# Sprint 27 Day 3 — Priority 2 (#1381 Pattern C Phase B) Phase 0 hand-derivations
+
+**Status:** 🟡 IN PROGRESS — camcge fully hand-derived (5 of 5 consolidation variants); cesam2 (dim-mismatch, B-3) identified + shape stated; full cesam2 derivation finalizes Day 4 per PLAN §6.
+**Date:** 2026-06-03
+**Anchor commit:** `8f755328` (main; post-P1 #1398)
+**Issue:** `docs/issues/ISSUE_1381_pattern-c-phase-b-redesign-plain-alias-and-dim-mismatch.md`
+**Targets:** camcge (#1354) + cesam2 (#1355). `Alias (i,j)` in camcge; variables `dk(i)`, `xd(i)`, `p(i)` 1-D over i.
+
+---
+
+## Phase 0 baseline (current main emit, regenerated `8f755328`)
+
+camcge is **path_syntax_error** (`$141`×2 + `$257`; 4 error markers). The #1398 (Phase A) gate does NOT fire on camcge because its alias-Sums have **no `$`-condition** — `_find_pattern_c_alias_sum` requires `expr.condition is not None`. So camcge falls through to the **standard offset-groups path**, which emits the consolidation as a **phantom-offset enumeration**: ~20 guarded terms per multiplier (40 for prodinv).
+
+Example — current `stat_dk(i)` (the nu_ieq cross-term, **wrong/over-enumerated form**):
+
+```
+stat_dk(i).. pk(i)*nu_prodinv(i)
+   + ((-1)*imat(i,i))*nu_ieq(i)
+   + (((-1)*imat(i-1,i))*nu_ieq(i-1))$(ord(i) > 1)
+   + (((-1)*imat(i+6,i))*nu_ieq(i+6))$(ord(i) <= card(i) - 6)
+   + … [20 phantom-offset nu_ieq(i±N) terms, N = −10..+10] … =E= 0;
+```
+
+Per-multiplier phantom-offset counts (Phase B consolidation targets): nu_ieq 20, nu_inteq 20, nu_actp 20, nu_pkdef 20, **nu_prodinv 40** (B-2 case).
+
+---
+
+## The consolidation rule (hand-derived; the Phase 0 invariant)
+
+For a source alias-Sum `eq(i).. … sum(j, COEFF · var(j)) …` where `j` is `Alias(i,j)` (canonical `i`), the stationarity cross-term in `stat_var(i)` consolidates to:
+
+> **`sum(j, ±COEFF' · nu_eq(j))`**, where `COEFF'` is the source `COEFF` with its **argument positions preserved**, but the **sum-index slot rewritten to the stat/var-domain index `i`** and the **eq-domain-index slot rewritten to the alias `j`**; the multiplier `nu_eq(j)` is **alias-indexed**.
+
+This is *not* the Phase A `alias↔eq_dom` swap — Phase A erases the coefficient's positional info via element-to-set (`imat(i,j)→imat(i,i)`) BEFORE the swap, then swaps to `imat(j,j)` (both coords wrong + `j` unbound). Phase B must build `COEFF'` **directly from the source body** (positions intact). [ISSUE_1381 §Root Cause]
+
+---
+
+## camcge — 5 consolidation variants (KU 2.1 Phase 0)
+
+### B-1 (simple plain-alias) — 4 variants
+
+**1. `ieq(i)..  id(i) =e= sum(j, imat(i,j)*dk(j));`  → stat_dk(i)** (the **nu_ieq** cross-term, primary Day 3 deliverable)
+
+∂L/∂dk(i) from ieq: each ieq-instance `j'` contributes `nu_ieq(j')·∂ieq(j')/∂dk(i)`; in `sum(j, imat(j',j)*dk(j))` the dk(i) term is `j=i`, coeff `−imat(j',i)`. Sum over `j'`, rename `j'→j` (alias):
+
+```
+stat_dk(i):  sum(j, (-imat(j,i)) * nu_ieq(j))
+```
+Source `imat(i,j)` [eq-slot `i` first, sum-slot `j` second] → `imat(j,i)` [eq-slot→`j`, sum-slot→`i`]. ✅ matches ISSUE_1381 table.
+
+**2. `inteq(j)..  int(j) =e= sum(i, io(j,i)*xd(i));`  → stat_xd(i)** (nu_inteq)
+
+(inteq's own domain index is written `j` in source = canonical `i`; sum index `i`, var `xd(i)`.) ∂inteq(j')/∂xd(i) = `−io(j',i)`:
+
+```
+stat_xd(i):  sum(j, (-io(j,i)) * nu_inteq(j))
+```
+
+**3. `actp(i)..  px(i)*(1-itax(i)) =e= pva(i) + sum(j, io(j,i)*p(j));`  → stat_p(i)** (nu_actp)
+
+Source coeff `io(j,i)` [sum-slot `j` first, eq-slot `i` second]. ∂actp(i')/∂p(i) = `−io(i,i')` → rename i'→j:
+
+```
+stat_p(i):  sum(j, (-io(i,j)) * nu_actp(j))
+```
+Note the **opposite arg orientation** to ieq — because here the sum-index is `io`'s *first* arg (→`i`) and the eq-index is the *second* (→`j`): `io(i,j)`. The rule still holds positionally.
+
+**4. `pkdef(i)..  pk(i) =e= sum(j, p(j)*imat(j,i));`  → stat_p(i)** (nu_pkdef)
+
+Source coeff `imat(j,i)` [sum-slot `j` first, eq-slot `i` second]. ∂pkdef(i')/∂p(i) = `−imat(i,i')` → rename:
+
+```
+stat_p(i):  sum(j, (-imat(i,j)) * nu_pkdef(j))
+```
+
+### B-2 (eq-domain factor OUTSIDE the inner Sum) — 1 variant
+
+**5. `prodinv(i)..  pk(i)*dk(i) =e= kio(i)*savings - kio(i)*sum(j, dst(j)*p(j));`  → stat_p(i)** (nu_prodinv)
+
+The inner sum `sum(j, dst(j)*p(j))` is multiplied by `kio(i)` **outside** the sum. ∂prodinv(i')/∂p(i): residual has `+kio(i')·sum(j, dst(j)*p(j))`, so ∂/∂p(i) = `kio(i')·dst(i)`. `dst(i)` is constant in `i'` → factor it out of the multiplier sum; rename i'→j:
+
+```
+stat_p(i):  dst(i) * sum(j, kio(j) * nu_prodinv(j))
+```
+- `dst(i)` — **var-side factor** (depends on the stat index `i`): stays OUTSIDE the new Sum.
+- `kio(i')→kio(j)` — **eq-side factor** (depends on the eq-domain index): moves INSIDE, reindexed to the alias.
+- `nu_prodinv(j)` — alias-indexed. ✅ matches ISSUE_1381 §Phase B-2.
+
+→ The Phase B builder must factor the equation body as `<var-side> · <eq-side> · sum(alias, …)` BEFORE consolidating (ISSUE_1381 §B-2 `_classify_eq_body_factors`).
+
+---
+
+## cesam2 — dim-mismatch second anchor (B-3) — Day 4 finalize
+
+`COLSUM(jj)..  sum(ii, TSAM(ii,jj)) =e= Y(jj);` — eq-domain 1-D `(jj,)` (canonical `i`); variable `TSAM` is **2-D** `(i,i)`. The alias-Sum iterator `ii` binds TSAM's **position 0**; the eq-domain `jj` binds TSAM's **position 1**. Correct consolidated form (NO outer Sum — the alias is already controlled by the stat-eq's own variable-domain index):
+
+```
+stat_tsam(i,j):  … + nu_COLSUM(j)$(jj(j)) + …
+```
+- multiplier `nu_COLSUM(j)` indexed by `var_dom[binding_position=1] = j`;
+- subset guard `$(jj(j))` since `jj ⊆ i`;
+- suppress the spurious `sameas`-block guards element-to-set emits under dim-mismatch (emit-formatting artifact). [ISSUE_1381 §B-3]
+
+**Day 4:** read cesam2 source (`TSAM`/`COLSUM`/`jj` decls), confirm the binding-position inference + the `jj ⊆ i` subset, finalize the stat_tsam hand-derivation; then implement Phase B-1/B-2/B-3 per ISSUE_1381 §Files Involved.
+
+---
+
+## Phase 0 verification specs (for the Day 4 PR — per-term greps on regenerated camcge_mcp.gms)
+
+```bash
+# B-1 consolidated single-Sum forms present (and phantom-offset enumeration gone):
+grep -c 'sum(j, ((-1) * imat(j,i)) * nu_ieq(j))'   camcge_mcp.gms   # ieq  → expect 1
+grep -c 'sum(j, ((-1) * io(j,i)) * nu_inteq(j))'   camcge_mcp.gms   # inteq→ expect 1
+grep -c 'sum(j, ((-1) * io(i,j)) * nu_actp(j))'    camcge_mcp.gms   # actp → expect 1
+grep -c 'sum(j, ((-1) * imat(i,j)) * nu_pkdef(j))' camcge_mcp.gms   # pkdef→ expect 1
+# B-2:
+grep -c 'dst(i) * sum(j, kio(j) * nu_prodinv(j))'  camcge_mcp.gms   # prodinv → expect 1
+# Regression — no phantom-offset enumeration + no Phase-A mis-swap:
+grep -oE 'nu_(ieq|inteq|actp|pkdef|prodinv)\(i[+-][0-9]+\)' camcge_mcp.gms | wc -l   # expect 0
+grep -c 'imat(j,j)' camcge_mcp.gms                                   # expect 0 (Phase-A mis-swap)
+# GAMS compile clean (camcge leaves path_syntax_error → +1 Solve / +1 Match):
+gams camcge_mcp.gms action=c lo=2  # expect 0 error markers
+```

--- a/docs/planning/EPIC_4/SPRINT_27/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/KNOWN_UNKNOWNS.md
@@ -420,7 +420,13 @@ Sprint planning + AD/KKT engineer
 
 ### Verification Results
 
-🔍 **Status:** INCOMPLETE
+🟡 **Status:** PARTIALLY VERIFIED (Sprint 27 Day 3 hand-derivation; binding verdict + implementation Day 4) — see `DAY3_P2_PHASE0_NOTES.md`.
+
+**Day 3 finding:** the "build consolidated term from the source Sum body" philosophy generalizes, but camcge and cesam2 need **related-but-distinct builders** (not a single code path):
+- **camcge (B-1/B-2):** all 5 variants hand-derived. Consolidation rule = `sum(j, COEFF'·nu_eq(j))` where `COEFF'` keeps the source coefficient's argument *positions* but rewrites the sum-index slot → stat index `i` and the eq-index slot → alias `j` (e.g. ieq `imat(i,j)→imat(j,i)`; actp `io(j,i)→io(i,j)`). prodinv (B-2) additionally factors a var-side `dst(i)` outside + an eq-side `kio(i)→kio(j)` inside the new Sum. The Phase A swap fails here because element-to-set collapses `imat(i,j)→imat(i,i)` (positions erased) → so Phase B must intercept BEFORE element-to-set.
+- **cesam2 (B-3):** dim-mismatch (1-D eq `COLSUM(jj)` vs 2-D var `TSAM(i,i)`) needs a **separate** builder — multiplier indexed by the var-domain position the eq-domain binds to, **no outer Sum**, + a `$(jj(j))` subset guard. Distinct detection (`len(var_domain) != len(eq_domain)`).
+
+**Binding answer (provisional):** YES, generalizes — under one source-body-driven design with **three sub-builders** (`_build_pattern_c_consolidated_term` B-1, `_classify_eq_body_factors` B-2, `_build_pattern_c_dim_mismatch_term` B-3) per ISSUE_1381 §Files Involved. Budget split across B-1/B-2/B-3 is sound. **Day 4: finalize cesam2 derivation + implement + byte-verify → moves to ✅ VERIFIED.**
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -176,25 +176,41 @@ _(no emit-affecting changes in range)_
 
 ## Day 3 — Priority 1 merge + Priority 2 Phase 0 start
 
-**Date:** TBD
-**Status:** 🔵 NOT STARTED
+**Date:** 2026-06-03
+**Status:** 🟢 COMPLETE
 **Hours budgeted:** ≤ 8
-**Hours actual:** —
+**Hours actual:** ~4 (agent-executed)
 
 ### Tasks completed
-- _(to be filled in during execution)_
+- **Task 3 — PR19 CI verified:** PR #1414's `pr19-emit-solve-validation` run **passed (37s, ≈ §7 projection)** on the merged P1 emit (sha `0bd1d8d2`/`102b2b3f` → success) — the widened 30-model target list fires correctly with the recovered emit (launch soft-fails as pattern-c; Tier 0/1 hard-fail all pass).
+- **Task 4 — Priority 2 (#1381) Phase 0 started:** hand-derived all **5 camcge** Pattern C consolidation variants from source → `DAY3_P2_PHASE0_NOTES.md`, and identified/stated **cesam2** as the dim-mismatch (B-3) second anchor (full cesam2 derivation finalizes Day 4). Derived the **consolidation rule** (source coeff positions preserved; sum-index slot → stat index `i`, eq-index slot → alias `j`; multiplier alias-indexed) — the invariant Phase B's source-body-driven builder must honor.
+- **Tasks 5–6** — KNOWN_UNKNOWNS KU 2.1 → 🟡 PARTIALLY VERIFIED (design-ready; binding Day 4); this Day 3 entry.
 
 ### Deliverables
-- _(to be filled in during execution)_
+- `DAY3_P2_PHASE0_NOTES.md` — camcge stat_dk/stat_xd/stat_p (×3) hand-derived KKTs + cesam2 B-3 shape + Day-4 per-term grep verification specs.
+- KU 2.1 updated (generalizes under one source-body design with 3 sub-builders B-1/B-2/B-3).
+
+### Phase 0 baseline (camcge, current main `8f755328`)
+path_syntax_error (`$141`×2 + `$257`). The #1398 (Phase A) gate does NOT fire (camcge alias-Sums have no `$`-condition) → phantom-offset enumeration (~20 guarded terms/multiplier; 40 for prodinv). Phase B consolidates each into a single alias-Sum.
+
+| eq | stat | correct consolidated form | sub-phase |
+|---|---|---|---|
+| ieq | stat_dk | `sum(j, (-imat(j,i)) * nu_ieq(j))` | B-1 |
+| inteq | stat_xd | `sum(j, (-io(j,i)) * nu_inteq(j))` | B-1 |
+| actp | stat_p | `sum(j, (-io(i,j)) * nu_actp(j))` | B-1 |
+| pkdef | stat_p | `sum(j, (-imat(i,j)) * nu_pkdef(j))` | B-1 |
+| prodinv | stat_p | `dst(i) * sum(j, kio(j) * nu_prodinv(j))` | B-2 |
+| cesam2 COLSUM | stat_tsam | `nu_COLSUM(j)$(jj(j))` (no outer Sum) | B-3 |
 
 ### KUs verified
-- _(target: KU 1.3 ✅ VERIFIED on merge)_
+- KU 1.3 ✅ VERIFIED (Day 1, merged in PR #1414). KU 2.1 → 🟡 PARTIALLY VERIFIED (Day 3 hand-derivation; binding Day 4). KU 1.1/1.2/1.4 verified at prep.
 
 ### Carryforward to Day 4
-- _(to be filled in during execution)_
+- Finalize cesam2 (B-3) hand-derivation (read `TSAM`/`COLSUM`/`jj` decls; confirm binding-position inference + `jj ⊆ i` subset).
+- Implement Phase B-1/B-2/B-3 per ISSUE_1381 §Files Involved (`_build_pattern_c_consolidated_term`, `_classify_eq_body_factors`, `_build_pattern_c_dim_mismatch_term`); regenerate camcge + cesam2; byte-verify against the §"Phase 0 verification specs"; expect 11 plain-alias canaries (quocge/prolog/paklive/…) to byte-shift (consolidation) — regenerate goldens per PR14.
 
 ### PR merged
-- _(P1 #1398 PR — merge SHA + bucket-recovery summary)_
+- **PR #1414** (P1 #1398) merged to main `853000ef`. Bucket recovery: qdemo7 → compare_match (+1 Solve/Match); egypt/ferts/shale/srpchase → path_solve_license; no regressions.
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -182,7 +182,7 @@ _(no emit-affecting changes in range)_
 **Hours actual:** ~4 (agent-executed)
 
 ### Tasks completed
-- **Task 3 — PR19 CI verified:** PR #1414's `pr19-emit-solve-validation` run **passed (37s, ≈ §7 projection)** on the merged P1 emit (sha `0bd1d8d2`/`102b2b3f` → success) — the widened 30-model target list fires correctly with the recovered emit (launch soft-fails as pattern-c; Tier 0/1 hard-fail all pass).
+- **Task 3 — PR19 CI verified:** PR #1414's `pr19-emit-solve-validation` run on the final PR head sha `0bd1d8d2` (run id 26911925363) **passed (37s, ≈ §7 projection)** — the widened 30-model target list fires correctly with the recovered emit (launch soft-fails as pattern-c; Tier 0/1 hard-fail all pass). (PR19 re-ran on each push to PR #1414 because the PR's cumulative diff includes `src/kkt/stationarity.py`; the head-sha run above is the authoritative one.)
 - **Task 4 — Priority 2 (#1381) Phase 0 started:** hand-derived all **5 camcge** Pattern C consolidation variants from source → `DAY3_P2_PHASE0_NOTES.md`, and identified/stated **cesam2** as the dim-mismatch (B-3) second anchor (full cesam2 derivation finalizes Day 4). Derived the **consolidation rule** (source coeff positions preserved; sum-index slot → stat index `i`, eq-index slot → alias `j`; multiplier alias-indexed) — the invariant Phase B's source-body-driven builder must honor.
 - **Tasks 5–6** — KNOWN_UNKNOWNS KU 2.1 → 🟡 PARTIALLY VERIFIED (design-ready; binding Day 4); this Day 3 entry.
 

--- a/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
@@ -136,10 +136,10 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 1. ✅ DONE. PR review iteration on Priority 1 PR #1414 (one round: ferts §4.2 header consistency).
 2. ✅ DONE. Priority 1 PR #1414 merged to main (`853000ef`).
-3. Verify PR19 widening CI fires correctly: trigger a no-op PR on the new widened target list; expect ~36s steady-state runtime per `PR19_WIDENING_DESIGN.md` §7 projection.
-4. **Start Priority 2 Phase 0** — hand-derive KKT for camcge `nu_ieq` cross-term. Recorded in scratch notes. Identify cesam2 as second-anchor model (same Phase C-derived shape per `PROJECT_PLAN.md` Priority 2).
-5. Update KNOWN_UNKNOWNS.md: KU 1.3 ✅ VERIFIED (gate predicate fires only on launch-shape); KU 1.1, 1.2, 1.4 already verified at prep.
-6. SPRINT_LOG.md Day 3 entry. Update sprint cumulative metrics: Solve / Match unchanged but P1 unblocks Day 5 retest.
+3. ✅ DONE. Verify PR19 widening CI fires correctly. Verified via **PR #1414's** `pr19-emit-solve-validation` run (it touches the trigger paths) — **passed at 37s** (~`PR19_WIDENING_DESIGN.md` §7 projection); launch soft-fails as pattern-c, Tier 0/1 hard-fail all pass. A dedicated no-op PR was unnecessary. (If verifying a future emit-only change that does NOT touch the trigger paths, trigger a no-op PR on the target list instead.)
+4. ✅ DONE. **Priority 2 Phase 0 started** — hand-derived camcge `nu_ieq` (stat_dk) cross-term + all 5 camcge consolidation variants; identified cesam2 (dim-mismatch B-3) as second anchor. Recorded in `DAY3_P2_PHASE0_NOTES.md`.
+5. ✅ DONE. KNOWN_UNKNOWNS.md: KU 1.3 ✅ VERIFIED (Day 1, in PR #1414); KU 2.1 → 🟡 PARTIALLY VERIFIED (Day 3 hand-derivation); KU 1.1/1.2/1.4 verified at prep.
+6. ✅ DONE. SPRINT_LOG.md Day 3 entry recorded. Solve/Match unchanged (P1 unblocks the Day 5 retest).
 
 **Success criteria (Day 3):**
 - [x] Priority 1 PR merged to main (PR #1414, `853000ef`).

--- a/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
@@ -143,8 +143,8 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 **Success criteria (Day 3):**
 - [x] Priority 1 PR merged to main (PR #1414, `853000ef`).
-- [ ] PR19 widening verified on a follow-up no-op PR.
-- [ ] camcge Phase 0 hand-derivation complete.
+- [x] PR19 widening verified — fired on PR #1414 (touches the trigger paths) and **passed (37s)**; a dedicated no-op PR was unnecessary.
+- [x] camcge Phase 0 hand-derivation complete — all 5 consolidation variants in `DAY3_P2_PHASE0_NOTES.md` (cesam2 B-3 identified; finalizes Day 4).
 - [x] KU 1.3 ✅ VERIFIED (Day 1).
 
 ---


### PR DESCRIPTION
## Sprint 27 Day 3 — Priority 2 (#1381) Phase 0 + PR19 CI verify (docs-only)

Priority 1 #1398 was already merged early (PR #1414 → main `853000ef`), so Day 3's live work was task 3 (verify PR19) + task 4 (start Priority 2 Phase 0). No `src` changes — this is Phase 0 hand-derivation.

### Task 3 — PR19 CI verified ✅
PR #1414's `pr19-emit-solve-validation` run **passed (37s, ≈ §7 projection)** on the merged P1 emit (sha `0bd1d8d2`/`102b2b3f` → success). The widened 30-model target list fires correctly with the recovered emit: launch soft-fails as pattern-c (MODEL STATUS 5, expected), Tier 0/1 hard-fail all pass. A dedicated no-op PR was unnecessary since #1414 touched the trigger paths.

### Task 4 — Priority 2 (#1381 Pattern C Phase B) Phase 0 hand-derivations
`DAY3_P2_PHASE0_NOTES.md` — all 5 camcge consolidation variants hand-derived from source + cesam2 (B-3) identified:

| eq | stat | correct consolidated form | sub-phase |
|---|---|---|---|
| ieq | stat_dk | `sum(j, (-imat(j,i)) * nu_ieq(j))` | B-1 |
| inteq | stat_xd | `sum(j, (-io(j,i)) * nu_inteq(j))` | B-1 |
| actp | stat_p | `sum(j, (-io(i,j)) * nu_actp(j))` | B-1 |
| pkdef | stat_p | `sum(j, (-imat(i,j)) * nu_pkdef(j))` | B-1 |
| prodinv | stat_p | `dst(i) * sum(j, kio(j) * nu_prodinv(j))` | B-2 |
| cesam2 COLSUM | stat_tsam | `nu_COLSUM(j)$(jj(j))` (no outer Sum) | B-3 |

**Consolidation rule** (the Phase 0 invariant): in `sum(j, COEFF'·nu_eq(j))`, `COEFF'` keeps the source coefficient's argument *positions* but rewrites the sum-index slot → stat index `i` and the eq-index slot → alias `j`; the multiplier is alias-indexed. The Phase A swap fails here because element-to-set collapses `imat(i,j)→imat(i,i)` before the swap → Phase B must intercept before element-to-set.

**camcge Phase 0 baseline:** path_syntax_error (`$141`×2/`$257`); the #1398 (Phase A) gate doesn't fire because camcge's alias-Sums have no `$`-condition → phantom-offset enumeration (~20 terms/multiplier; 40 for prodinv). Phase B consolidates each into one alias-Sum.

### KUs
KU 2.1 → 🟡 PARTIALLY VERIFIED (generalizes under one source-body-driven design with 3 sub-builders B-1/B-2/B-3; binding Day 4). KU 1.3 ✅ (Day 1, in #1414).

### Day 4 (next)
Finalize cesam2 (B-3) derivation; implement Phase B-1/B-2/B-3; regenerate camcge + cesam2 + the 11 byte-shifting plain-alias canaries (PR14); byte-verify against the §"Phase 0 verification specs".

PR23 N/A; docs-only (no `*.py`, no CI files).
