### PR TITLE
Sprint 27 Day 10 — Checkpoint 2: full pipeline retest (Solve 105 / Match 62)

### DIFF
--- a/data/gamslib/gamslib_status.json
+++ b/data/gamslib/gamslib_status.json
@@ -106,22 +106,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:08:47.550101+00:00",
+        "parse_date": "2026-06-08T02:28:44.963219+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 24.4997,
+        "parse_time_seconds": 29.8551,
         "variables_count": 18,
         "equations_count": 14
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:09:16.380602+00:00",
+        "translate_date": "2026-06-08T02:29:21.169631+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 28.5963,
+        "translate_time_seconds": 36.0059,
         "output_file": "data/gamslib/mcp/agreste_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:09:22.527108+00:00",
+        "solve_date": "2026-06-08T02:29:23.473598+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -129,7 +129,7 @@
         "model_status": 5,
         "model_status_text": "Locally Infeasible",
         "objective_value": 3501.634,
-        "solve_time_seconds": 6.0972,
+        "solve_time_seconds": 2.1443,
         "iterations": 9734,
         "outcome_category": "model_infeasible",
         "error": {
@@ -139,7 +139,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:09:51.070785+00:00",
+        "comparison_date": "2026-06-08T02:30:01.468498+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -173,9 +173,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:09:53.463641+00:00",
+        "parse_date": "2026-06-08T02:30:06.188479+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.3922,
+        "parse_time_seconds": 4.7061,
         "variables_count": 6,
         "equations_count": 8
       },
@@ -187,14 +187,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:09:57.791398+00:00",
+        "translate_date": "2026-06-08T02:30:11.259204+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.3223,
+        "translate_time_seconds": 5.0637,
         "output_file": "data/gamslib/mcp/aircraft_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:09:58.509449+00:00",
+        "solve_date": "2026-06-08T02:30:12.563238+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -202,13 +202,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 5534.815,
-        "solve_time_seconds": 0.6972,
+        "solve_time_seconds": 1.2791,
         "iterations": 504,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T16:09:58.509614+00:00",
+        "comparison_date": "2026-06-08T02:30:12.563396+00:00",
         "nlp_objective": 1566.0422,
         "mcp_objective": 5534.815,
         "absolute_difference": null,
@@ -292,9 +292,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:09:59.676151+00:00",
+        "parse_date": "2026-06-08T02:30:14.044741+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.1661,
+        "parse_time_seconds": 1.4799,
         "variables_count": 2,
         "equations_count": 3
       },
@@ -306,14 +306,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:03.181260+00:00",
+        "translate_date": "2026-06-08T02:30:18.178233+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.499,
+        "translate_time_seconds": 4.1233,
         "output_file": "data/gamslib/mcp/ajax_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:03.919109+00:00",
+        "solve_date": "2026-06-08T02:30:19.199546+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -321,13 +321,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 441003.595,
-        "solve_time_seconds": 0.7171,
+        "solve_time_seconds": 0.9657,
         "iterations": 58,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:10:03.919405+00:00",
+        "comparison_date": "2026-06-08T02:30:19.199731+00:00",
         "nlp_objective": 441003.5953,
         "mcp_objective": 441003.595,
         "absolute_difference": 0.0003000000142492354,
@@ -400,9 +400,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:05.319693+00:00",
+        "parse_date": "2026-06-08T02:30:20.739232+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.3991,
+        "parse_time_seconds": 1.5385,
         "variables_count": 15,
         "equations_count": 8
       },
@@ -414,14 +414,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:08.764558+00:00",
+        "translate_date": "2026-06-08T02:30:25.381766+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.4375,
+        "translate_time_seconds": 4.6339,
         "output_file": "data/gamslib/mcp/alkyl_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:10.680707+00:00",
+        "solve_date": "2026-06-08T02:30:27.465007+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -429,13 +429,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -1.765,
-        "solve_time_seconds": 1.8947,
+        "solve_time_seconds": 2.0316,
         "iterations": 2664,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:10:10.680864+00:00",
+        "comparison_date": "2026-06-08T02:30:27.465165+00:00",
         "nlp_objective": -1.765,
         "mcp_objective": -1.765,
         "absolute_difference": 0.0,
@@ -476,22 +476,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:11.517066+00:00",
+        "parse_date": "2026-06-08T02:30:28.430714+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.8355,
+        "parse_time_seconds": 0.9645,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:15.107119+00:00",
+        "translate_date": "2026-06-08T02:30:31.805785+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.5815,
+        "translate_time_seconds": 3.3622,
         "output_file": "data/gamslib/mcp/ampl_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:16.059280+00:00",
+        "solve_date": "2026-06-08T02:30:32.663507+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -499,13 +499,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 79.341,
-        "solve_time_seconds": 0.9211,
+        "solve_time_seconds": 0.8303,
         "iterations": 25,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:10:16.059618+00:00",
+        "comparison_date": "2026-06-08T02:30:32.663745+00:00",
         "nlp_objective": 79.3413,
         "mcp_objective": 79.341,
         "absolute_difference": 0.00030000000000995897,
@@ -582,9 +582,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:19.207795+00:00",
+        "parse_date": "2026-06-08T02:30:35.400273+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.1476,
+        "parse_time_seconds": 2.7338,
         "variables_count": 4,
         "equations_count": 5
       },
@@ -596,14 +596,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:24.384361+00:00",
+        "translate_date": "2026-06-08T02:30:40.661155+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.1686,
+        "translate_time_seconds": 5.2544,
         "output_file": "data/gamslib/mcp/apl1p_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:25.188690+00:00",
+        "solve_date": "2026-06-08T02:30:41.620782+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -611,13 +611,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 23700.147,
-        "solve_time_seconds": 0.7837,
+        "solve_time_seconds": 0.9325,
         "iterations": 23,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T16:10:25.188847+00:00",
+        "comparison_date": "2026-06-08T02:30:41.621184+00:00",
         "nlp_objective": 24515.6483,
         "mcp_objective": 23700.147,
         "absolute_difference": null,
@@ -659,22 +659,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:27.289594+00:00",
+        "parse_date": "2026-06-08T02:30:44.251635+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.1001,
+        "parse_time_seconds": 2.629,
         "variables_count": 4,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:32.329261+00:00",
+        "translate_date": "2026-06-08T02:30:49.838798+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.0318,
+        "translate_time_seconds": 5.5809,
         "output_file": "data/gamslib/mcp/apl1pca_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:33.203117+00:00",
+        "solve_date": "2026-06-08T02:30:51.001443+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -682,13 +682,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 23700.147,
-        "solve_time_seconds": 0.8482,
+        "solve_time_seconds": 1.1329,
         "iterations": 23,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T16:10:33.203430+00:00",
+        "comparison_date": "2026-06-08T02:30:51.001636+00:00",
         "nlp_objective": 15902.4936,
         "mcp_objective": 23700.147,
         "absolute_difference": null,
@@ -757,9 +757,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:35.428510+00:00",
+        "parse_date": "2026-06-08T02:30:54.047330+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.2244,
+        "parse_time_seconds": 3.0447,
         "variables_count": 14,
         "equations_count": 13
       },
@@ -771,14 +771,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:39.998731+00:00",
+        "translate_date": "2026-06-08T02:30:59.747167+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.5615,
+        "translate_time_seconds": 5.6867,
         "output_file": "data/gamslib/mcp/bearing_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:51.842032+00:00",
+        "solve_date": "2026-06-08T02:31:11.319910+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -786,7 +786,7 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 19517.3319,
-        "solve_time_seconds": 2.7185,
+        "solve_time_seconds": 2.368,
         "iterations": 2554,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -794,7 +794,7 @@
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:10:51.842421+00:00",
+        "comparison_date": "2026-06-08T02:31:11.320640+00:00",
         "nlp_objective": 19517.3319,
         "mcp_objective": 19517.3319,
         "absolute_difference": 0.0,
@@ -835,9 +835,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:10:53.263252+00:00",
+        "parse_date": "2026-06-08T02:31:13.079823+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.4197,
+        "parse_time_seconds": 1.7557,
         "variables_count": 2,
         "equations_count": 3
       },
@@ -849,14 +849,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:10:57.047315+00:00",
+        "translate_date": "2026-06-08T02:31:18.910090+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.7743,
+        "translate_time_seconds": 5.8011,
         "output_file": "data/gamslib/mcp/blend_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:10:57.932550+00:00",
+        "solve_date": "2026-06-08T02:31:22.899573+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -864,13 +864,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 4.98,
-        "solve_time_seconds": 0.8615,
+        "solve_time_seconds": 3.9428,
         "iterations": 5,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:10:57.932728+00:00",
+        "comparison_date": "2026-06-08T02:31:22.899794+00:00",
         "nlp_objective": 4.98,
         "mcp_objective": 4.98,
         "absolute_difference": 0.0,
@@ -911,22 +911,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:11:34.541475+00:00",
+        "parse_date": "2026-06-08T02:32:09.642366+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 36.6039,
+        "parse_time_seconds": 46.7395,
         "variables_count": 38,
         "equations_count": 34
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:12:16.301624+00:00",
+        "translate_date": "2026-06-08T02:33:02.819576+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 41.7468,
+        "translate_time_seconds": 53.1563,
         "output_file": "data/gamslib/mcp/camcge_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:12:17.366784+00:00",
+        "solve_date": "2026-06-08T02:33:04.408488+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -934,7 +934,7 @@
         "model_status": 4,
         "model_status_text": "Infeasible",
         "objective_value": 0.0,
-        "solve_time_seconds": 1.0071,
+        "solve_time_seconds": 1.4911,
         "iterations": 0,
         "outcome_category": "model_infeasible",
         "error": {
@@ -944,7 +944,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:12:17.366970+00:00",
+        "comparison_date": "2026-06-08T02:33:04.411323+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -978,22 +978,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:12:18.868985+00:00",
+        "parse_date": "2026-06-08T02:33:06.557476+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.4182,
+        "parse_time_seconds": 1.9892,
         "variables_count": 3,
         "equations_count": 6
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:12:51.742321+00:00",
+        "translate_date": "2026-06-08T02:33:47.609559+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 32.8642,
+        "translate_time_seconds": 41.0321,
         "output_file": "data/gamslib/mcp/camshape_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:12:56.410091+00:00",
+        "solve_date": "2026-06-08T02:33:53.169446+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1001,7 +1001,7 @@
         "model_status": 5,
         "model_status_text": "Locally Infeasible",
         "objective_value": 6.2,
-        "solve_time_seconds": 4.511,
+        "solve_time_seconds": 5.4698,
         "iterations": 48314,
         "outcome_category": "model_infeasible",
         "error": {
@@ -1011,7 +1011,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:13:52.438403+00:00",
+        "comparison_date": "2026-06-08T02:34:48.998048+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -1045,22 +1045,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:13:54.446782+00:00",
+        "parse_date": "2026-06-08T02:34:51.176377+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.0031,
+        "parse_time_seconds": 2.1676,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:15:06.666513+00:00",
+        "translate_date": "2026-06-08T02:36:14.566652+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 72.1829,
+        "translate_time_seconds": 83.3075,
         "output_file": "data/gamslib/mcp/catmix_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:15:07.641304+00:00",
+        "solve_date": "2026-06-08T02:36:16.693992+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1068,13 +1068,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -0.048,
-        "solve_time_seconds": 0.9474,
+        "solve_time_seconds": 1.9716,
         "iterations": 1548,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:15:07.641657+00:00",
+        "comparison_date": "2026-06-08T02:36:16.699665+00:00",
         "nlp_objective": -0.0481,
         "mcp_objective": -0.048,
         "absolute_difference": 9.999999999999593e-05,
@@ -1121,9 +1121,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:15:08.340249+00:00",
+        "parse_date": "2026-06-08T02:36:25.012596+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.6978,
+        "parse_time_seconds": 8.3006,
         "variables_count": 3,
         "equations_count": 2
       },
@@ -1135,14 +1135,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:15:12.297615+00:00",
+        "translate_date": "2026-06-08T02:36:29.723551+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.9481,
+        "translate_time_seconds": 4.6932,
         "output_file": "data/gamslib/mcp/cclinpts_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:15:13.150009+00:00",
+        "solve_date": "2026-06-08T02:36:30.782247+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1150,13 +1150,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.0,
-        "solve_time_seconds": 0.8103,
+        "solve_time_seconds": 0.9875,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:15:13.150231+00:00",
+        "comparison_date": "2026-06-08T02:36:30.782504+00:00",
         "nlp_objective": -3.0011,
         "mcp_objective": 0.0,
         "absolute_difference": 3.0011,
@@ -1197,22 +1197,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:15:30.937063+00:00",
+        "parse_date": "2026-06-08T02:36:49.360464+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 17.7851,
+        "parse_time_seconds": 18.5757,
         "variables_count": 21,
         "equations_count": 21
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:15:53.786823+00:00",
+        "translate_date": "2026-06-08T02:37:16.472371+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 22.8404,
+        "translate_time_seconds": 27.1009,
         "output_file": "data/gamslib/mcp/cesam_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:15:54.706803+00:00",
+        "solve_date": "2026-06-08T02:37:17.931515+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1220,7 +1220,7 @@
         "model_status": 4,
         "model_status_text": "Infeasible",
         "objective_value": 0.0,
-        "solve_time_seconds": 0.8859,
+        "solve_time_seconds": 1.3957,
         "iterations": 0,
         "outcome_category": "model_infeasible",
         "error": {
@@ -1230,7 +1230,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:15:54.706958+00:00",
+        "comparison_date": "2026-06-08T02:37:17.931760+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -1264,22 +1264,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:16:09.091255+00:00",
+        "parse_date": "2026-06-08T02:37:35.384062+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 14.3833,
+        "parse_time_seconds": 17.448,
         "variables_count": 11,
         "equations_count": 16
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:16:56.310484+00:00",
+        "translate_date": "2026-06-08T02:38:51.128797+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 47.2118,
+        "translate_time_seconds": 75.7118,
         "output_file": "data/gamslib/mcp/cesam2_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:16:58.481211+00:00",
+        "solve_date": "2026-06-08T02:39:00.327038+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1287,13 +1287,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.508,
-        "solve_time_seconds": 2.1403,
+        "solve_time_seconds": 8.8353,
         "iterations": 2508,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:16:58.481614+00:00",
+        "comparison_date": "2026-06-08T02:39:00.335700+00:00",
         "nlp_objective": 0.508,
         "mcp_objective": 0.508,
         "absolute_difference": 0.0,
@@ -1340,22 +1340,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:16:59.469713+00:00",
+        "parse_date": "2026-06-08T02:39:02.358604+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.9872,
+        "parse_time_seconds": 2.0034,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:17:04.603597+00:00",
+        "translate_date": "2026-06-08T02:39:08.925755+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.1258,
+        "translate_time_seconds": 6.5406,
         "output_file": "data/gamslib/mcp/chain_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:17:14.599197+00:00",
+        "solve_date": "2026-06-08T02:39:25.782966+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1363,7 +1363,7 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 5.1199,
-        "solve_time_seconds": 1.1212,
+        "solve_time_seconds": 2.2993,
         "iterations": 4,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -1371,7 +1371,7 @@
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:17:14.599715+00:00",
+        "comparison_date": "2026-06-08T02:39:25.783274+00:00",
         "nlp_objective": 5.0723,
         "mcp_objective": 5.1199,
         "absolute_difference": 0.04760000000000009,
@@ -1418,22 +1418,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:17:15.880201+00:00",
+        "parse_date": "2026-06-08T02:39:28.932422+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.2797,
+        "parse_time_seconds": 3.1473,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:17:19.484048+00:00",
+        "translate_date": "2026-06-08T02:39:35.711050+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.598,
+        "translate_time_seconds": 6.7424,
         "output_file": "data/gamslib/mcp/chakra_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:17:20.194118+00:00",
+        "solve_date": "2026-06-08T02:39:36.902509+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1441,13 +1441,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 177.867,
-        "solve_time_seconds": 0.6895,
+        "solve_time_seconds": 1.1641,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:17:20.194263+00:00",
+        "comparison_date": "2026-06-08T02:39:36.902838+00:00",
         "nlp_objective": 179.1336,
         "mcp_objective": 177.867,
         "absolute_difference": 1.266600000000011,
@@ -1518,9 +1518,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:17:21.428439+00:00",
+        "parse_date": "2026-06-08T02:39:38.056889+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.2333,
+        "parse_time_seconds": 1.1525,
         "variables_count": 3,
         "equations_count": 3
       },
@@ -1532,14 +1532,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:17:24.039713+00:00",
+        "translate_date": "2026-06-08T02:39:41.841361+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 2.6043,
+        "translate_time_seconds": 3.7737,
         "output_file": "data/gamslib/mcp/chem_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:17:24.830490+00:00",
+        "solve_date": "2026-06-08T02:39:42.922261+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1547,13 +1547,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -47.707,
-        "solve_time_seconds": 0.7743,
+        "solve_time_seconds": 1.0341,
         "iterations": 16,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:17:24.830656+00:00",
+        "comparison_date": "2026-06-08T02:39:42.922466+00:00",
         "nlp_objective": -47.7065,
         "mcp_objective": -47.707,
         "absolute_difference": 0.0005000000000023874,
@@ -1594,9 +1594,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:17:28.349081+00:00",
+        "parse_date": "2026-06-08T02:39:48.717118+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.5178,
+        "parse_time_seconds": 5.7925,
         "variables_count": 15,
         "equations_count": 14
       },
@@ -1608,14 +1608,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:17:34.715768+00:00",
+        "translate_date": "2026-06-08T02:39:55.025780+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.3604,
+        "translate_time_seconds": 6.3013,
         "output_file": "data/gamslib/mcp/chenery_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:17:36.616239+00:00",
+        "solve_date": "2026-06-08T02:39:57.715878+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1623,13 +1623,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1005.185,
-        "solve_time_seconds": 1.8728,
+        "solve_time_seconds": 2.6634,
         "iterations": 5154,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:17:36.616463+00:00",
+        "comparison_date": "2026-06-08T02:39:57.716030+00:00",
         "nlp_objective": 1058.9199,
         "mcp_objective": 1005.185,
         "absolute_difference": 53.73490000000015,
@@ -1670,22 +1670,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:17:51.324817+00:00",
+        "parse_date": "2026-06-08T02:40:14.291994+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 14.7067,
+        "parse_time_seconds": 16.5726,
         "variables_count": 10,
         "equations_count": 10
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:18:11.710768+00:00",
+        "translate_date": "2026-06-08T02:40:47.955957+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 20.38,
+        "translate_time_seconds": 33.6447,
         "output_file": "data/gamslib/mcp/china_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:18:12.479938+00:00",
+        "solve_date": "2026-06-08T02:40:49.831259+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1693,13 +1693,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 24782.883,
-        "solve_time_seconds": 0.7407,
+        "solve_time_seconds": 1.8071,
         "iterations": 252,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:18:12.480074+00:00",
+        "comparison_date": "2026-06-08T02:40:49.832774+00:00",
         "nlp_objective": 40561.5739,
         "mcp_objective": 24782.883,
         "absolute_difference": 15778.690900000001,
@@ -1746,9 +1746,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:18:13.067059+00:00",
+        "parse_date": "2026-06-08T02:40:51.547035+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.5348,
+        "parse_time_seconds": 1.4795,
         "variables_count": 3,
         "equations_count": 1
       },
@@ -1760,14 +1760,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:18:15.319320+00:00",
+        "translate_date": "2026-06-08T02:40:56.561541+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 2.2443,
+        "translate_time_seconds": 4.9928,
         "output_file": "data/gamslib/mcp/circle_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:18:16.028927+00:00",
+        "solve_date": "2026-06-08T02:40:58.099588+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1775,13 +1775,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 4.071,
-        "solve_time_seconds": 0.6872,
+        "solve_time_seconds": 1.3672,
         "iterations": 6,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:18:16.029086+00:00",
+        "comparison_date": "2026-06-08T02:40:58.099810+00:00",
         "nlp_objective": 4.5742,
         "mcp_objective": 4.071,
         "absolute_difference": 0.5032000000000005,
@@ -1853,22 +1853,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:18:18.536038+00:00",
+        "parse_date": "2026-06-08T02:41:04.903655+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.5063,
+        "parse_time_seconds": 6.8013,
         "variables_count": 5,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:23:50.989389+00:00",
+        "translate_date": "2026-06-08T02:50:11.569143+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 332.4364,
+        "translate_time_seconds": 546.6035,
         "output_file": "data/gamslib/mcp/clearlak_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:23:51.482545+00:00",
+        "solve_date": "2026-06-08T02:50:13.448623+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -1876,7 +1876,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4399,
+        "solve_time_seconds": 1.2451,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -1886,7 +1886,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:23:51.482910+00:00",
+        "comparison_date": "2026-06-08T02:50:13.456578+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -1920,9 +1920,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:23:51.943659+00:00",
+        "parse_date": "2026-06-08T02:50:16.690521+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.4582,
+        "parse_time_seconds": 3.188,
         "variables_count": 3,
         "equations_count": 2
       },
@@ -1934,14 +1934,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:23:54.437216+00:00",
+        "translate_date": "2026-06-08T02:50:21.643619+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 2.4858,
+        "translate_time_seconds": 4.9311,
         "output_file": "data/gamslib/mcp/cpack_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:23:55.554180+00:00",
+        "solve_date": "2026-06-08T02:50:24.995620+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -1949,13 +1949,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.203,
-        "solve_time_seconds": 1.1008,
+        "solve_time_seconds": 3.2934,
         "iterations": 2014,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:23:55.554370+00:00",
+        "comparison_date": "2026-06-08T02:50:24.995803+00:00",
         "nlp_objective": 0.3702,
         "mcp_objective": 0.203,
         "absolute_difference": 0.16719999999999996,
@@ -2008,17 +2008,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:23:59.026754+00:00",
+        "parse_date": "2026-06-08T02:50:31.023741+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.4714,
+        "parse_time_seconds": 6.0249,
         "variables_count": 5,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T16:24:03.404995+00:00",
+        "translate_date": "2026-06-08T02:50:39.828587+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.3721,
+        "translate_time_seconds": 8.7899,
         "error": {
           "category": "internal_error",
           "message": "Error: Model is a multi-solve driver script and is out of scope for nlp2mcp (NLP\u2192MCP via KKT). Declared models: ['master', 'mcf', 'pricing']; distinct solve targets: ['master', 'mcf', 'pricing']; equation-marginal feedback to a subsequent solve: mdefbal.m.\n\nSuggestion: nlp2mcp transforms a single NLP's KKT conditions into an MCP. Driver scripts (Dantzig\u2013Wolfe, column generation, Benders', primal-dual alternation) combine multiple solves with dual feedback; their converged objective cannot be rec"
@@ -2026,11 +2026,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T16:24:03.409895+00:00"
+        "solve_date": "2026-06-08T02:50:39.850994+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:24:03.409895+00:00",
+        "comparison_date": "2026-06-08T02:50:39.850994+00:00",
         "notes": "Skipped due to translate failure"
       }
     },
@@ -2070,17 +2070,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:24:04.757687+00:00",
+        "parse_date": "2026-06-08T02:50:42.443303+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.3474,
+        "parse_time_seconds": 2.5899,
         "variables_count": 6,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T16:24:07.463902+00:00",
+        "translate_date": "2026-06-08T02:50:47.409139+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 2.7023,
+        "translate_time_seconds": 4.9585,
         "error": {
           "category": "internal_error",
           "message": "Error: Model is a multi-solve driver script and is out of scope for nlp2mcp (NLP\u2192MCP via KKT). Declared models: ['master', 'sub']; distinct solve targets: ['master', 'sub']; equation-marginal feedback to a subsequent solve: tbal.m, convex.m.\n\nSuggestion: nlp2mcp transforms a single NLP's KKT conditions into an MCP. Driver scripts (Dantzig\u2013Wolfe, column generation, Benders', primal-dual alternation) combine multiple solves with dual feedback; their converged objective cannot be recovered from any"
@@ -2088,11 +2088,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T16:24:07.469205+00:00"
+        "solve_date": "2026-06-08T02:50:47.418153+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:24:07.469205+00:00",
+        "comparison_date": "2026-06-08T02:50:47.418153+00:00",
         "notes": "Skipped due to translate failure"
       }
     },
@@ -2120,22 +2120,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:24:10.297126+00:00",
+        "parse_date": "2026-06-08T02:50:57.537554+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.8274,
+        "parse_time_seconds": 10.1166,
         "variables_count": 9,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:24:14.913638+00:00",
+        "translate_date": "2026-06-08T02:51:06.637634+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.6108,
+        "translate_time_seconds": 9.0928,
         "output_file": "data/gamslib/mcp/demo1_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:24:15.467035+00:00",
+        "solve_date": "2026-06-08T02:51:07.838974+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -2143,13 +2143,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1898.52,
-        "solve_time_seconds": 0.535,
+        "solve_time_seconds": 1.1601,
         "iterations": 157,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:24:15.467380+00:00",
+        "comparison_date": "2026-06-08T02:51:07.839151+00:00",
         "nlp_objective": 1898.52,
         "mcp_objective": 1898.52,
         "absolute_difference": 0.0,
@@ -2220,22 +2220,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:26:05.203298+00:00",
+        "parse_date": "2026-06-08T02:54:59.660754+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 109.7319,
+        "parse_time_seconds": 231.799,
         "variables_count": 22,
         "equations_count": 19
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:28:44.090858+00:00",
+        "translate_date": "2026-06-08T03:01:09.384764+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 158.8749,
+        "translate_time_seconds": 369.6316,
         "output_file": "data/gamslib/mcp/dinam_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:28:44.559674+00:00",
+        "solve_date": "2026-06-08T03:01:10.910459+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2243,7 +2243,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.4531,
+        "solve_time_seconds": 1.2926,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -2253,7 +2253,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:28:44.559798+00:00",
+        "comparison_date": "2026-06-08T03:01:10.914633+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -2287,9 +2287,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:28:45.478024+00:00",
+        "parse_date": "2026-06-08T03:01:14.909153+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.9159,
+        "parse_time_seconds": 3.9773,
         "variables_count": 3,
         "equations_count": 3
       },
@@ -2301,14 +2301,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:28:48.104881+00:00",
+        "translate_date": "2026-06-08T03:01:19.631531+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 2.62,
+        "translate_time_seconds": 4.7044,
         "output_file": "data/gamslib/mcp/dispatch_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:28:48.959543+00:00",
+        "solve_date": "2026-06-08T03:01:21.226097+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -2316,13 +2316,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 7.955,
-        "solve_time_seconds": 0.8363,
+        "solve_time_seconds": 1.5244,
         "iterations": 143,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:28:48.959780+00:00",
+        "comparison_date": "2026-06-08T03:01:21.231654+00:00",
         "nlp_objective": 7.9546,
         "mcp_objective": 7.955,
         "absolute_difference": 0.00039999999999995595,
@@ -2384,22 +2384,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:29:02.248031+00:00",
+        "parse_date": "2026-06-08T03:01:54.424915+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 13.2864,
+        "parse_time_seconds": 33.1849,
         "variables_count": 31,
         "equations_count": 29
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:29:15.308739+00:00",
+        "translate_date": "2026-06-08T03:02:25.100049+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 13.0555,
+        "translate_time_seconds": 30.6413,
         "output_file": "data/gamslib/mcp/dyncge_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:29:15.652641+00:00",
+        "solve_date": "2026-06-08T03:02:26.510838+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2407,7 +2407,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.3231,
+        "solve_time_seconds": 1.3172,
         "iterations": null,
         "outcome_category": "path_solve_terminated",
         "error": {
@@ -2417,7 +2417,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:29:15.652755+00:00",
+        "comparison_date": "2026-06-08T03:02:26.513012+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -2451,22 +2451,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:29:54.211376+00:00",
+        "parse_date": "2026-06-08T03:04:23.325127+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 38.557,
+        "parse_time_seconds": 116.7945,
         "variables_count": 11,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:31:45.822922+00:00",
+        "translate_date": "2026-06-08T03:08:28.521932+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 111.6018,
+        "translate_time_seconds": 245.137,
         "output_file": "data/gamslib/mcp/egypt_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:31:46.354154+00:00",
+        "solve_date": "2026-06-08T03:08:29.866791+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2474,7 +2474,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.5096,
+        "solve_time_seconds": 1.0901,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -2484,7 +2484,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:31:46.354872+00:00",
+        "comparison_date": "2026-06-08T03:08:29.867113+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -2518,22 +2518,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:31:46.914525+00:00",
+        "parse_date": "2026-06-08T03:08:33.458922+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.5024,
+        "parse_time_seconds": 3.2343,
         "variables_count": 4,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:31:51.282265+00:00",
+        "translate_date": "2026-06-08T03:08:42.344641+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.3621,
+        "translate_time_seconds": 8.8255,
         "output_file": "data/gamslib/mcp/elec_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:31:51.999015+00:00",
+        "solve_date": "2026-06-08T03:08:44.516193+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2541,7 +2541,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6908,
+        "solve_time_seconds": 2.1035,
         "iterations": null,
         "outcome_category": "path_solve_terminated",
         "error": {
@@ -2551,7 +2551,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:31:51.999128+00:00",
+        "comparison_date": "2026-06-08T03:08:44.517170+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -2658,22 +2658,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:31:55.646180+00:00",
+        "parse_date": "2026-06-08T03:08:57.140379+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.6451,
+        "parse_time_seconds": 12.6201,
         "variables_count": 12,
         "equations_count": 13
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:32:03.053175+00:00",
+        "translate_date": "2026-06-08T03:09:12.760615+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.3997,
+        "translate_time_seconds": 15.5948,
         "output_file": "data/gamslib/mcp/etamac_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:32:03.954212+00:00",
+        "solve_date": "2026-06-08T03:09:16.969231+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -2681,13 +2681,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 5.091,
-        "solve_time_seconds": 0.8829,
+        "solve_time_seconds": 4.0833,
         "iterations": 1884,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T16:32:03.954353+00:00",
+        "comparison_date": "2026-06-08T03:09:16.972199+00:00",
         "nlp_objective": 15.2947,
         "mcp_objective": 5.091,
         "absolute_difference": 10.203700000000001,
@@ -2734,40 +2734,40 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:32:10.420076+00:00",
+        "parse_date": "2026-06-08T03:09:44.634821+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 6.4651,
+        "parse_time_seconds": 27.6582,
         "variables_count": 15,
         "equations_count": 10
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:32:17.866939+00:00",
+        "translate_date": "2026-06-08T03:10:03.332907+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.4409,
+        "translate_time_seconds": 18.6686,
         "output_file": "data/gamslib/mcp/fawley_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:32:18.176277+00:00",
+        "solve_date": "2026-06-08T03:10:05.444235+00:00",
         "solver": "PATH",
         "solver_version": null,
-        "solver_status": null,
-        "solver_status_text": null,
-        "model_status": null,
-        "model_status_text": null,
-        "objective_value": null,
-        "solve_time_seconds": 0.296,
-        "iterations": null,
-        "outcome_category": "path_syntax_error",
+        "solver_status": 1,
+        "solver_status_text": "Normal Completion",
+        "model_status": 5,
+        "model_status_text": "Locally Infeasible",
+        "objective_value": 6329.272,
+        "solve_time_seconds": 2.0535,
+        "iterations": 6304,
+        "outcome_category": "model_infeasible",
         "error": {
-          "category": "path_syntax_error",
-          "message": "Parse error: compilation_error"
+          "category": "model_infeasible",
+          "message": "Model: Locally Infeasible (status 5)"
         }
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:32:18.176415+00:00",
+        "comparison_date": "2026-06-08T03:10:21.126292+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -2801,22 +2801,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:32:19.005122+00:00",
+        "parse_date": "2026-06-08T03:10:27.249571+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.8282,
+        "parse_time_seconds": 6.1175,
         "variables_count": 6,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:32:23.079587+00:00",
+        "translate_date": "2026-06-08T03:10:36.438984+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.0701,
+        "translate_time_seconds": 9.1356,
         "output_file": "data/gamslib/mcp/fdesign_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T16:32:23.703899+00:00",
+        "solve_date": "2026-06-08T03:10:38.573776+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -2824,13 +2824,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1.046,
-        "solve_time_seconds": 0.6027,
+        "solve_time_seconds": 2.0457,
         "iterations": 339,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T16:32:23.704044+00:00",
+        "comparison_date": "2026-06-08T03:10:38.574051+00:00",
         "nlp_objective": 1.0465,
         "mcp_objective": 1.046,
         "absolute_difference": 0.0004999999999999449,
@@ -2951,22 +2951,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:32:43.565405+00:00",
+        "parse_date": "2026-06-08T03:11:26.259841+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 19.8601,
+        "parse_time_seconds": 47.6791,
         "variables_count": 11,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:36:31.220550+00:00",
+        "translate_date": "2026-06-08T03:19:07.259098+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 227.6419,
+        "translate_time_seconds": 460.9349,
         "output_file": "data/gamslib/mcp/ferts_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:36:31.965174+00:00",
+        "solve_date": "2026-06-08T03:19:12.944388+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -2974,7 +2974,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.7212,
+        "solve_time_seconds": 4.5721,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -2984,7 +2984,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:36:31.965331+00:00",
+        "comparison_date": "2026-06-08T03:19:12.946229+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -3041,41 +3041,30 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:41:08.563981+00:00",
+        "parse_date": "2026-06-08T03:30:46.436592+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 276.5884,
+        "parse_time_seconds": 693.3479,
         "variables_count": 74,
         "equations_count": 68
       },
       "nlp2mcp_translate": {
-        "status": "success",
-        "translate_date": "2026-06-06T16:46:07.789707+00:00",
+        "status": "failure",
+        "translate_date": "2026-06-08T03:40:47.171263+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 299.1962,
-        "output_file": "data/gamslib/mcp/ganges_mcp.gms"
+        "translate_time_seconds": 600.6469,
+        "error": {
+          "category": "timeout",
+          "message": "Translation timeout after 600 seconds"
+        }
       },
       "mcp_solve": {
-        "status": "failure",
-        "solve_date": "2026-06-06T16:46:08.443210+00:00",
-        "solver": "PATH",
-        "solver_version": null,
-        "solver_status": null,
-        "solver_status_text": null,
-        "model_status": null,
-        "model_status_text": null,
-        "objective_value": null,
-        "solve_time_seconds": 0.5718,
-        "iterations": null,
-        "outcome_category": "path_syntax_error",
-        "error": {
-          "category": "path_syntax_error",
-          "message": "Parse error: compilation_error"
-        }
+        "status": "not_tested",
+        "solve_date": "2026-06-08T03:40:47.517613+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:46:08.444199+00:00",
-        "notes": "Skipped due to solve failure"
+        "comparison_date": "2026-06-08T03:40:47.517613+00:00",
+        "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
         "variables": 74,
@@ -3108,22 +3097,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:50:27.818548+00:00",
+        "parse_date": "2026-06-08T03:52:04.939606+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 259.3641,
+        "parse_time_seconds": 677.3333,
         "variables_count": 74,
         "equations_count": 68
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T16:58:42.214277+00:00",
+        "translate_date": "2026-06-08T04:01:58.980456+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 494.3485,
+        "translate_time_seconds": 593.882,
         "output_file": "data/gamslib/mcp/gangesx_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T16:58:43.245225+00:00",
+        "solve_date": "2026-06-08T04:02:00.487809+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3131,7 +3120,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.8986,
+        "solve_time_seconds": 1.1282,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -3141,7 +3130,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T16:58:43.246825+00:00",
+        "comparison_date": "2026-06-08T04:02:00.491412+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -3234,22 +3223,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T16:58:48.641300+00:00",
+        "parse_date": "2026-06-08T04:02:08.897747+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 5.3917,
+        "parse_time_seconds": 8.3826,
         "variables_count": 13,
         "equations_count": 12
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:00:12.058411+00:00",
+        "translate_date": "2026-06-08T04:03:33.035953+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 83.3988,
+        "translate_time_seconds": 84.0925,
         "output_file": "data/gamslib/mcp/glider_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:00:13.066998+00:00",
+        "solve_date": "2026-06-08T04:03:34.138503+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -3257,7 +3246,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.9592,
+        "solve_time_seconds": 0.8716,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -3267,7 +3256,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:00:13.067894+00:00",
+        "comparison_date": "2026-06-08T04:03:34.139706+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -3331,22 +3320,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:00:24.544886+00:00",
+        "parse_date": "2026-06-08T04:03:58.728972+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 11.4741,
+        "parse_time_seconds": 24.5761,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:00:41.447564+00:00",
+        "translate_date": "2026-06-08T04:04:20.007594+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 16.8866,
+        "translate_time_seconds": 21.2601,
         "output_file": "data/gamslib/mcp/gtm_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:00:44.482154+00:00",
+        "solve_date": "2026-06-08T04:04:22.180369+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3354,13 +3343,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -543.565,
-        "solve_time_seconds": 2.9483,
+        "solve_time_seconds": 2.0836,
         "iterations": 119,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:00:44.485349+00:00",
+        "comparison_date": "2026-06-08T04:04:22.189306+00:00",
         "nlp_objective": -543.5651,
         "mcp_objective": -543.565,
         "absolute_difference": 9.999999997489795e-05,
@@ -3476,22 +3465,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:00:47.912536+00:00",
+        "parse_date": "2026-06-08T04:05:53.036909+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.4236,
+        "parse_time_seconds": 90.8367,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:00:54.065128+00:00",
+        "translate_date": "2026-06-08T04:06:00.095121+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.1401,
+        "translate_time_seconds": 7.0447,
         "output_file": "data/gamslib/mcp/gussrisk_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:00:55.157433+00:00",
+        "solve_date": "2026-06-08T04:06:01.643959+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3499,13 +3488,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 148.214,
-        "solve_time_seconds": 1.0671,
+        "solve_time_seconds": 1.4729,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:00:55.157600+00:00",
+        "comparison_date": "2026-06-08T04:06:01.644209+00:00",
         "nlp_objective": 148.2143,
         "mcp_objective": 148.214,
         "absolute_difference": 0.00030000000000995897,
@@ -3552,22 +3541,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:00:59.735937+00:00",
+        "parse_date": "2026-06-08T04:06:05.859508+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.3727,
+        "parse_time_seconds": 4.0226,
         "variables_count": 5,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:06.661958+00:00",
+        "translate_date": "2026-06-08T04:06:19.243222+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.9166,
+        "translate_time_seconds": 13.3694,
         "output_file": "data/gamslib/mcp/harker_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:07.880642+00:00",
+        "solve_date": "2026-06-08T04:06:21.051766+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3575,13 +3564,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 832.204,
-        "solve_time_seconds": 1.1767,
+        "solve_time_seconds": 1.7535,
         "iterations": 108,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:01:07.880933+00:00",
+        "comparison_date": "2026-06-08T04:06:21.052823+00:00",
         "nlp_objective": 706.3091,
         "mcp_objective": 832.204,
         "absolute_difference": 125.8949,
@@ -3628,22 +3617,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:10.257963+00:00",
+        "parse_date": "2026-06-08T04:06:24.003799+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.3757,
+        "parse_time_seconds": 2.9412,
         "variables_count": 10,
         "equations_count": 10
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:15.814978+00:00",
+        "translate_date": "2026-06-08T04:06:30.167404+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.5475,
+        "translate_time_seconds": 6.1502,
         "output_file": "data/gamslib/mcp/hhfair_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:17.142109+00:00",
+        "solve_date": "2026-06-08T04:06:31.404515+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3651,13 +3640,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 72.147,
-        "solve_time_seconds": 1.2797,
+        "solve_time_seconds": 1.2004,
         "iterations": 174,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:01:17.142451+00:00",
+        "comparison_date": "2026-06-08T04:06:31.404788+00:00",
         "nlp_objective": 87.159,
         "mcp_objective": 72.147,
         "absolute_difference": 15.012,
@@ -3704,22 +3693,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:18.170582+00:00",
+        "parse_date": "2026-06-08T04:06:31.906278+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.0266,
+        "parse_time_seconds": 0.4988,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:21.646400+00:00",
+        "translate_date": "2026-06-08T04:06:35.329602+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.4658,
+        "translate_time_seconds": 3.4096,
         "output_file": "data/gamslib/mcp/hhmax_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:22.916068+00:00",
+        "solve_date": "2026-06-08T04:06:36.715953+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3727,13 +3716,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 13.929,
-        "solve_time_seconds": 1.2304,
+        "solve_time_seconds": 1.36,
         "iterations": 3,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:01:22.916311+00:00",
+        "comparison_date": "2026-06-08T04:06:36.716206+00:00",
         "nlp_objective": 13.9288,
         "mcp_objective": 13.929,
         "absolute_difference": 0.00019999999999953388,
@@ -3780,9 +3769,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:24.312480+00:00",
+        "parse_date": "2026-06-08T04:06:37.567747+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.3953,
+        "parse_time_seconds": 0.8454,
         "variables_count": 10,
         "equations_count": 5
       },
@@ -3794,14 +3783,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:28.207996+00:00",
+        "translate_date": "2026-06-08T04:06:41.481464+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.8782,
+        "translate_time_seconds": 3.901,
         "output_file": "data/gamslib/mcp/himmel11_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:29.485002+00:00",
+        "solve_date": "2026-06-08T04:06:42.641877+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3809,13 +3798,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -30665.539,
-        "solve_time_seconds": 1.2455,
+        "solve_time_seconds": 1.1144,
         "iterations": 64,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:01:29.485316+00:00",
+        "comparison_date": "2026-06-08T04:06:42.642053+00:00",
         "nlp_objective": -30665.5387,
         "mcp_objective": -30665.539,
         "absolute_difference": 0.00029999999969732016,
@@ -3856,9 +3845,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:30.836075+00:00",
+        "parse_date": "2026-06-08T04:06:43.874277+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.345,
+        "parse_time_seconds": 1.2311,
         "variables_count": 4,
         "equations_count": 4
       },
@@ -3870,14 +3859,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:34.810436+00:00",
+        "translate_date": "2026-06-08T04:06:48.281849+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.9626,
+        "translate_time_seconds": 4.4004,
         "output_file": "data/gamslib/mcp/himmel16_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:36.293733+00:00",
+        "solve_date": "2026-06-08T04:06:49.647948+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3885,13 +3874,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.385,
-        "solve_time_seconds": 1.4487,
+        "solve_time_seconds": 1.3431,
         "iterations": 2,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:01:36.293997+00:00",
+        "comparison_date": "2026-06-08T04:06:49.648261+00:00",
         "nlp_objective": 0.675,
         "mcp_objective": 0.385,
         "absolute_difference": 0.29000000000000004,
@@ -3932,9 +3921,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:37.591943+00:00",
+        "parse_date": "2026-06-08T04:06:50.540557+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.2965,
+        "parse_time_seconds": 0.8909,
         "variables_count": 9,
         "equations_count": 9
       },
@@ -3946,14 +3935,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:41.645058+00:00",
+        "translate_date": "2026-06-08T04:06:54.501687+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.0356,
+        "translate_time_seconds": 3.9511,
         "output_file": "data/gamslib/mcp/house_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:42.891855+00:00",
+        "solve_date": "2026-06-08T04:06:55.992956+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -3961,13 +3950,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 4500.0,
-        "solve_time_seconds": 1.2081,
+        "solve_time_seconds": 1.4566,
         "iterations": 128,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:01:42.892150+00:00",
+        "comparison_date": "2026-06-08T04:06:55.994164+00:00",
         "nlp_objective": 4500.0,
         "mcp_objective": 4500.0,
         "absolute_difference": 0.0,
@@ -4008,9 +3997,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:44.007972+00:00",
+        "parse_date": "2026-06-08T04:06:56.810023+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.115,
+        "parse_time_seconds": 0.8119,
         "variables_count": 4,
         "equations_count": 3
       },
@@ -4022,14 +4011,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:48.157487+00:00",
+        "translate_date": "2026-06-08T04:07:01.107493+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.1321,
+        "translate_time_seconds": 4.2809,
         "output_file": "data/gamslib/mcp/hs62_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:49.311209+00:00",
+        "solve_date": "2026-06-08T04:07:02.716385+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4037,13 +4026,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -26272.514,
-        "solve_time_seconds": 1.1177,
+        "solve_time_seconds": 1.5807,
         "iterations": 26,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:01:49.311515+00:00",
+        "comparison_date": "2026-06-08T04:07:02.716593+00:00",
         "nlp_objective": -26272.5168,
         "mcp_objective": -26272.514,
         "absolute_difference": 0.0028000000020256266,
@@ -4084,9 +4073,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:01:50.798545+00:00",
+        "parse_date": "2026-06-08T04:07:03.960645+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.485,
+        "parse_time_seconds": 1.2424,
         "variables_count": 6,
         "equations_count": 5
       },
@@ -4098,14 +4087,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:01:55.134696+00:00",
+        "translate_date": "2026-06-08T04:07:12.545578+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.32,
+        "translate_time_seconds": 8.5664,
         "output_file": "data/gamslib/mcp/hydro_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:01:56.466033+00:00",
+        "solve_date": "2026-06-08T04:07:14.182175+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4113,13 +4102,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 4366944.16,
-        "solve_time_seconds": 1.2877,
+        "solve_time_seconds": 1.5749,
         "iterations": 182,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:01:56.466340+00:00",
+        "comparison_date": "2026-06-08T04:07:14.182484+00:00",
         "nlp_objective": 4366944.1598,
         "mcp_objective": 4366944.16,
         "absolute_difference": 0.0002000005915760994,
@@ -4160,9 +4149,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:02:01.219590+00:00",
+        "parse_date": "2026-06-08T04:07:18.514316+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.7515,
+        "parse_time_seconds": 4.3284,
         "variables_count": 3,
         "equations_count": 3
       },
@@ -4174,14 +4163,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:02:08.026634+00:00",
+        "translate_date": "2026-06-08T04:07:25.589845+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.7928,
+        "translate_time_seconds": 7.0651,
         "output_file": "data/gamslib/mcp/ibm1_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:02:09.164754+00:00",
+        "solve_date": "2026-06-08T04:07:27.303294+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4189,13 +4178,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 287.105,
-        "solve_time_seconds": 1.1031,
+        "solve_time_seconds": 1.6855,
         "iterations": 483,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:02:09.165142+00:00",
+        "comparison_date": "2026-06-08T04:07:27.303541+00:00",
         "nlp_objective": 287.1357,
         "mcp_objective": 287.105,
         "absolute_difference": 0.03069999999996753,
@@ -4260,22 +4249,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:02:13.032083+00:00",
+        "parse_date": "2026-06-08T04:07:30.945059+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.8658,
+        "parse_time_seconds": 3.6378,
         "variables_count": 6,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:02:19.979675+00:00",
+        "translate_date": "2026-06-08T04:07:38.334073+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.9348,
+        "translate_time_seconds": 7.3726,
         "output_file": "data/gamslib/mcp/imsl_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:02:21.130738+00:00",
+        "solve_date": "2026-06-08T04:07:40.077270+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4283,13 +4272,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 69.66,
-        "solve_time_seconds": 1.1069,
+        "solve_time_seconds": 1.7047,
         "iterations": 58,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:02:21.131042+00:00",
+        "comparison_date": "2026-06-08T04:07:40.077538+00:00",
         "nlp_objective": 1.1317,
         "mcp_objective": 69.66,
         "absolute_difference": 68.5283,
@@ -4336,22 +4325,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:03:56.052831+00:00",
+        "parse_date": "2026-06-08T04:09:12.416599+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 94.8275,
+        "parse_time_seconds": 92.2302,
         "variables_count": 27,
         "equations_count": 22
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:07:09.127336+00:00",
+        "translate_date": "2026-06-08T04:12:21.375777+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 193.0525,
+        "translate_time_seconds": 188.8859,
         "output_file": "data/gamslib/mcp/indus_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:07:10.037034+00:00",
+        "solve_date": "2026-06-08T04:12:22.722766+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -4359,7 +4348,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.8455,
+        "solve_time_seconds": 1.125,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -4369,7 +4358,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:07:10.037686+00:00",
+        "comparison_date": "2026-06-08T04:12:22.727868+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -4460,22 +4449,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:07:28.133853+00:00",
+        "parse_date": "2026-06-08T04:12:47.619903+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 18.0885,
+        "parse_time_seconds": 24.8704,
         "variables_count": 25,
         "equations_count": 25
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:07:46.147443+00:00",
+        "translate_date": "2026-06-08T04:13:06.446302+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 18.0037,
+        "translate_time_seconds": 18.8013,
         "output_file": "data/gamslib/mcp/irscge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:07:47.585553+00:00",
+        "solve_date": "2026-06-08T04:13:09.136410+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4483,13 +4472,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.508,
-        "solve_time_seconds": 1.3944,
+        "solve_time_seconds": 2.5914,
         "iterations": 4,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:07:47.585813+00:00",
+        "comparison_date": "2026-06-08T04:13:09.141970+00:00",
         "nlp_objective": 26.0914,
         "mcp_objective": 25.508,
         "absolute_difference": 0.583400000000001,
@@ -4536,17 +4525,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:08:52.227075+00:00",
+        "parse_date": "2026-06-08T04:14:45.121965+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 64.6371,
+        "parse_time_seconds": 95.9667,
         "variables_count": 4,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T17:18:52.427487+00:00",
+        "translate_date": "2026-06-08T04:24:45.391880+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.1717,
+        "translate_time_seconds": 600.1983,
         "error": {
           "category": "timeout",
           "message": "Translation timeout after 600 seconds"
@@ -4554,11 +4543,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T17:18:52.465864+00:00"
+        "solve_date": "2026-06-08T04:24:45.577601+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:18:52.465864+00:00",
+        "comparison_date": "2026-06-08T04:24:45.577601+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -4613,9 +4602,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:18:53.709365+00:00",
+        "parse_date": "2026-06-08T04:24:47.698509+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.2401,
+        "parse_time_seconds": 2.0937,
         "variables_count": 7,
         "equations_count": 4
       },
@@ -4627,14 +4616,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:18:57.984766+00:00",
+        "translate_date": "2026-06-08T04:24:52.123926+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.2667,
+        "translate_time_seconds": 4.3931,
         "output_file": "data/gamslib/mcp/jobt_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:18:59.655737+00:00",
+        "solve_date": "2026-06-08T04:24:54.211772+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4642,13 +4631,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 21343.056,
-        "solve_time_seconds": 1.632,
+        "solve_time_seconds": 1.9638,
         "iterations": 665,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:18:59.656542+00:00",
+        "comparison_date": "2026-06-08T04:24:54.213255+00:00",
         "nlp_objective": 21343.0556,
         "mcp_objective": 21343.056,
         "absolute_difference": 0.0004000000008090865,
@@ -4689,22 +4678,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:19:06.699290+00:00",
+        "parse_date": "2026-06-08T04:25:08.030129+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 7.0412,
+        "parse_time_seconds": 13.8115,
         "variables_count": 3,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:19:14.248089+00:00",
+        "translate_date": "2026-06-08T04:25:18.429146+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.5368,
+        "translate_time_seconds": 10.3726,
         "output_file": "data/gamslib/mcp/kand_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:19:15.440405+00:00",
+        "solve_date": "2026-06-08T04:25:20.975550+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4712,13 +4701,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 195.0,
-        "solve_time_seconds": 1.142,
+        "solve_time_seconds": 2.4804,
         "iterations": 13,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:19:15.440667+00:00",
+        "comparison_date": "2026-06-08T04:25:20.976447+00:00",
         "nlp_objective": 2613.0,
         "mcp_objective": 195.0,
         "absolute_difference": 2418.0,
@@ -4765,22 +4754,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:19:30.128124+00:00",
+        "parse_date": "2026-06-08T04:25:41.885176+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 14.6854,
+        "parse_time_seconds": 20.8907,
         "variables_count": 44,
         "equations_count": 38
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:19:49.543365+00:00",
+        "translate_date": "2026-06-08T04:26:14.571658+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 19.3976,
+        "translate_time_seconds": 32.6368,
         "output_file": "data/gamslib/mcp/korcge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:19:50.863480+00:00",
+        "solve_date": "2026-06-08T04:26:19.315535+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4788,13 +4777,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 339.213,
-        "solve_time_seconds": 1.2807,
+        "solve_time_seconds": 4.5282,
         "iterations": 2,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:19:50.863868+00:00",
+        "comparison_date": "2026-06-08T04:26:19.316199+00:00",
         "nlp_objective": 339.213,
         "mcp_objective": 339.213,
         "absolute_difference": 0.0,
@@ -4871,22 +4860,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:19:53.666560+00:00",
+        "parse_date": "2026-06-08T04:26:21.794782+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.8018,
+        "parse_time_seconds": 2.4706,
         "variables_count": 4,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:19:58.492931+00:00",
+        "translate_date": "2026-06-08T04:26:27.323237+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.818,
+        "translate_time_seconds": 5.4873,
         "output_file": "data/gamslib/mcp/lands_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:19:59.571686+00:00",
+        "solve_date": "2026-06-08T04:26:29.067041+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4894,13 +4883,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 381.853,
-        "solve_time_seconds": 1.0455,
+        "solve_time_seconds": 1.6954,
         "iterations": 62,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:19:59.571912+00:00",
+        "comparison_date": "2026-06-08T04:26:29.070431+00:00",
         "nlp_objective": 381.8533,
         "mcp_objective": 381.853,
         "absolute_difference": 0.00029999999998153726,
@@ -4947,22 +4936,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-07T21:53:18.487415+00:00",
+        "parse_date": "2026-06-08T04:26:34.982386+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.9551,
+        "parse_time_seconds": 5.9087,
         "variables_count": 15,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-07T21:53:26.956551+00:00",
+        "translate_date": "2026-06-08T04:26:42.898706+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.3133,
+        "translate_time_seconds": 7.9019,
         "output_file": "data/gamslib/mcp/launch_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-07T21:53:36.326732+00:00",
+        "solve_date": "2026-06-08T04:26:56.408421+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -4970,7 +4959,7 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 2257.7976,
-        "solve_time_seconds": 1.5946,
+        "solve_time_seconds": 2.444,
         "iterations": 673,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -4978,7 +4967,7 @@
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-07T21:53:36.327672+00:00",
+        "comparison_date": "2026-06-08T04:26:56.409868+00:00",
         "nlp_objective": 2257.7976,
         "mcp_objective": 2257.7976,
         "absolute_difference": 0.0,
@@ -5025,9 +5014,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:20:30.118523+00:00",
+        "parse_date": "2026-06-08T04:26:58.208575+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.1487,
+        "parse_time_seconds": 1.79,
         "variables_count": 5,
         "equations_count": 3
       },
@@ -5039,14 +5028,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:20:34.359037+00:00",
+        "translate_date": "2026-06-08T04:27:02.004291+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.2311,
+        "translate_time_seconds": 3.7789,
         "output_file": "data/gamslib/mcp/least_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:20:35.859766+00:00",
+        "solve_date": "2026-06-08T04:27:03.215052+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5054,13 +5043,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 14085.14,
-        "solve_time_seconds": 1.4585,
+        "solve_time_seconds": 1.177,
         "iterations": 3,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:20:35.860076+00:00",
+        "comparison_date": "2026-06-08T04:27:03.215561+00:00",
         "nlp_objective": 14085.1398,
         "mcp_objective": 14085.14,
         "absolute_difference": 0.00019999999858555384,
@@ -5101,9 +5090,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:20:43.717807+00:00",
+        "parse_date": "2026-06-08T04:27:08.806049+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 7.8567,
+        "parse_time_seconds": 5.589,
         "variables_count": 4,
         "equations_count": 3
       },
@@ -5115,14 +5104,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:20:53.986192+00:00",
+        "translate_date": "2026-06-08T04:27:19.593628+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 10.2471,
+        "translate_time_seconds": 10.7692,
         "output_file": "data/gamslib/mcp/like_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:20:55.422097+00:00",
+        "solve_date": "2026-06-08T04:27:22.910667+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5130,13 +5119,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -1168.649,
-        "solve_time_seconds": 1.398,
+        "solve_time_seconds": 3.2626,
         "iterations": 72,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:20:55.422333+00:00",
+        "comparison_date": "2026-06-08T04:27:22.912327+00:00",
         "nlp_objective": -1138.4106,
         "mcp_objective": -1168.649,
         "absolute_difference": 30.238399999999956,
@@ -5201,22 +5190,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:20:58.034803+00:00",
+        "parse_date": "2026-06-08T04:27:26.105763+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.4625,
+        "parse_time_seconds": 2.9887,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:21:21.048968+00:00",
+        "translate_date": "2026-06-08T04:27:47.974404+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 23.0038,
+        "translate_time_seconds": 21.8538,
         "output_file": "data/gamslib/mcp/lmp2_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:21:22.405089+00:00",
+        "solve_date": "2026-06-08T04:27:49.743324+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5224,13 +5213,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 35.292,
-        "solve_time_seconds": 1.3106,
+        "solve_time_seconds": 1.7055,
         "iterations": 45,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:21:22.405325+00:00",
+        "comparison_date": "2026-06-08T04:27:49.745299+00:00",
         "nlp_objective": 4024.3928,
         "mcp_objective": 35.292,
         "absolute_difference": 3989.1008,
@@ -5301,22 +5290,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:21:24.030437+00:00",
+        "parse_date": "2026-06-08T04:27:50.878818+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.6233,
+        "parse_time_seconds": 1.1203,
         "variables_count": 4,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:21:59.796687+00:00",
+        "translate_date": "2026-06-08T04:28:24.427483+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 35.7526,
+        "translate_time_seconds": 33.5267,
         "output_file": "data/gamslib/mcp/lnts_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:22:01.003685+00:00",
+        "solve_date": "2026-06-08T04:28:26.323789+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5324,7 +5313,7 @@
         "model_status": 4,
         "model_status_text": "Infeasible",
         "objective_value": 0.0,
-        "solve_time_seconds": 1.1555,
+        "solve_time_seconds": 1.7996,
         "iterations": 0,
         "outcome_category": "model_infeasible",
         "error": {
@@ -5334,7 +5323,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:22:01.004044+00:00",
+        "comparison_date": "2026-06-08T04:28:26.324366+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -5400,22 +5389,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:22:13.769996+00:00",
+        "parse_date": "2026-06-08T04:28:40.341514+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 12.763,
+        "parse_time_seconds": 14.002,
         "variables_count": 27,
         "equations_count": 27
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:22:27.944290+00:00",
+        "translate_date": "2026-06-08T04:28:56.166037+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 14.1651,
+        "translate_time_seconds": 15.8059,
         "output_file": "data/gamslib/mcp/lrgcge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:22:29.169802+00:00",
+        "solve_date": "2026-06-08T04:28:58.667081+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5423,13 +5412,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.508,
-        "solve_time_seconds": 1.1781,
+        "solve_time_seconds": 2.2336,
         "iterations": 5,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:22:29.170041+00:00",
+        "comparison_date": "2026-06-08T04:28:58.680299+00:00",
         "nlp_objective": 25.7679,
         "mcp_objective": 25.508,
         "absolute_difference": 0.2599000000000018,
@@ -5476,22 +5465,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:22:32.973952+00:00",
+        "parse_date": "2026-06-08T04:29:07.956952+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.8028,
+        "parse_time_seconds": 9.138,
         "variables_count": 9,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:22:41.019948+00:00",
+        "translate_date": "2026-06-08T04:29:23.020302+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.0391,
+        "translate_time_seconds": 15.0379,
         "output_file": "data/gamslib/mcp/marco_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:22:42.340460+00:00",
+        "solve_date": "2026-06-08T04:29:25.064569+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5499,13 +5488,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -13.367,
-        "solve_time_seconds": 1.2795,
+        "solve_time_seconds": 1.9868,
         "iterations": 3670,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:22:42.340709+00:00",
+        "comparison_date": "2026-06-08T04:29:25.065895+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": -13.367,
         "absolute_difference": 13.367,
@@ -5552,9 +5541,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:22:44.228220+00:00",
+        "parse_date": "2026-06-08T04:29:27.527085+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.8867,
+        "parse_time_seconds": 2.4522,
         "variables_count": 2,
         "equations_count": 3
       },
@@ -5566,14 +5555,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:22:52.465759+00:00",
+        "translate_date": "2026-06-08T04:29:36.120084+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.23,
+        "translate_time_seconds": 8.5832,
         "output_file": "data/gamslib/mcp/markov_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:22:53.642723+00:00",
+        "solve_date": "2026-06-08T04:29:38.240149+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5581,13 +5570,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 2571.794,
-        "solve_time_seconds": 1.1359,
+        "solve_time_seconds": 2.0702,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:22:53.642965+00:00",
+        "comparison_date": "2026-06-08T04:29:38.243162+00:00",
         "nlp_objective": 2401.5773,
         "mcp_objective": 2571.794,
         "absolute_difference": 170.21669999999995,
@@ -5628,9 +5617,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:22:54.393129+00:00",
+        "parse_date": "2026-06-08T04:29:39.113100+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.7493,
+        "parse_time_seconds": 0.854,
         "variables_count": 3,
         "equations_count": 3
       },
@@ -5642,14 +5631,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:22:57.950960+00:00",
+        "translate_date": "2026-06-08T04:29:42.497527+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.5469,
+        "translate_time_seconds": 3.371,
         "output_file": "data/gamslib/mcp/mathopt1_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:22:59.072221+00:00",
+        "solve_date": "2026-06-08T04:29:43.715729+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5657,13 +5646,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 8.08582e-30,
-        "solve_time_seconds": 1.088,
+        "solve_time_seconds": 1.1932,
         "iterations": 9,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:22:59.072428+00:00",
+        "comparison_date": "2026-06-08T04:29:43.716193+00:00",
         "nlp_objective": 1.0,
         "mcp_objective": 8.08582e-30,
         "absolute_difference": 1.0,
@@ -5704,9 +5693,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:22:59.992280+00:00",
+        "parse_date": "2026-06-08T04:29:44.379382+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.9191,
+        "parse_time_seconds": 0.662,
         "variables_count": 3,
         "equations_count": 5
       },
@@ -5718,14 +5707,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:23:03.355517+00:00",
+        "translate_date": "2026-06-08T04:29:48.054035+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.357,
+        "translate_time_seconds": 3.6539,
         "output_file": "data/gamslib/mcp/mathopt2_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:23:04.641022+00:00",
+        "solve_date": "2026-06-08T04:29:49.465188+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5733,13 +5722,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.0,
-        "solve_time_seconds": 1.2558,
+        "solve_time_seconds": 1.3697,
         "iterations": 31,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:23:04.641433+00:00",
+        "comparison_date": "2026-06-08T04:29:49.465435+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": 0.0,
         "absolute_difference": 0.0,
@@ -5780,22 +5769,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:23:06.303027+00:00",
+        "parse_date": "2026-06-08T04:29:51.249914+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.66,
+        "parse_time_seconds": 1.7777,
         "variables_count": 7,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:23:10.087705+00:00",
+        "translate_date": "2026-06-08T04:29:55.252433+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.7735,
+        "translate_time_seconds": 3.9926,
         "output_file": "data/gamslib/mcp/mathopt3_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:23:24.158546+00:00",
+        "solve_date": "2026-06-08T04:30:14.884078+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5803,7 +5792,7 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.0,
-        "solve_time_seconds": 1.6432,
+        "solve_time_seconds": 2.0349,
         "iterations": 3,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -5811,7 +5800,7 @@
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:23:24.158815+00:00",
+        "comparison_date": "2026-06-08T04:30:14.888515+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": 0.0,
         "absolute_difference": 0.0,
@@ -5858,22 +5847,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:23:25.969231+00:00",
+        "parse_date": "2026-06-08T04:30:17.092928+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.8093,
+        "parse_time_seconds": 2.1844,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:23:29.927139+00:00",
+        "translate_date": "2026-06-08T04:30:21.793039+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.9491,
+        "translate_time_seconds": 4.6809,
         "output_file": "data/gamslib/mcp/mathopt4_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:23:30.969405+00:00",
+        "solve_date": "2026-06-08T04:30:23.466708+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -5881,13 +5870,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 15.356,
-        "solve_time_seconds": 1.0158,
+        "solve_time_seconds": 1.6193,
         "iterations": 8,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:23:30.969626+00:00",
+        "comparison_date": "2026-06-08T04:30:23.467165+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": 15.356,
         "absolute_difference": 15.356,
@@ -5964,9 +5953,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:23:32.714193+00:00",
+        "parse_date": "2026-06-08T04:30:25.154358+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.7435,
+        "parse_time_seconds": 1.6852,
         "variables_count": 3,
         "equations_count": 5
       },
@@ -5978,14 +5967,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:23:40.096904+00:00",
+        "translate_date": "2026-06-08T04:30:34.526793+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.375,
+        "translate_time_seconds": 9.3594,
         "output_file": "data/gamslib/mcp/maxmin_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:23:40.754762+00:00",
+        "solve_date": "2026-06-08T04:30:35.917410+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -5993,7 +5982,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6307,
+        "solve_time_seconds": 1.3101,
         "iterations": null,
         "outcome_category": "path_solve_terminated",
         "error": {
@@ -6003,7 +5992,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:23:40.754895+00:00",
+        "comparison_date": "2026-06-08T04:30:35.918051+00:00",
         "notes": "Skipped due to solve failure"
       }
     },
@@ -6088,17 +6077,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:24:56.128074+00:00",
+        "parse_date": "2026-06-08T04:32:25.082110+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 75.293,
+        "parse_time_seconds": 108.9464,
         "variables_count": 17,
         "equations_count": 16
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T17:34:56.290645+00:00",
+        "translate_date": "2026-06-08T04:42:25.338146+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.1324,
+        "translate_time_seconds": 600.1836,
         "error": {
           "category": "timeout",
           "message": "Translation timeout after 600 seconds"
@@ -6106,11 +6095,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T17:34:56.308405+00:00"
+        "solve_date": "2026-06-08T04:42:25.522401+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:34:56.308405+00:00",
+        "comparison_date": "2026-06-08T04:42:25.522401+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -6144,9 +6133,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:00.725644+00:00",
+        "parse_date": "2026-06-08T04:42:35.435789+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.4135,
+        "parse_time_seconds": 9.8805,
         "variables_count": 10,
         "equations_count": 11
       },
@@ -6158,14 +6147,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:08.299971+00:00",
+        "translate_date": "2026-06-08T04:42:41.532743+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.5655,
+        "translate_time_seconds": 6.0866,
         "output_file": "data/gamslib/mcp/mexss_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:09.592249+00:00",
+        "solve_date": "2026-06-08T04:42:42.900166+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6173,13 +6162,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 538.811,
-        "solve_time_seconds": 1.2446,
+        "solve_time_seconds": 1.3274,
         "iterations": 83,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:35:09.593319+00:00",
+        "comparison_date": "2026-06-08T04:42:42.900333+00:00",
         "nlp_objective": 538.8112,
         "mcp_objective": 538.811,
         "absolute_difference": 0.0001999999999497959,
@@ -6220,9 +6209,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:10.444893+00:00",
+        "parse_date": "2026-06-08T04:42:43.368163+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.8495,
+        "parse_time_seconds": 0.4657,
         "variables_count": 6,
         "equations_count": 4
       },
@@ -6234,14 +6223,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:13.762840+00:00",
+        "translate_date": "2026-06-08T04:42:46.388641+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.3084,
+        "translate_time_seconds": 3.0097,
         "output_file": "data/gamslib/mcp/mhw4d_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:14.852051+00:00",
+        "solve_date": "2026-06-08T04:42:47.595345+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6249,13 +6238,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 27.872,
-        "solve_time_seconds": 1.0561,
+        "solve_time_seconds": 1.1795,
         "iterations": 6,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:35:14.852313+00:00",
+        "comparison_date": "2026-06-08T04:42:47.595517+00:00",
         "nlp_objective": 27.8719,
         "mcp_objective": 27.872,
         "absolute_difference": 9.999999999976694e-05,
@@ -6296,9 +6285,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:18.430108+00:00",
+        "parse_date": "2026-06-08T04:42:50.572976+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.5742,
+        "parse_time_seconds": 2.9762,
         "variables_count": 6,
         "equations_count": 4
       },
@@ -6310,14 +6299,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:24.384559+00:00",
+        "translate_date": "2026-06-08T04:42:55.918302+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.945,
+        "translate_time_seconds": 5.338,
         "output_file": "data/gamslib/mcp/mhw4dx_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:27.784097+00:00",
+        "solve_date": "2026-06-08T04:42:56.877603+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6325,13 +6314,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 27.872,
-        "solve_time_seconds": 3.3657,
+        "solve_time_seconds": 0.9328,
         "iterations": 6,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:35:27.784447+00:00",
+        "comparison_date": "2026-06-08T04:42:56.877869+00:00",
         "nlp_objective": 27.8719,
         "mcp_objective": 27.872,
         "absolute_difference": 9.999999999976694e-05,
@@ -6393,29 +6382,29 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:31.455300+00:00",
+        "parse_date": "2026-06-08T04:42:58.877147+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.6689,
+        "parse_time_seconds": 1.9975,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T17:35:39.450491+00:00",
+        "translate_date": "2026-06-08T04:43:04.700918+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.9786,
+        "translate_time_seconds": 5.8158,
         "error": {
           "category": "internal_error",
-          "message": "/Users/jeff/experiments/nlp2mcp/src/ad/index_mapping.py:556: UserWarning: Failed to evaluate condition for equation 'pr': Failed to evaluate condition SetMembershipTest(c, (SymbolRef(l), SymbolRef(i), SymbolRef(j))) with indices ('nw', '1', '1', '1'): Set membership for 'c' cannot be evaluated statically because the set has no concrete members at compile time. Including unevaluable instances by default.\n  instances = enumerate_equation_instances(eq_name, eq_def.domain, model_ir, eq_def.condition"
+          "message": "/Users/jeff/experiments/nlp2mcp/src/ad/index_mapping.py:648: UserWarning: Failed to evaluate condition for equation 'pr': Failed to evaluate condition SetMembershipTest(c, (SymbolRef(l), SymbolRef(i), SymbolRef(j))) with indices ('nw', '1', '1', '1'): Set membership for 'c' cannot be evaluated statically because the set has no concrete members at compile time. Including unevaluable instances by default.\n  instances = enumerate_equation_instances(eq_name, eq_def.domain, model_ir, eq_def.condition"
         }
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T17:35:39.458358+00:00"
+        "solve_date": "2026-06-08T04:43:04.717558+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:35:39.458358+00:00",
+        "comparison_date": "2026-06-08T04:43:04.717558+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -6449,9 +6438,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:40.640729+00:00",
+        "parse_date": "2026-06-08T04:43:05.440700+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.1816,
+        "parse_time_seconds": 0.7198,
         "variables_count": 4,
         "equations_count": 2
       },
@@ -6463,14 +6452,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:44.919375+00:00",
+        "translate_date": "2026-06-08T04:43:08.170396+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.2657,
+        "translate_time_seconds": 2.7242,
         "output_file": "data/gamslib/mcp/mingamma_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:46.308516+00:00",
+        "solve_date": "2026-06-08T04:43:09.128346+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6478,13 +6467,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -0.121,
-        "solve_time_seconds": 1.3612,
+        "solve_time_seconds": 0.9316,
         "iterations": 9,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:35:46.308791+00:00",
+        "comparison_date": "2026-06-08T04:43:09.128609+00:00",
         "nlp_objective": -0.1215,
         "mcp_objective": -0.121,
         "absolute_difference": 0.0005000000000000004,
@@ -6579,22 +6568,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:47.840867+00:00",
+        "parse_date": "2026-06-08T04:43:10.057997+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.5305,
+        "parse_time_seconds": 0.9254,
         "variables_count": 3,
         "equations_count": 1
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:51.868499+00:00",
+        "translate_date": "2026-06-08T04:43:12.915596+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.0141,
+        "translate_time_seconds": 2.8455,
         "output_file": "data/gamslib/mcp/mlbeta_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:52.912324+00:00",
+        "solve_date": "2026-06-08T04:43:13.680272+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6602,13 +6591,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.318,
-        "solve_time_seconds": 1.016,
+        "solve_time_seconds": 0.7404,
         "iterations": 2,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:35:52.912556+00:00",
+        "comparison_date": "2026-06-08T04:43:13.680532+00:00",
         "nlp_objective": 25.3176,
         "mcp_objective": 25.318,
         "absolute_difference": 0.0004000000000026205,
@@ -6655,22 +6644,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:35:53.938038+00:00",
+        "parse_date": "2026-06-08T04:43:14.221286+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.0246,
+        "parse_time_seconds": 0.5388,
         "variables_count": 3,
         "equations_count": 1
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:35:57.933780+00:00",
+        "translate_date": "2026-06-08T04:43:17.090547+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.9843,
+        "translate_time_seconds": 2.8601,
         "output_file": "data/gamslib/mcp/mlgamma_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:35:59.172496+00:00",
+        "solve_date": "2026-06-08T04:43:18.349078+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6678,13 +6667,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -155.347,
-        "solve_time_seconds": 1.2058,
+        "solve_time_seconds": 1.1995,
         "iterations": 43,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:35:59.172810+00:00",
+        "comparison_date": "2026-06-08T04:43:18.349305+00:00",
         "nlp_objective": -155.3468,
         "mcp_objective": -155.347,
         "absolute_difference": 0.0002000000000066393,
@@ -6731,22 +6720,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:36:20.612008+00:00",
+        "parse_date": "2026-06-08T04:43:30.829287+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 21.4375,
+        "parse_time_seconds": 12.4767,
         "variables_count": 26,
         "equations_count": 26
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:36:37.573874+00:00",
+        "translate_date": "2026-06-08T04:43:47.721262+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 16.9503,
+        "translate_time_seconds": 16.8809,
         "output_file": "data/gamslib/mcp/moncge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:36:38.864761+00:00",
+        "solve_date": "2026-06-08T04:43:49.603060+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -6754,13 +6743,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.508,
-        "solve_time_seconds": 1.2509,
+        "solve_time_seconds": 1.7862,
         "iterations": 5,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:36:38.865227+00:00",
+        "comparison_date": "2026-06-08T04:43:49.603317+00:00",
         "nlp_objective": 25.9819,
         "mcp_objective": 25.508,
         "absolute_difference": 0.47390000000000043,
@@ -6828,17 +6817,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:37:15.707410+00:00",
+        "parse_date": "2026-06-08T04:44:46.003042+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 36.8393,
+        "parse_time_seconds": 56.3934,
         "variables_count": 29,
         "equations_count": 25
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T17:47:15.895944+00:00",
+        "translate_date": "2026-06-08T04:54:46.288964+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.1387,
+        "translate_time_seconds": 600.2198,
         "error": {
           "category": "timeout",
           "message": "Translation timeout after 600 seconds"
@@ -6846,11 +6835,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T17:47:16.057057+00:00"
+        "solve_date": "2026-06-08T04:54:46.649656+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:47:16.057057+00:00",
+        "comparison_date": "2026-06-08T04:54:46.649656+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -7017,40 +7006,40 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:47:20.310319+00:00",
+        "parse_date": "2026-06-08T04:54:54.171205+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.9663,
+        "parse_time_seconds": 6.7922,
         "variables_count": 10,
         "equations_count": 10
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:47:28.672953+00:00",
+        "translate_date": "2026-06-08T04:55:03.282246+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.3448,
+        "translate_time_seconds": 9.0964,
         "output_file": "data/gamslib/mcp/otpop_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:47:29.587027+00:00",
+        "solve_date": "2026-06-08T04:55:09.711090+00:00",
         "solver": "PATH",
         "solver_version": null,
-        "solver_status": null,
-        "solver_status_text": null,
-        "model_status": null,
-        "model_status_text": null,
-        "objective_value": null,
-        "solve_time_seconds": 0.8792,
-        "iterations": null,
-        "outcome_category": "path_syntax_error",
+        "solver_status": 1,
+        "solver_status_text": "Normal Completion",
+        "model_status": 5,
+        "model_status_text": "Locally Infeasible",
+        "objective_value": 2348.971,
+        "solve_time_seconds": 6.277,
+        "iterations": 6090,
+        "outcome_category": "model_infeasible",
         "error": {
-          "category": "path_syntax_error",
-          "message": "Parse error: compilation_error"
+          "category": "model_infeasible",
+          "message": "Model: Locally Infeasible (status 5)"
         }
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:47:29.587315+00:00",
+        "comparison_date": "2026-06-08T04:55:18.612475+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -7084,9 +7073,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:47:32.792074+00:00",
+        "parse_date": "2026-06-08T04:55:23.985690+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.2039,
+        "parse_time_seconds": 5.3681,
         "variables_count": 11,
         "equations_count": 15
       },
@@ -7098,14 +7087,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:47:43.263695+00:00",
+        "translate_date": "2026-06-08T04:55:34.428782+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 10.4592,
+        "translate_time_seconds": 10.4196,
         "output_file": "data/gamslib/mcp/pak_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:47:46.387553+00:00",
+        "solve_date": "2026-06-08T04:55:37.943631+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7113,13 +7102,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1075.547,
-        "solve_time_seconds": 3.0862,
+        "solve_time_seconds": 3.4495,
         "iterations": 12796,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:47:46.388060+00:00",
+        "comparison_date": "2026-06-08T04:55:37.947309+00:00",
         "nlp_objective": 1075.5471,
         "mcp_objective": 1075.547,
         "absolute_difference": 9.999999997489795e-05,
@@ -7160,22 +7149,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:47:50.610405+00:00",
+        "parse_date": "2026-06-08T04:55:43.950446+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.2214,
+        "parse_time_seconds": 5.9986,
         "variables_count": 13,
         "equations_count": 13
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:47:57.993753+00:00",
+        "translate_date": "2026-06-08T04:55:51.848835+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.3713,
+        "translate_time_seconds": 7.8841,
         "output_file": "data/gamslib/mcp/paklive_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:47:59.208713+00:00",
+        "solve_date": "2026-06-08T04:55:53.215618+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7183,13 +7172,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 19468.087,
-        "solve_time_seconds": 1.1751,
+        "solve_time_seconds": 1.3118,
         "iterations": 315,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:47:59.208996+00:00",
+        "comparison_date": "2026-06-08T04:55:53.216081+00:00",
         "nlp_objective": 19468.0877,
         "mcp_objective": 19468.087,
         "absolute_difference": 0.0007000000005064066,
@@ -7236,22 +7225,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:48:04.898583+00:00",
+        "parse_date": "2026-06-08T04:56:04.261299+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 5.6884,
+        "parse_time_seconds": 11.042,
         "variables_count": 8,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:48:10.423888+00:00",
+        "translate_date": "2026-06-08T04:56:09.679138+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.5125,
+        "translate_time_seconds": 5.4052,
         "output_file": "data/gamslib/mcp/paperco_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:48:11.685959+00:00",
+        "solve_date": "2026-06-08T04:56:10.766639+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7259,13 +7248,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 4476.265,
-        "solve_time_seconds": 1.226,
+        "solve_time_seconds": 1.039,
         "iterations": 33,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:48:11.686238+00:00",
+        "comparison_date": "2026-06-08T04:56:10.766979+00:00",
         "nlp_objective": 4615.4242,
         "mcp_objective": 4476.265,
         "absolute_difference": 139.15920000000006,
@@ -7312,22 +7301,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:48:17.025308+00:00",
+        "parse_date": "2026-06-08T04:56:15.307366+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 5.3368,
+        "parse_time_seconds": 4.5367,
         "variables_count": 4,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:48:24.907540+00:00",
+        "translate_date": "2026-06-08T04:56:21.978790+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.8747,
+        "translate_time_seconds": 6.6597,
         "output_file": "data/gamslib/mcp/partssupply_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:48:26.212918+00:00",
+        "solve_date": "2026-06-08T04:56:24.941665+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7335,13 +7324,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.917,
-        "solve_time_seconds": 1.2587,
+        "solve_time_seconds": 2.9194,
         "iterations": 11,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:48:26.213348+00:00",
+        "comparison_date": "2026-06-08T04:56:24.941973+00:00",
         "nlp_objective": 0.9167,
         "mcp_objective": 0.917,
         "absolute_difference": 0.000300000000000078,
@@ -7388,22 +7377,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:48:30.411513+00:00",
+        "parse_date": "2026-06-08T04:56:28.364736+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.1972,
+        "parse_time_seconds": 3.4207,
         "variables_count": 12,
         "equations_count": 9
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:48:38.521597+00:00",
+        "translate_date": "2026-06-08T04:56:38.032069+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.0998,
+        "translate_time_seconds": 9.6479,
         "output_file": "data/gamslib/mcp/pdi_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:48:40.123633+00:00",
+        "solve_date": "2026-06-08T04:56:39.659256+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7411,13 +7400,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 294070.0,
-        "solve_time_seconds": 1.5528,
+        "solve_time_seconds": 1.5811,
         "iterations": 6489,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:48:40.124103+00:00",
+        "comparison_date": "2026-06-08T04:56:39.659526+00:00",
         "nlp_objective": 294070.0,
         "mcp_objective": 294070.0,
         "absolute_difference": 0.0,
@@ -7485,22 +7474,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:48:42.142005+00:00",
+        "parse_date": "2026-06-08T04:56:41.467401+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.0118,
+        "parse_time_seconds": 1.8054,
         "variables_count": 8,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:48:49.959209+00:00",
+        "translate_date": "2026-06-08T04:56:48.418994+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.8065,
+        "translate_time_seconds": 6.9411,
         "output_file": "data/gamslib/mcp/pindyck_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:48:51.423058+00:00",
+        "solve_date": "2026-06-08T04:56:49.796101+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7508,13 +7497,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1170.486,
-        "solve_time_seconds": 1.4188,
+        "solve_time_seconds": 1.3267,
         "iterations": 358,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:48:51.423314+00:00",
+        "comparison_date": "2026-06-08T04:56:49.796512+00:00",
         "nlp_objective": 1170.4863,
         "mcp_objective": 1170.486,
         "absolute_difference": 0.00029999999992469384,
@@ -7582,9 +7571,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:49:08.144519+00:00",
+        "parse_date": "2026-06-08T04:57:05.927241+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 16.7199,
+        "parse_time_seconds": 16.127,
         "variables_count": 5,
         "equations_count": 6
       },
@@ -7596,14 +7585,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:49:26.356942+00:00",
+        "translate_date": "2026-06-08T04:57:23.124096+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 18.1983,
+        "translate_time_seconds": 17.1777,
         "output_file": "data/gamslib/mcp/pollut_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:49:27.726321+00:00",
+        "solve_date": "2026-06-08T04:57:24.652363+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7611,13 +7600,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 5353268.629,
-        "solve_time_seconds": 1.3333,
+        "solve_time_seconds": 1.4647,
         "iterations": 452,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:49:27.726551+00:00",
+        "comparison_date": "2026-06-08T04:57:24.652549+00:00",
         "nlp_objective": 5353268.6287,
         "mcp_objective": 5353268.629,
         "absolute_difference": 0.00029999949038028717,
@@ -7658,22 +7647,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:49:28.778131+00:00",
+        "parse_date": "2026-06-08T04:57:26.195599+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.05,
+        "parse_time_seconds": 1.5402,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:49:44.503555+00:00",
+        "translate_date": "2026-06-08T04:57:40.472602+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 15.7169,
+        "translate_time_seconds": 14.2668,
         "output_file": "data/gamslib/mcp/polygon_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:49:47.063218+00:00",
+        "solve_date": "2026-06-08T04:57:43.324317+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7681,13 +7670,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.514,
-        "solve_time_seconds": 2.5056,
+        "solve_time_seconds": 2.7953,
         "iterations": 14807,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:49:47.063432+00:00",
+        "comparison_date": "2026-06-08T04:57:43.324696+00:00",
         "nlp_objective": 0.7797,
         "mcp_objective": 0.514,
         "absolute_difference": 0.26569999999999994,
@@ -7776,9 +7765,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:49:48.158668+00:00",
+        "parse_date": "2026-06-08T04:57:44.184838+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.0943,
+        "parse_time_seconds": 0.8578,
         "variables_count": 3,
         "equations_count": 5
       },
@@ -7790,14 +7779,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:49:51.721886+00:00",
+        "translate_date": "2026-06-08T04:57:47.780147+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.5555,
+        "translate_time_seconds": 3.5841,
         "output_file": "data/gamslib/mcp/port_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:49:52.846716+00:00",
+        "solve_date": "2026-06-08T04:57:48.722175+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7805,13 +7794,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.298,
-        "solve_time_seconds": 1.1007,
+        "solve_time_seconds": 0.9177,
         "iterations": 18,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:49:52.846967+00:00",
+        "comparison_date": "2026-06-08T04:57:48.722346+00:00",
         "nlp_objective": 0.2984,
         "mcp_objective": 0.298,
         "absolute_difference": 0.00040000000000001146,
@@ -7852,9 +7841,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:49:54.745173+00:00",
+        "parse_date": "2026-06-08T04:57:50.993689+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.8136,
+        "parse_time_seconds": 2.0789,
         "variables_count": 15,
         "equations_count": 12
       },
@@ -7866,14 +7855,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:49:58.648206+00:00",
+        "translate_date": "2026-06-08T04:57:55.583325+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.8892,
+        "translate_time_seconds": 4.5776,
         "output_file": "data/gamslib/mcp/process_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:49:59.713582+00:00",
+        "solve_date": "2026-06-08T04:57:56.846162+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7881,13 +7870,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 2410.828,
-        "solve_time_seconds": 1.0356,
+        "solve_time_seconds": 1.2297,
         "iterations": 31,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:49:59.713910+00:00",
+        "comparison_date": "2026-06-08T04:57:56.846396+00:00",
         "nlp_objective": 2410.8283,
         "mcp_objective": 2410.828,
         "absolute_difference": 0.0003000000001520675,
@@ -7928,22 +7917,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:01.032391+00:00",
+        "parse_date": "2026-06-08T04:57:57.896233+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.3177,
+        "parse_time_seconds": 1.0479,
         "variables_count": 3,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:04.239775+00:00",
+        "translate_date": "2026-06-08T04:58:02.251672+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.1931,
+        "translate_time_seconds": 4.3373,
         "output_file": "data/gamslib/mcp/procmean_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:05.663190+00:00",
+        "solve_date": "2026-06-08T04:58:03.543394+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -7951,13 +7940,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 14.166,
-        "solve_time_seconds": 1.3933,
+        "solve_time_seconds": 1.264,
         "iterations": 3,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:50:05.663566+00:00",
+        "comparison_date": "2026-06-08T04:58:03.543617+00:00",
         "nlp_objective": 14.1661,
         "mcp_objective": 14.166,
         "absolute_difference": 9.999999999976694e-05,
@@ -8004,9 +7993,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:07.377105+00:00",
+        "parse_date": "2026-06-08T04:58:04.211881+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.7124,
+        "parse_time_seconds": 0.666,
         "variables_count": 2,
         "equations_count": 2
       },
@@ -8018,14 +8007,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:10.670544+00:00",
+        "translate_date": "2026-06-08T04:58:07.524255+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.2865,
+        "translate_time_seconds": 3.3039,
         "output_file": "data/gamslib/mcp/prodmix_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:11.678587+00:00",
+        "solve_date": "2026-06-08T04:58:08.364567+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8033,13 +8022,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 18666.667,
-        "solve_time_seconds": 0.9839,
+        "solve_time_seconds": 0.8165,
         "iterations": 13,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:50:11.678822+00:00",
+        "comparison_date": "2026-06-08T04:58:08.364734+00:00",
         "nlp_objective": 18666.6667,
         "mcp_objective": 18666.667,
         "absolute_difference": 0.00029999999969732016,
@@ -8101,22 +8090,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:15.092618+00:00",
+        "parse_date": "2026-06-08T04:58:11.630996+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.4129,
+        "parse_time_seconds": 3.2651,
         "variables_count": 5,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:20.625637+00:00",
+        "translate_date": "2026-06-08T04:58:17.769997+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.5256,
+        "translate_time_seconds": 6.1257,
         "output_file": "data/gamslib/mcp/prodsp2_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:21.684311+00:00",
+        "solve_date": "2026-06-08T04:58:18.836800+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8124,13 +8113,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 18666.667,
-        "solve_time_seconds": 1.0274,
+        "solve_time_seconds": 1.035,
         "iterations": 13,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:50:21.684554+00:00",
+        "comparison_date": "2026-06-08T04:58:18.837102+00:00",
         "nlp_objective": 17845.6087,
         "mcp_objective": 18666.667,
         "absolute_difference": 821.0583000000006,
@@ -8177,22 +8166,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:26.481235+00:00",
+        "parse_date": "2026-06-08T04:58:23.421395+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.7957,
+        "parse_time_seconds": 4.5828,
         "variables_count": 6,
         "equations_count": 9
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:34.785692+00:00",
+        "translate_date": "2026-06-08T04:58:31.183957+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 8.2935,
+        "translate_time_seconds": 7.7522,
         "output_file": "data/gamslib/mcp/prolog_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:36.648680+00:00",
+        "solve_date": "2026-06-08T04:58:32.601610+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8200,13 +8189,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -6.2528e-13,
-        "solve_time_seconds": 1.8362,
+        "solve_time_seconds": 1.3859,
         "iterations": 107,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:50:36.648845+00:00",
+        "comparison_date": "2026-06-08T04:58:32.601830+00:00",
         "nlp_objective": -0.0,
         "mcp_objective": -6.2528e-13,
         "absolute_difference": 6.2528e-13,
@@ -8331,22 +8320,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:41.103604+00:00",
+        "parse_date": "2026-06-08T04:58:36.632482+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.4542,
+        "parse_time_seconds": 4.0292,
         "variables_count": 4,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:47.497894+00:00",
+        "translate_date": "2026-06-08T04:58:43.401486+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.3868,
+        "translate_time_seconds": 6.7617,
         "output_file": "data/gamslib/mcp/ps10_s_mn_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:48.920695+00:00",
+        "solve_date": "2026-06-08T04:58:45.401922+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8354,13 +8343,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 2.181,
-        "solve_time_seconds": 1.3878,
+        "solve_time_seconds": 1.9677,
         "iterations": 54,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T17:50:48.921038+00:00",
+        "comparison_date": "2026-06-08T04:58:45.402145+00:00",
         "nlp_objective": 0.4035,
         "mcp_objective": 2.181,
         "absolute_difference": null,
@@ -8408,22 +8397,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:49.616411+00:00",
+        "parse_date": "2026-06-08T04:58:45.892414+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.6944,
+        "parse_time_seconds": 0.489,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:50:53.663757+00:00",
+        "translate_date": "2026-06-08T04:58:49.160151+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.0339,
+        "translate_time_seconds": 3.2582,
         "output_file": "data/gamslib/mcp/ps2_f_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:50:55.078360+00:00",
+        "solve_date": "2026-06-08T04:58:51.375053+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8431,13 +8420,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.917,
-        "solve_time_seconds": 1.3842,
+        "solve_time_seconds": 2.185,
         "iterations": 11,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:50:55.078566+00:00",
+        "comparison_date": "2026-06-08T04:58:51.375311+00:00",
         "nlp_objective": 0.9167,
         "mcp_objective": 0.917,
         "absolute_difference": 0.000300000000000078,
@@ -8484,22 +8473,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:50:56.383512+00:00",
+        "parse_date": "2026-06-08T04:58:52.431922+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.3043,
+        "parse_time_seconds": 1.0553,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:51:01.091568+00:00",
+        "translate_date": "2026-06-08T04:58:55.751460+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.6966,
+        "translate_time_seconds": 3.3109,
         "output_file": "data/gamslib/mcp/ps2_f_eff_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:51:02.288880+00:00",
+        "solve_date": "2026-06-08T04:58:56.942512+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8507,13 +8496,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1.25,
-        "solve_time_seconds": 1.1724,
+        "solve_time_seconds": 1.1604,
         "iterations": 9,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:51:02.289069+00:00",
+        "comparison_date": "2026-06-08T04:58:56.942691+00:00",
         "nlp_objective": 1.25,
         "mcp_objective": 1.25,
         "absolute_difference": 0.0,
@@ -8560,9 +8549,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:51:03.231382+00:00",
+        "parse_date": "2026-06-08T04:58:57.707283+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.9416,
+        "parse_time_seconds": 0.7621,
         "variables_count": 4,
         "equations_count": 3
       },
@@ -8574,14 +8563,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:51:07.312330+00:00",
+        "translate_date": "2026-06-08T04:59:01.237343+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.0726,
+        "translate_time_seconds": 3.5182,
         "output_file": "data/gamslib/mcp/ps2_f_inf_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:51:08.571029+00:00",
+        "solve_date": "2026-06-08T04:59:02.385221+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8589,13 +8578,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.833,
-        "solve_time_seconds": 1.2098,
+        "solve_time_seconds": 1.1224,
         "iterations": 8,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:51:08.571523+00:00",
+        "comparison_date": "2026-06-08T04:59:02.385447+00:00",
         "nlp_objective": 0.8333,
         "mcp_objective": 0.833,
         "absolute_difference": 0.000300000000000078,
@@ -8792,22 +8781,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:51:09.283804+00:00",
+        "parse_date": "2026-06-08T04:59:03.128629+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.711,
+        "parse_time_seconds": 0.7394,
         "variables_count": 4,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:51:12.909872+00:00",
+        "translate_date": "2026-06-08T04:59:06.620512+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.6156,
+        "translate_time_seconds": 3.4629,
         "output_file": "data/gamslib/mcp/ps3_f_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:51:14.089238+00:00",
+        "solve_date": "2026-06-08T04:59:07.693288+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -8815,13 +8804,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1.375,
-        "solve_time_seconds": 1.1401,
+        "solve_time_seconds": 1.053,
         "iterations": 14,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:51:14.089922+00:00",
+        "comparison_date": "2026-06-08T04:59:07.693470+00:00",
         "nlp_objective": 1.375,
         "mcp_objective": 1.375,
         "absolute_difference": 0.0,
@@ -9180,22 +9169,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:51:18.465165+00:00",
+        "parse_date": "2026-06-08T04:59:11.425731+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 4.2757,
+        "parse_time_seconds": 3.6473,
         "variables_count": 4,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:51:25.543004+00:00",
+        "translate_date": "2026-06-08T04:59:17.641940+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.0627,
+        "translate_time_seconds": 6.2079,
         "output_file": "data/gamslib/mcp/ps5_s_mn_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:51:26.994127+00:00",
+        "solve_date": "2026-06-08T04:59:19.428356+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9203,13 +9192,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.908,
-        "solve_time_seconds": 1.4121,
+        "solve_time_seconds": 1.7651,
         "iterations": 31,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T17:51:26.994376+00:00",
+        "comparison_date": "2026-06-08T04:59:19.428578+00:00",
         "nlp_objective": 0.4254,
         "mcp_objective": 0.908,
         "absolute_difference": null,
@@ -9257,9 +9246,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:51:28.933906+00:00",
+        "parse_date": "2026-06-08T04:59:21.172066+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.9389,
+        "parse_time_seconds": 1.7403,
         "variables_count": 3,
         "equations_count": 2
       },
@@ -9271,14 +9260,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:52:00.178275+00:00",
+        "translate_date": "2026-06-08T04:59:48.516505+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 31.2319,
+        "translate_time_seconds": 27.3376,
         "output_file": "data/gamslib/mcp/qabel_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:52:01.671384+00:00",
+        "solve_date": "2026-06-08T04:59:49.638339+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9286,13 +9275,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 46965.036,
-        "solve_time_seconds": 1.4499,
+        "solve_time_seconds": 1.0943,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:52:01.671631+00:00",
+        "comparison_date": "2026-06-08T04:59:49.638576+00:00",
         "nlp_objective": 46965.0362,
         "mcp_objective": 46965.036,
         "absolute_difference": 0.00020000000222353265,
@@ -9387,22 +9376,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:52:10.165447+00:00",
+        "parse_date": "2026-06-08T04:59:55.894408+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 8.4908,
+        "parse_time_seconds": 6.2527,
         "variables_count": 20,
         "equations_count": 13
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:52:22.003093+00:00",
+        "translate_date": "2026-06-08T05:00:07.857248+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 11.8295,
+        "translate_time_seconds": 11.9554,
         "output_file": "data/gamslib/mcp/qdemo7_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:52:23.851205+00:00",
+        "solve_date": "2026-06-08T05:00:09.645184+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9410,13 +9399,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1589042.386,
-        "solve_time_seconds": 1.8125,
+        "solve_time_seconds": 1.7408,
         "iterations": 1468,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:52:23.851483+00:00",
+        "comparison_date": "2026-06-08T05:00:09.645475+00:00",
         "nlp_objective": 1589042.3862,
         "mcp_objective": 1589042.386,
         "absolute_difference": 0.0002000001259148121,
@@ -9631,22 +9620,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:52:25.360351+00:00",
+        "parse_date": "2026-06-08T05:00:11.391175+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.5076,
+        "parse_time_seconds": 1.7428,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:52:30.714999+00:00",
+        "translate_date": "2026-06-08T05:00:15.352665+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.344,
+        "translate_time_seconds": 3.9536,
         "output_file": "data/gamslib/mcp/qsambal_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:52:32.187610+00:00",
+        "solve_date": "2026-06-08T05:00:16.337897+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9654,13 +9643,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1028.0,
-        "solve_time_seconds": 1.4387,
+        "solve_time_seconds": 0.9566,
         "iterations": 11,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:52:32.192158+00:00",
+        "comparison_date": "2026-06-08T05:00:16.338119+00:00",
         "nlp_objective": 3.9682,
         "mcp_objective": 1028.0,
         "absolute_difference": 1024.0318,
@@ -9707,22 +9696,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:52:48.618718+00:00",
+        "parse_date": "2026-06-08T05:00:26.995679+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 16.4251,
+        "parse_time_seconds": 10.6558,
         "variables_count": 27,
         "equations_count": 28
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:53:05.729799+00:00",
+        "translate_date": "2026-06-08T05:00:40.534868+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 17.1034,
+        "translate_time_seconds": 13.5297,
         "output_file": "data/gamslib/mcp/quocge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:53:08.448497+00:00",
+        "solve_date": "2026-06-08T05:00:42.864579+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9730,13 +9719,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.683,
-        "solve_time_seconds": 2.6807,
+        "solve_time_seconds": 2.2906,
         "iterations": 1010,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:53:08.448685+00:00",
+        "comparison_date": "2026-06-08T05:00:42.864804+00:00",
         "nlp_objective": 25.6834,
         "mcp_objective": 25.683,
         "absolute_difference": 0.00039999999999906777,
@@ -9783,9 +9772,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:53:09.880984+00:00",
+        "parse_date": "2026-06-08T05:00:44.744529+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.4317,
+        "parse_time_seconds": 1.8781,
         "variables_count": 4,
         "equations_count": 4
       },
@@ -9797,14 +9786,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:53:14.975389+00:00",
+        "translate_date": "2026-06-08T05:00:53.122253+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.0882,
+        "translate_time_seconds": 8.3649,
         "output_file": "data/gamslib/mcp/ramsey_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:53:16.175700+00:00",
+        "solve_date": "2026-06-08T05:00:54.893936+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9812,13 +9801,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 2.487,
-        "solve_time_seconds": 1.1712,
+        "solve_time_seconds": 1.7139,
         "iterations": 371,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:53:16.175978+00:00",
+        "comparison_date": "2026-06-08T05:00:54.894589+00:00",
         "nlp_objective": 2.4875,
         "mcp_objective": 2.487,
         "absolute_difference": 0.0004999999999997229,
@@ -9859,9 +9848,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:53:16.594225+00:00",
+        "parse_date": "2026-06-08T05:00:55.209246+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.416,
+        "parse_time_seconds": 0.3117,
         "variables_count": 3,
         "equations_count": 1
       },
@@ -9873,14 +9862,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:53:19.814103+00:00",
+        "translate_date": "2026-06-08T05:00:59.362359+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.2128,
+        "translate_time_seconds": 4.0539,
         "output_file": "data/gamslib/mcp/rbrock_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:53:20.960757+00:00",
+        "solve_date": "2026-06-08T05:01:00.259706+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9888,13 +9877,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 3.43265e-20,
-        "solve_time_seconds": 1.1121,
+        "solve_time_seconds": 0.8618,
         "iterations": 5,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:53:20.961136+00:00",
+        "comparison_date": "2026-06-08T05:01:00.259947+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": 3.43265e-20,
         "absolute_difference": 3.43265e-20,
@@ -9935,9 +9924,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:53:22.586207+00:00",
+        "parse_date": "2026-06-08T05:01:01.437251+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.6238,
+        "parse_time_seconds": 1.1745,
         "variables_count": 3,
         "equations_count": 3
       },
@@ -9949,14 +9938,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:53:26.261145+00:00",
+        "translate_date": "2026-06-08T05:01:05.532727+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.6668,
+        "translate_time_seconds": 4.087,
         "output_file": "data/gamslib/mcp/robert_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:53:27.295399+00:00",
+        "solve_date": "2026-06-08T05:01:06.735308+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -9964,13 +9953,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 6741.667,
-        "solve_time_seconds": 1.0074,
+        "solve_time_seconds": 1.1363,
         "iterations": 275,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:53:27.295700+00:00",
+        "comparison_date": "2026-06-08T05:01:06.735592+00:00",
         "nlp_objective": 11025.0,
         "mcp_objective": 6741.667,
         "absolute_difference": 4283.333,
@@ -10011,22 +10000,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:53:30.017171+00:00",
+        "parse_date": "2026-06-08T05:01:10.471512+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.7172,
+        "parse_time_seconds": 3.7323,
         "variables_count": 13,
         "equations_count": 9
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:53:59.700704+00:00",
+        "translate_date": "2026-06-08T05:01:42.154314+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 29.6693,
+        "translate_time_seconds": 31.6705,
         "output_file": "data/gamslib/mcp/robot_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:54:00.392971+00:00",
+        "solve_date": "2026-06-08T05:01:43.223089+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -10034,7 +10023,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6501,
+        "solve_time_seconds": 0.8615,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -10044,7 +10033,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:54:00.393168+00:00",
+        "comparison_date": "2026-06-08T05:01:43.223834+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -10078,22 +10067,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:54:02.163512+00:00",
+        "parse_date": "2026-06-08T05:01:44.979549+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.7693,
+        "parse_time_seconds": 1.7465,
         "variables_count": 6,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:54:06.823439+00:00",
+        "translate_date": "2026-06-08T05:01:49.081348+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.6525,
+        "translate_time_seconds": 4.0931,
         "output_file": "data/gamslib/mcp/robustlp_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:54:19.004041+00:00",
+        "solve_date": "2026-06-08T05:02:00.834323+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10101,7 +10090,7 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -2.3296,
-        "solve_time_seconds": 4.2466,
+        "solve_time_seconds": 4.2801,
         "iterations": 2228,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -10109,7 +10098,7 @@
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:54:19.004403+00:00",
+        "comparison_date": "2026-06-08T05:02:00.834516+00:00",
         "nlp_objective": -2.3296,
         "mcp_objective": -2.3296,
         "absolute_difference": 0.0,
@@ -10156,22 +10145,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:54:21.490002+00:00",
+        "parse_date": "2026-06-08T05:02:02.738505+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.3799,
+        "parse_time_seconds": 1.8185,
         "variables_count": 8,
         "equations_count": 6
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:54:55.195843+00:00",
+        "translate_date": "2026-06-08T05:02:30.957688+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 33.6936,
+        "translate_time_seconds": 28.206,
         "output_file": "data/gamslib/mcp/rocket_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:55:34.564373+00:00",
+        "solve_date": "2026-06-08T05:03:11.008392+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10179,7 +10168,7 @@
         "model_status": 2,
         "model_status_text": "Locally Optimal",
         "objective_value": 1.0128,
-        "solve_time_seconds": 1.4739,
+        "solve_time_seconds": 1.8621,
         "iterations": 20,
         "outcome_category": "model_optimal_presolve",
         "presolve_required": true,
@@ -10187,7 +10176,7 @@
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T17:55:34.564980+00:00",
+        "comparison_date": "2026-06-08T05:03:11.011147+00:00",
         "nlp_objective": 1.0128,
         "mcp_objective": 1.0128,
         "absolute_difference": 0.0,
@@ -10234,22 +10223,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:55:36.065632+00:00",
+        "parse_date": "2026-06-08T05:03:12.954981+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.4985,
+        "parse_time_seconds": 1.9256,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:55:40.254428+00:00",
+        "translate_date": "2026-06-08T05:03:17.795594+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.182,
+        "translate_time_seconds": 4.8182,
         "output_file": "data/gamslib/mcp/sambal_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T17:55:41.302801+00:00",
+        "solve_date": "2026-06-08T05:03:18.779266+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10257,13 +10246,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1028.0,
-        "solve_time_seconds": 1.0271,
+        "solve_time_seconds": 0.9407,
         "iterations": 11,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T17:55:41.303117+00:00",
+        "comparison_date": "2026-06-08T05:03:18.779589+00:00",
         "nlp_objective": 3.9682,
         "mcp_objective": 1028.0,
         "absolute_difference": 1024.0318,
@@ -10310,9 +10299,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:55:42.859718+00:00",
+        "parse_date": "2026-06-08T05:03:20.402627+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.556,
+        "parse_time_seconds": 1.6161,
         "variables_count": 3,
         "equations_count": 4
       },
@@ -10324,14 +10313,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T17:55:46.300158+00:00",
+        "translate_date": "2026-06-08T05:03:24.918850+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.4337,
+        "translate_time_seconds": 4.4591,
         "output_file": "data/gamslib/mcp/sample_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T17:55:46.929915+00:00",
+        "solve_date": "2026-06-08T05:03:25.800534+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -10339,7 +10328,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6108,
+        "solve_time_seconds": 0.8566,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -10349,7 +10338,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:55:46.930131+00:00",
+        "comparison_date": "2026-06-08T05:03:25.800692+00:00",
         "notes": "Skipped due to solve failure"
       }
     },
@@ -10377,17 +10366,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:56:37.452359+00:00",
+        "parse_date": "2026-06-08T05:05:28.760611+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 50.5193,
+        "parse_time_seconds": 122.9541,
         "variables_count": 21,
         "equations_count": 40
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T17:57:31.612311+00:00",
+        "translate_date": "2026-06-08T05:06:40.238166+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 54.1484,
+        "translate_time_seconds": 71.4301,
         "error": {
           "category": "internal_error",
           "message": "Error: Model is a multi-solve driver script and is out of scope for nlp2mcp (NLP\u2192MCP via KKT). Declared models: ['sarasdual', 'sarasprimal']; distinct solve targets: ['sarasdual', 'sarasprimal']; equation-marginal feedback to a subsequent solve: calibuc.m, calibul.m.\n\nSuggestion: nlp2mcp transforms a single NLP's KKT conditions into an MCP. Driver scripts (Dantzig\u2013Wolfe, column generation, Benders', primal-dual alternation) combine multiple solves with dual feedback; their converged objective ca"
@@ -10395,11 +10384,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T17:57:31.623148+00:00"
+        "solve_date": "2026-06-08T05:06:40.368636+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T17:57:31.623148+00:00",
+        "comparison_date": "2026-06-08T05:06:40.368636+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -10433,17 +10422,17 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T17:57:58.481886+00:00",
+        "parse_date": "2026-06-08T05:07:20.273254+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 26.8545,
+        "parse_time_seconds": 39.8853,
         "variables_count": 10,
         "equations_count": 16
       },
       "nlp2mcp_translate": {
         "status": "failure",
-        "translate_date": "2026-06-06T18:07:58.703375+00:00",
+        "translate_date": "2026-06-08T05:17:20.570686+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.1846,
+        "translate_time_seconds": 600.2479,
         "error": {
           "category": "timeout",
           "message": "Translation timeout after 600 seconds"
@@ -10451,11 +10440,11 @@
       },
       "mcp_solve": {
         "status": "not_tested",
-        "solve_date": "2026-06-06T18:07:58.835176+00:00"
+        "solve_date": "2026-06-08T05:17:21.326936+00:00"
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:07:58.835176+00:00",
+        "comparison_date": "2026-06-08T05:17:21.326936+00:00",
         "notes": "Skipped due to translate failure"
       },
       "model_statistics": {
@@ -10531,22 +10520,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:08:01.113150+00:00",
+        "parse_date": "2026-06-08T05:17:25.976609+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.2695,
+        "parse_time_seconds": 4.5944,
         "variables_count": 2,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:08:05.328311+00:00",
+        "translate_date": "2026-06-08T05:17:30.992645+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.2046,
+        "translate_time_seconds": 4.9885,
         "output_file": "data/gamslib/mcp/senstran_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:08:06.665655+00:00",
+        "solve_date": "2026-06-08T05:17:33.265966+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10554,13 +10543,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 153.675,
-        "solve_time_seconds": 1.3043,
+        "solve_time_seconds": 2.0858,
         "iterations": 30,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "skipped",
-        "comparison_date": "2026-06-06T18:08:06.666508+00:00",
+        "comparison_date": "2026-06-08T05:17:33.269961+00:00",
         "nlp_objective": 163.98,
         "mcp_objective": 153.675,
         "absolute_difference": null,
@@ -10608,22 +10597,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:08:34.884738+00:00",
+        "parse_date": "2026-06-08T05:18:04.885935+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 28.2161,
+        "parse_time_seconds": 31.6127,
         "variables_count": 15,
         "equations_count": 22
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:16.938099+00:00",
+        "translate_date": "2026-06-08T05:18:44.643969+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 42.0411,
+        "translate_time_seconds": 39.7413,
         "output_file": "data/gamslib/mcp/shale_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:09:17.633754+00:00",
+        "solve_date": "2026-06-08T05:18:46.189267+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -10631,7 +10620,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6495,
+        "solve_time_seconds": 1.5053,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -10641,7 +10630,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:09:17.633960+00:00",
+        "comparison_date": "2026-06-08T05:18:46.189699+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -10675,22 +10664,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:20.703165+00:00",
+        "parse_date": "2026-06-08T05:18:48.615228+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.0682,
+        "parse_time_seconds": 2.4231,
         "variables_count": 7,
         "equations_count": 8
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:25.279296+00:00",
+        "translate_date": "2026-06-08T05:18:53.551414+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.5648,
+        "translate_time_seconds": 4.9177,
         "output_file": "data/gamslib/mcp/ship_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:09:26.374207+00:00",
+        "solve_date": "2026-06-08T05:18:54.742652+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10698,13 +10687,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 5.541,
-        "solve_time_seconds": 1.0635,
+        "solve_time_seconds": 1.1556,
         "iterations": 22,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:09:26.374484+00:00",
+        "comparison_date": "2026-06-08T05:18:54.743021+00:00",
         "nlp_objective": 5.5409,
         "mcp_objective": 5.541,
         "absolute_difference": 0.00010000000000065512,
@@ -10772,22 +10761,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:27.801704+00:00",
+        "parse_date": "2026-06-08T05:18:55.965749+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.425,
+        "parse_time_seconds": 1.2204,
         "variables_count": 5,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:31.187336+00:00",
+        "translate_date": "2026-06-08T05:18:59.719986+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.3755,
+        "translate_time_seconds": 3.7442,
         "output_file": "data/gamslib/mcp/solveopt_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:09:32.190860+00:00",
+        "solve_date": "2026-06-08T05:19:00.625504+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10795,13 +10784,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 6.0,
-        "solve_time_seconds": 0.973,
+        "solve_time_seconds": 0.8723,
         "iterations": 0,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:09:32.191126+00:00",
+        "comparison_date": "2026-06-08T05:19:00.625887+00:00",
         "nlp_objective": 6.0,
         "mcp_objective": 6.0,
         "absolute_difference": 0.0,
@@ -10848,22 +10837,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:33.842521+00:00",
+        "parse_date": "2026-06-08T05:19:02.020992+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.6505,
+        "parse_time_seconds": 1.3918,
         "variables_count": 3,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:38.146265+00:00",
+        "translate_date": "2026-06-08T05:19:05.833728+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.2956,
+        "translate_time_seconds": 3.8028,
         "output_file": "data/gamslib/mcp/sparta_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:09:39.128671+00:00",
+        "solve_date": "2026-06-08T05:19:06.837545+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10871,13 +10860,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 3466.38,
-        "solve_time_seconds": 0.9548,
+        "solve_time_seconds": 0.9802,
         "iterations": 172,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:09:39.128947+00:00",
+        "comparison_date": "2026-06-08T05:19:06.837784+00:00",
         "nlp_objective": 3466.38,
         "mcp_objective": 3466.38,
         "absolute_difference": 0.0,
@@ -10924,22 +10913,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:42.415916+00:00",
+        "parse_date": "2026-06-08T05:19:11.243928+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.2184,
+        "parse_time_seconds": 4.2498,
         "variables_count": 8,
         "equations_count": 14
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:47.207030+00:00",
+        "translate_date": "2026-06-08T05:19:18.688295+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.7841,
+        "translate_time_seconds": 7.4335,
         "output_file": "data/gamslib/mcp/spatequ_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:09:48.188338+00:00",
+        "solve_date": "2026-06-08T05:19:19.853617+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -10947,13 +10936,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1473.861,
-        "solve_time_seconds": 0.9515,
+        "solve_time_seconds": 1.141,
         "iterations": 114,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:09:48.188648+00:00",
+        "comparison_date": "2026-06-08T05:19:19.853780+00:00",
         "nlp_objective": 7906.9463,
         "mcp_objective": 1473.861,
         "absolute_difference": 6433.0853,
@@ -11063,22 +11052,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:50.322243+00:00",
+        "parse_date": "2026-06-08T05:19:21.539461+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.1323,
+        "parse_time_seconds": 1.6846,
         "variables_count": 7,
         "equations_count": 7
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:09:54.808113+00:00",
+        "translate_date": "2026-06-08T05:19:26.537366+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.4776,
+        "translate_time_seconds": 4.9915,
         "output_file": "data/gamslib/mcp/splcge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:09:55.968854+00:00",
+        "solve_date": "2026-06-08T05:19:27.460560+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11086,13 +11075,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 27.144,
-        "solve_time_seconds": 1.1278,
+        "solve_time_seconds": 0.8978,
         "iterations": 2,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:09:55.969054+00:00",
+        "comparison_date": "2026-06-08T05:19:27.460737+00:00",
         "nlp_objective": 27.1441,
         "mcp_objective": 27.144,
         "absolute_difference": 0.00010000000000331966,
@@ -11139,22 +11128,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:09:57.752173+00:00",
+        "parse_date": "2026-06-08T05:19:29.193295+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.782,
+        "parse_time_seconds": 1.729,
         "variables_count": 9,
         "equations_count": 6
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:10:01.725799+00:00",
+        "translate_date": "2026-06-08T05:19:34.873607+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.964,
+        "translate_time_seconds": 5.673,
         "output_file": "data/gamslib/mcp/springchain_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:10:02.853462+00:00",
+        "solve_date": "2026-06-08T05:19:36.364651+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11162,13 +11151,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -185.446,
-        "solve_time_seconds": 1.1038,
+        "solve_time_seconds": 1.3966,
         "iterations": 289,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:10:02.853648+00:00",
+        "comparison_date": "2026-06-08T05:19:36.364836+00:00",
         "nlp_objective": -185.4461,
         "mcp_objective": -185.446,
         "absolute_difference": 0.00010000000000331966,
@@ -11239,22 +11228,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:10:06.699026+00:00",
+        "parse_date": "2026-06-08T05:19:40.078690+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.8447,
+        "parse_time_seconds": 3.7111,
         "variables_count": 3,
         "equations_count": 4
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:10:14.339693+00:00",
+        "translate_date": "2026-06-08T05:19:48.993523+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 7.6298,
+        "translate_time_seconds": 8.9049,
         "output_file": "data/gamslib/mcp/srkandw_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:10:15.397253+00:00",
+        "solve_date": "2026-06-08T05:19:52.203993+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11262,13 +11251,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 195.0,
-        "solve_time_seconds": 1.0247,
+        "solve_time_seconds": 3.1745,
         "iterations": 13,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:10:15.397545+00:00",
+        "comparison_date": "2026-06-08T05:19:52.204258+00:00",
         "nlp_objective": 2613.0,
         "mcp_objective": 195.0,
         "absolute_difference": 2418.0,
@@ -11315,22 +11304,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:10:16.382296+00:00",
+        "parse_date": "2026-06-08T05:19:53.055660+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.9838,
+        "parse_time_seconds": 0.8485,
         "variables_count": 2,
         "equations_count": 2
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:10:49.816662+00:00",
+        "translate_date": "2026-06-08T05:20:20.399280+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 33.4223,
+        "translate_time_seconds": 27.3304,
         "output_file": "data/gamslib/mcp/sroute_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:10:50.499912+00:00",
+        "solve_date": "2026-06-08T05:20:20.915399+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -11338,7 +11327,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.6612,
+        "solve_time_seconds": 0.4974,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -11348,7 +11337,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:10:50.500147+00:00",
+        "comparison_date": "2026-06-08T05:20:20.915529+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -11382,30 +11371,41 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:10:52.185966+00:00",
+        "parse_date": "2026-06-08T05:20:22.363747+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.6837,
+        "parse_time_seconds": 1.4459,
         "variables_count": 3,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
-        "status": "failure",
-        "translate_date": "2026-06-06T18:20:52.384566+00:00",
+        "status": "success",
+        "translate_date": "2026-06-08T05:20:27.226458+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.1631,
-        "error": {
-          "category": "timeout",
-          "message": "Translation timeout after 600 seconds"
-        }
+        "translate_time_seconds": 4.8536,
+        "output_file": "data/gamslib/mcp/srpchase_mcp.gms"
       },
       "mcp_solve": {
-        "status": "not_tested",
-        "solve_date": "2026-06-06T18:20:52.470366+00:00"
+        "status": "failure",
+        "solve_date": "2026-06-08T05:20:28.223508+00:00",
+        "solver": "PATH",
+        "solver_version": null,
+        "solver_status": null,
+        "solver_status_text": null,
+        "model_status": null,
+        "model_status_text": null,
+        "objective_value": null,
+        "solve_time_seconds": 0.9654,
+        "iterations": null,
+        "outcome_category": "path_solve_license",
+        "error": {
+          "category": "path_solve_license",
+          "message": "Parse error: license_limit"
+        }
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:20:52.470366+00:00",
-        "notes": "Skipped due to translate failure"
+        "comparison_date": "2026-06-08T05:20:28.223743+00:00",
+        "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
         "variables": 3,
@@ -11438,22 +11438,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:21:06.342778+00:00",
+        "parse_date": "2026-06-08T05:20:43.365921+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 13.8667,
+        "parse_time_seconds": 15.1407,
         "variables_count": 25,
         "equations_count": 25
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:21:22.545061+00:00",
+        "translate_date": "2026-06-08T05:20:59.943633+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 16.1944,
+        "translate_time_seconds": 16.5614,
         "output_file": "data/gamslib/mcp/stdcge_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:21:24.131541+00:00",
+        "solve_date": "2026-06-08T05:21:01.072312+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11461,13 +11461,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 25.508,
-        "solve_time_seconds": 1.5483,
+        "solve_time_seconds": 1.0946,
         "iterations": 4,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:21:24.131727+00:00",
+        "comparison_date": "2026-06-08T05:21:01.072482+00:00",
         "nlp_objective": 26.0926,
         "mcp_objective": 25.508,
         "absolute_difference": 0.5846000000000018,
@@ -11535,22 +11535,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:21:29.627120+00:00",
+        "parse_date": "2026-06-08T05:21:06.014132+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 5.4947,
+        "parse_time_seconds": 4.9401,
         "variables_count": 8,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:24:43.179561+00:00",
+        "translate_date": "2026-06-08T05:24:26.923545+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 193.5376,
+        "translate_time_seconds": 200.8749,
         "output_file": "data/gamslib/mcp/tabora_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:24:43.914290+00:00",
+        "solve_date": "2026-06-08T05:24:27.753960+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -11558,7 +11558,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.7073,
+        "solve_time_seconds": 0.6986,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -11568,7 +11568,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:24:43.914489+00:00",
+        "comparison_date": "2026-06-08T05:24:27.756492+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -11602,22 +11602,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:24:52.222077+00:00",
+        "parse_date": "2026-06-08T05:24:42.859223+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 8.305,
+        "parse_time_seconds": 15.0914,
         "variables_count": 12,
         "equations_count": 16
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:26:22.303570+00:00",
+        "translate_date": "2026-06-08T05:26:03.187975+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 90.0602,
+        "translate_time_seconds": 80.3033,
         "output_file": "data/gamslib/mcp/tfordy_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:26:23.176424+00:00",
+        "solve_date": "2026-06-08T05:26:03.829410+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -11625,7 +11625,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 0.8396,
+        "solve_time_seconds": 0.547,
         "iterations": null,
         "outcome_category": "path_solve_license",
         "error": {
@@ -11635,7 +11635,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:26:23.176606+00:00",
+        "comparison_date": "2026-06-08T05:26:03.832632+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -11669,22 +11669,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:26:26.772649+00:00",
+        "parse_date": "2026-06-08T05:26:08.498455+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.5934,
+        "parse_time_seconds": 4.6605,
         "variables_count": 11,
         "equations_count": 10
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:26:32.934661+00:00",
+        "translate_date": "2026-06-08T05:26:13.236007+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 6.1556,
+        "translate_time_seconds": 4.7278,
         "output_file": "data/gamslib/mcp/tforss_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:26:34.084615+00:00",
+        "solve_date": "2026-06-08T05:26:14.069161+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11692,13 +11692,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 32970.342,
-        "solve_time_seconds": 1.1136,
+        "solve_time_seconds": 0.7976,
         "iterations": 201,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:26:34.084858+00:00",
+        "comparison_date": "2026-06-08T05:26:14.069345+00:00",
         "nlp_objective": 2177.796,
         "mcp_objective": 32970.342,
         "absolute_difference": 30792.546,
@@ -11787,22 +11787,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:26:37.156680+00:00",
+        "parse_date": "2026-06-08T05:26:16.901603+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 2.9541,
+        "parse_time_seconds": 2.7529,
         "variables_count": 6,
         "equations_count": 3
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:27:12.403754+00:00",
+        "translate_date": "2026-06-08T05:26:42.191695+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 35.2341,
+        "translate_time_seconds": 25.2803,
         "output_file": "data/gamslib/mcp/tricp_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:27:13.853246+00:00",
+        "solve_date": "2026-06-08T05:26:43.145350+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -11810,7 +11810,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 1.3871,
+        "solve_time_seconds": 0.9101,
         "iterations": null,
         "outcome_category": "path_solve_terminated",
         "error": {
@@ -11820,7 +11820,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:27:13.853448+00:00",
+        "comparison_date": "2026-06-08T05:26:43.145565+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -11854,9 +11854,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:27:14.603512+00:00",
+        "parse_date": "2026-06-08T05:26:43.627978+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 0.747,
+        "parse_time_seconds": 0.4799,
         "variables_count": 2,
         "equations_count": 2
       },
@@ -11868,14 +11868,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:27:18.109660+00:00",
+        "translate_date": "2026-06-08T05:26:46.655129+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.4835,
+        "translate_time_seconds": 3.0167,
         "output_file": "data/gamslib/mcp/trig_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:27:19.339183+00:00",
+        "solve_date": "2026-06-08T05:26:47.635379+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -11883,13 +11883,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.23,
-        "solve_time_seconds": 1.207,
+        "solve_time_seconds": 0.9505,
         "iterations": 3,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:27:19.339375+00:00",
+        "comparison_date": "2026-06-08T05:26:47.635579+00:00",
         "nlp_objective": 0.0,
         "mcp_objective": 0.23,
         "absolute_difference": 0.23,
@@ -11982,9 +11982,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:27:20.416148+00:00",
+        "parse_date": "2026-06-08T05:26:48.304886+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.0763,
+        "parse_time_seconds": 0.6674,
         "variables_count": 2,
         "equations_count": 3
       },
@@ -11996,14 +11996,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:27:24.215565+00:00",
+        "translate_date": "2026-06-08T05:26:52.024114+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 3.7913,
+        "translate_time_seconds": 3.6832,
         "output_file": "data/gamslib/mcp/trnsport_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:27:25.291382+00:00",
+        "solve_date": "2026-06-08T05:26:53.026753+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12011,13 +12011,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 153.675,
-        "solve_time_seconds": 1.0407,
+        "solve_time_seconds": 0.9709,
         "iterations": 30,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:27:25.291641+00:00",
+        "comparison_date": "2026-06-08T05:26:53.027249+00:00",
         "nlp_objective": 153.675,
         "mcp_objective": 153.675,
         "absolute_difference": 0.0,
@@ -12126,9 +12126,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:27:27.191347+00:00",
+        "parse_date": "2026-06-08T05:26:54.303354+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.899,
+        "parse_time_seconds": 1.2731,
         "variables_count": 5,
         "equations_count": 5
       },
@@ -12140,14 +12140,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:27:31.578468+00:00",
+        "translate_date": "2026-06-08T05:26:58.627392+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 4.3814,
+        "translate_time_seconds": 4.3165,
         "output_file": "data/gamslib/mcp/trussm_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:27:32.848693+00:00",
+        "solve_date": "2026-06-08T05:26:59.898887+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12155,13 +12155,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 0.45,
-        "solve_time_seconds": 1.2327,
+        "solve_time_seconds": 1.2387,
         "iterations": 340,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:27:32.849165+00:00",
+        "comparison_date": "2026-06-08T05:26:59.899113+00:00",
         "nlp_objective": 0.4499,
         "mcp_objective": 0.45,
         "absolute_difference": 9.999999999998899e-05,
@@ -12202,22 +12202,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:29:37.032144+00:00",
+        "parse_date": "2026-06-08T05:29:28.640550+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 124.1778,
+        "parse_time_seconds": 148.7345,
         "variables_count": 31,
         "equations_count": 35
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:32:22.699437+00:00",
+        "translate_date": "2026-06-08T05:32:09.459308+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 165.6514,
+        "translate_time_seconds": 160.7769,
         "output_file": "data/gamslib/mcp/turkey_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:32:23.949306+00:00",
+        "solve_date": "2026-06-08T05:32:10.175684+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -12225,7 +12225,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 1.2015,
+        "solve_time_seconds": 0.5802,
         "iterations": null,
         "outcome_category": "path_syntax_error",
         "error": {
@@ -12235,7 +12235,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:32:23.950216+00:00",
+        "comparison_date": "2026-06-08T05:32:10.176015+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -12269,30 +12269,41 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:32:43.980381+00:00",
+        "parse_date": "2026-06-08T05:32:40.729714+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 20.0279,
+        "parse_time_seconds": 30.5451,
         "variables_count": 8,
         "equations_count": 11
       },
       "nlp2mcp_translate": {
-        "status": "failure",
-        "translate_date": "2026-06-06T18:42:44.111184+00:00",
+        "status": "success",
+        "translate_date": "2026-06-08T05:40:40.791301+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 600.0988,
-        "error": {
-          "category": "timeout",
-          "message": "Translation timeout after 600 seconds"
-        }
+        "translate_time_seconds": 481.1262,
+        "output_file": "data/gamslib/mcp/turkpow_mcp.gms"
       },
       "mcp_solve": {
-        "status": "not_tested",
-        "solve_date": "2026-06-06T18:42:44.257987+00:00"
+        "status": "failure",
+        "solve_date": "2026-06-08T05:40:42.254265+00:00",
+        "solver": "PATH",
+        "solver_version": null,
+        "solver_status": null,
+        "solver_status_text": null,
+        "model_status": null,
+        "model_status_text": null,
+        "objective_value": null,
+        "solve_time_seconds": 1.1852,
+        "iterations": null,
+        "outcome_category": "path_syntax_error",
+        "error": {
+          "category": "path_syntax_error",
+          "message": "Parse error: compilation_error"
+        }
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:42:44.257987+00:00",
-        "notes": "Skipped due to translate failure"
+        "comparison_date": "2026-06-08T05:40:42.255100+00:00",
+        "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
         "variables": 8,
@@ -12325,22 +12336,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:43:08.844327+00:00",
+        "parse_date": "2026-06-08T05:41:05.150609+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 24.5666,
+        "parse_time_seconds": 22.8611,
         "variables_count": 28,
         "equations_count": 28
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:43:39.220228+00:00",
+        "translate_date": "2026-06-08T05:41:35.910861+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 30.3677,
+        "translate_time_seconds": 30.7448,
         "output_file": "data/gamslib/mcp/twocge_mcp.gms"
       },
       "mcp_solve": {
         "status": "failure",
-        "solve_date": "2026-06-06T18:43:40.380659+00:00",
+        "solve_date": "2026-06-08T05:41:36.989302+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": null,
@@ -12348,7 +12359,7 @@
         "model_status": null,
         "model_status_text": null,
         "objective_value": null,
-        "solve_time_seconds": 1.0831,
+        "solve_time_seconds": 1.025,
         "iterations": null,
         "outcome_category": "path_solve_terminated",
         "error": {
@@ -12358,7 +12369,7 @@
       },
       "solution_comparison": {
         "comparison_status": "not_tested",
-        "comparison_date": "2026-06-06T18:43:40.380872+00:00",
+        "comparison_date": "2026-06-08T05:41:36.989535+00:00",
         "notes": "Skipped due to solve failure"
       },
       "model_statistics": {
@@ -12392,22 +12403,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:43:44.190109+00:00",
+        "parse_date": "2026-06-08T05:41:40.891715+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 3.8066,
+        "parse_time_seconds": 3.8964,
         "variables_count": 6,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:43:54.418093+00:00",
+        "translate_date": "2026-06-08T05:41:47.966925+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 10.2173,
+        "translate_time_seconds": 7.0534,
         "output_file": "data/gamslib/mcp/uimp_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:43:56.564634+00:00",
+        "solve_date": "2026-06-08T05:41:50.986520+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12415,13 +12426,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1571.048,
-        "solve_time_seconds": 2.0765,
+        "solve_time_seconds": 2.9881,
         "iterations": 715,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:43:56.564877+00:00",
+        "comparison_date": "2026-06-08T05:41:50.986847+00:00",
         "nlp_objective": 1571.0476,
         "mcp_objective": 1571.048,
         "absolute_difference": 0.0003999999998995918,
@@ -12468,22 +12479,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:43:57.781458+00:00",
+        "parse_date": "2026-06-08T05:41:52.098427+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.2144,
+        "parse_time_seconds": 1.1089,
         "variables_count": 6,
         "equations_count": 6
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:44:03.085994+00:00",
+        "translate_date": "2026-06-08T05:41:56.978742+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.2749,
+        "translate_time_seconds": 4.8598,
         "output_file": "data/gamslib/mcp/wall_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:44:05.124511+00:00",
+        "solve_date": "2026-06-08T05:41:58.764774+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12491,13 +12502,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1.0,
-        "solve_time_seconds": 2.0017,
+        "solve_time_seconds": 1.7527,
         "iterations": 1,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:44:05.124739+00:00",
+        "comparison_date": "2026-06-08T05:41:58.765098+00:00",
         "nlp_objective": 1.0,
         "mcp_objective": 1.0,
         "absolute_difference": 0.0,
@@ -12544,22 +12555,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:44:25.839346+00:00",
+        "parse_date": "2026-06-08T05:42:15.365154+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 20.7131,
+        "parse_time_seconds": 16.598,
         "variables_count": 3,
         "equations_count": 5
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:44:52.626698+00:00",
+        "translate_date": "2026-06-08T05:42:40.552105+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 26.7724,
+        "translate_time_seconds": 25.1691,
         "output_file": "data/gamslib/mcp/weapons_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:44:54.290495+00:00",
+        "solve_date": "2026-06-08T05:42:45.459925+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12567,13 +12578,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 1700.397,
-        "solve_time_seconds": 1.6109,
+        "solve_time_seconds": 4.7929,
         "iterations": 24,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:44:54.290744+00:00",
+        "comparison_date": "2026-06-08T05:42:45.460274+00:00",
         "nlp_objective": 1735.5696,
         "mcp_objective": 1700.397,
         "absolute_difference": 35.1726000000001,
@@ -12620,9 +12631,9 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:44:55.509519+00:00",
+        "parse_date": "2026-06-08T05:42:46.499064+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 1.0691,
+        "parse_time_seconds": 0.84,
         "variables_count": 4,
         "equations_count": 2
       },
@@ -12634,14 +12645,14 @@
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:45:01.149399+00:00",
+        "translate_date": "2026-06-08T05:42:52.336175+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 5.6225,
+        "translate_time_seconds": 5.8095,
         "output_file": "data/gamslib/mcp/whouse_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:45:02.829751+00:00",
+        "solve_date": "2026-06-08T05:42:54.077132+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12649,13 +12660,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": -600.0,
-        "solve_time_seconds": 1.5883,
+        "solve_time_seconds": 1.6966,
         "iterations": 8,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "match",
-        "comparison_date": "2026-06-06T18:45:02.830010+00:00",
+        "comparison_date": "2026-06-08T05:42:54.077375+00:00",
         "nlp_objective": -600.0,
         "mcp_objective": -600.0,
         "absolute_difference": 0.0,
@@ -12696,22 +12707,22 @@
       },
       "nlp2mcp_parse": {
         "status": "success",
-        "parse_date": "2026-06-06T18:45:08.089617+00:00",
+        "parse_date": "2026-06-08T05:42:59.379496+00:00",
         "nlp2mcp_version": "1.1.0",
-        "parse_time_seconds": 5.2581,
+        "parse_time_seconds": 5.2999,
         "variables_count": 8,
         "equations_count": 6
       },
       "nlp2mcp_translate": {
         "status": "success",
-        "translate_date": "2026-06-06T18:45:19.013613+00:00",
+        "translate_date": "2026-06-08T05:43:09.676198+00:00",
         "nlp2mcp_version": "1.1.0",
-        "translate_time_seconds": 10.907,
+        "translate_time_seconds": 10.2827,
         "output_file": "data/gamslib/mcp/worst_mcp.gms"
       },
       "mcp_solve": {
         "status": "success",
-        "solve_date": "2026-06-06T18:45:20.505821+00:00",
+        "solve_date": "2026-06-08T05:43:11.410506+00:00",
         "solver": "PATH",
         "solver_version": null,
         "solver_status": 1,
@@ -12719,13 +12730,13 @@
         "model_status": 1,
         "model_status_text": "Optimal",
         "objective_value": 20800200.0,
-        "solve_time_seconds": 1.4298,
+        "solve_time_seconds": 1.6926,
         "iterations": 92,
         "outcome_category": "model_optimal"
       },
       "solution_comparison": {
         "comparison_status": "mismatch",
-        "comparison_date": "2026-06-06T18:45:20.506099+00:00",
+        "comparison_date": "2026-06-08T05:43:11.410748+00:00",
         "nlp_objective": 20941621.7948,
         "mcp_objective": 20800200.0,
         "absolute_difference": 141421.7947999984,

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -28,12 +28,12 @@ Filled in at each checkpoint (Days 5, 10, 13). Track delta vs Day 0 baseline.
 
 | Metric | Day 0 baseline | Day 5 (Checkpoint 1) | Day 10 (Checkpoint 2) | Day 13 (Final) | Target |
 |---|---|---|---|---|---|
-| Parse success | 142/142 | TBD | TBD | TBD | ≥ 142/142 |
-| Translate success | 131/142 | TBD | TBD | TBD | ≥ 135/142 |
-| Solve success | 103/142 | TBD | TBD | TBD | ≥ 111/142 |
-| Solution match | 59/142 | TBD | TBD | TBD | ≥ 66/142 |
-| path_syntax_error | 14 | TBD | TBD | TBD | ≤ 6 |
-| path_solve_terminated | 5 | TBD | TBD | TBD | ≤ 5 (maintain) |
+| Parse success | 142/142 | 142/142 | 142/142 | TBD | ≥ 142/142 |
+| Translate success | 131/142 | 132/142 | 133/142 | TBD | ≥ 135/142 |
+| Solve success | 103/142 | 105/142 | 105/142 | TBD | ≥ 111/142 |
+| Solution match | 59/142 | 61/142 | 62/142 | TBD | ≥ 66/142 |
+| path_syntax_error | 14 | 9 | 7 | TBD | ≤ 6 |
+| path_solve_terminated | 5 | 5 | 5 | TBD | ≤ 5 (maintain) |
 | model_infeasible | 4 | TBD | TBD | TBD | ≤ 3 |
 | Tests passing | 4,737 | TBD | TBD | TBD | ≥ 4,750 |
 | Determinism (3 `PYTHONHASHSEED`) | n/a | n/a | n/a | TBD | byte-identical |
@@ -444,39 +444,60 @@ Day 6 is **gated on the Day 5 #1390 re-scoped Phase 0**, which returned **re-REP
 
 ---
 
-## Day 10 — Checkpoint 2: Pipeline Retest + Priority 4 close + Priority 7 #1387 implement
+## Day 10 — Checkpoint 2: full pipeline retest (Solve 105 / Match 62; no regression, gap = Sprint 28 deferrals)
 
-**Date:** TBD
-**Status:** 🔵 NOT STARTED
-**Hours budgeted:** ≤ 10
-**Hours actual:** —
+**Date:** 2026-06-08
+**Status:** 🟢 DONE — full 142-model retest complete. **Solve 105/142, Match 62/142**, both **below the optimistic targets (≥108 / ≥65) by exactly the Sprint 28 deferrals** (camcge, otpop, fawley — all `model_infeasible`). **No silent regression**: the Solve-success and Match sets are byte-identical to the committed (Day-9) DB.
 
-### Checkpoint 2 metrics (from full pipeline retest)
-| Metric | Day 0 | Day 5 | Day 10 | Δ Day 0 → Day 10 |
-|---|---|---|---|---|
-| Solve | 103 | TBD | TBD | TBD |
-| Match | 59 | TBD | TBD | TBD |
-| path_syntax_error | 14 | TBD | TBD | TBD |
-| Translate | 131 | TBD | TBD | TBD |
-| Tests | 4,737 | TBD | TBD | TBD |
+### Adjusted scope (vs the prompt)
+- **Task 4 (Priority 4 close) — done.** PR #1422 (launch #1378) merged.
+- **Task 5 (merge P7 #1387) — N/A.** #1387 was never implemented (Day 6 diagnosed + reverted → Sprint 28 carryforward, filed Day 8). No PR to merge.
+- Day 10 = PR22 audit + full pipeline retest + this checkpoint entry.
 
-### PR22 audit-script Day 10 output
-_(paste `/tmp/sprint27_day10_retest.md` here)_
+### Checkpoint 2 metrics (full pipeline retest, all 142 models)
+| Metric | Day 0 | Day 5 | Day 10 | CP2 target | Δ Day 0 → Day 10 |
+|---|---|---|---|---|---|
+| Parse | 142 | 142 | **142** | — | +0 |
+| Translate | 131 | 132 | **133** | — | +2 |
+| Solve | 103 | 105 | **105** | ≥ 108 | **+2** (miss −3) |
+| Match | 59 | 61 | **62** | ≥ 65 | **+3** (miss −3) |
+| path_syntax_error | 14 | 9 | **7** | ≤ 6 | −7 (miss −1) |
+| path_solve_terminated | 5 | 5 | **5** | ≤ 5 | +0 (met) |
 
-### Bucket-provenance updates
-_(table)_
+Solve-failure bucket reconciliation (133 translated = 105 solved + 28 failed): `path_solve_license` 9 · `model_infeasible` 7 · `path_syntax_error` 7 · `path_solve_terminated` 5.
+
+### No-regression verification (the prompt's "investigate if Match=62" gate)
+Compared the retest DB against the committed (Day-9) `gamslib_status.json`:
+- **Match set: identical** (62 = 62; 0 gained, 0 lost). **Solve-success set: identical** (0 gained, 0 lost).
+- The only deltas are **reclassifications within the failure set** (this is the first full re-solve since Day 5, refreshing stale buckets): `path_syntax_error` 9 → 7, `model_infeasible` 5 → 7, `path_solve_license` 8 → 9. None of these moved a model out of Solve/Match.
+- **Conclusion: the 62 is NOT a silent recovery failure.** The realized firm Match gains are exactly `qdemo7` (#1398, Day 5) + `cesam2` (#1381, Day 4) + `launch` (#1378, Day 9) = baseline 59 **+3 = 62**. The Day-0 "+6 firm" projection assumed `fawley` (#1356), `otpop` (#1357), and a second `#1381` model (`camcge`) would also deliver Match — but all three went **`model_infeasible`** (documented Days 4–5: forward bucket moves needing the deferred #1393+#1335 / the CGE singular-Jacobian degeneracy). Same story for Solve: realized firm gains = `qdemo7` + `cesam2` = +2 → 105; the other 3 projected solves are the deferred infeasibles.
+
+### Named non-success buckets (Day 10)
+- **Match (62):** baseline 59 + qdemo7 + cesam2 + launch.
+- **model_infeasible (7):** agreste, **camcge**, camshape, cesam, **fawley**, lnts, **otpop** — bold = Sprint 28 carryforward Solve/Match targets (#1393+#1335, CGE degeneracy).
+- **path_syntax_error (7):** clearlak, dinam, gangesx, indus, sample, turkey, turkpow — pre-existing (non-#1398; turkpow byte-identical to baseline per Day-5 notes).
+- **path_solve_license (9):** egypt, ferts, glider, robot, shale, sroute, srpchase, tabora, tfordy (license-limited, not a translation defect).
+- **path_solve_terminated (5):** dyncge, elec, maxmin, tricp, twocge.
+
+### PR22 audit-script Day 10 output (`scripts/sprint_audit/changed_emit_artifacts.py --since-commit 148662a5 --mode retest`)
+- **Range:** `148662a5cfba..HEAD` — **11 commits, 54 emit changes (36 unique `*_mcp.gms` paths).**
+- Changed emit artifacts (P1 #1398 + P2 #1381 + P5 #1356/#1357 + P4 #1378 sweep): abel, agreste(+presolve), camcge, cesam, cesam2, dinam, dyncge, egypt, fawley, feasopt1, ferts, ganges, gangesx, iobalance, irscge, korcge, **launch_mcp_presolve**, lrgcge, markov, meanvar, moncge, orani, otpop, ps10_s, ps2_f_s, ps2_s, ps3_s(+gic/mn/scp), qdemo7, quocge, shale, srpchase, stdcge. Full per-commit table: `/tmp/sprint27_day10_retest.md`.
 
 ### Tasks completed
-- _(to be filled in)_
+- Full 142-model pipeline retest (`run_full_test.py`) — refreshed `gamslib_status.json` (authoritative Checkpoint 2 state); determinism confirmed (Solve/Match sets byte-identical to committed).
+- PR22 audit-script invocation (above).
+- This checkpoint entry.
 
 ### Deliverables
-- _(to be filled in)_
+- `data/gamslib/gamslib_status.json` (refreshed Checkpoint 2 DB). Docs-only otherwise (no `src/` change → no quality-gate run; the retest IS the verification).
 
 ### KUs verified
-- _(to be filled in)_
+- Checkpoint 2 confirms the realized Solve/Match deltas (+2 / +3) match the landed work; the gap to target is the recorded Sprint 28 deferrals (#1390, #1393+#1335, #1387) — per PLAN §17, Match 62 (target-minus-3, all deferral-attributable) is recorded, not treated as a regression.
 
 ### Carryforward to Day 11
-- _(to be filled in)_
+- **Sprint 28 carryforwards (Solve/Match-bearing):** #1393+#1335 (otpop/camcge/cesam infeasible), #1390 (kand), #1387 (cclinpts), + camcge CGE singular-Jacobian degeneracy. These are the Solve 105→108 / Match 62→65 gap.
+- Per PLAN §11: Priority 7 #1388 discriminator + Priority 6 #1224 start. (#1387 already → Sprint 28.)
+- **Pre-existing `*_mcp_presolve.gms` golden staleness** (cesam/fawley/korcge) noted Day 9 — still candidate housekeeping, not gating.
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -34,8 +34,8 @@ Filled in at each checkpoint (Days 5, 10, 13). Track delta vs Day 0 baseline.
 | Solution match | 59/142 | 61/142 | 62/142 | TBD | ≥ 66/142 |
 | path_syntax_error | 14 | 9 | 7 | TBD | ≤ 6 |
 | path_solve_terminated | 5 | 5 | 5 | TBD | ≤ 5 (maintain) |
-| model_infeasible | 4 | TBD | TBD | TBD | ≤ 3 |
-| Tests passing | 4,737 | TBD | TBD | TBD | ≥ 4,750 |
+| model_infeasible | 4 | 5 | 7 | TBD | ≤ 3 |
+| Tests passing | 4,737 | 4,758 | 4,768 | TBD | ≥ 4,750 |
 | Determinism (3 `PYTHONHASHSEED`) | n/a | n/a | n/a | TBD | byte-identical |
 
 ---


### PR DESCRIPTION
## Summary

Mid-sprint **Checkpoint 2** (per PR6): full 142-model pipeline retest refreshing the status DB, plus the SPRINT_LOG checkpoint entry. No `src/` changes — measurement only.

## Checkpoint 2 metrics (142 corpus)

| Metric | Day 0 | Day 5 | **Day 10** | CP2 target |
|---|---|---|---|---|
| Parse | 142 | 142 | **142** | — |
| Translate | 131 | 132 | **133** | — |
| Solve | 103 | 105 | **105** | ≥ 108 |
| Match | 59 | 61 | **62** | ≥ 65 |
| path_syntax_error | 14 | 9 | **7** | ≤ 6 |
| path_solve_terminated | 5 | 5 | **5** | ≤ 5 ✅ |

Solve-failure reconciliation (133 translated = 105 solved + 28 failed): `path_solve_license` 9 · `model_infeasible` 7 · `path_syntax_error` 7 · `path_solve_terminated` 5.

## No silent regression (the prompt's "investigate if Match=62" gate)

Compared the retest DB to the committed (Day-9) DB:
- **Match set identical** (62 = 62, 0 gained / 0 lost); **Solve-success set identical**.
- Only deltas are reclassifications *within* the failure set (first full re-solve since Day 5 refreshing stale buckets: `path_syntax_error` 9→7, `model_infeasible` 5→7, `path_solve_license` 8→9) — none move a model out of Solve/Match.

**Match 62 is fully attributable, not a silent failure.** Realized firm gains = `qdemo7` (#1398) + `cesam2` (#1381) + `launch` (#1378) = baseline 59 **+3**. The Day-0 "+6 firm" projection assumed `fawley` (#1356), `otpop` (#1357), and a second `#1381` model (`camcge`) would also deliver, but all three went **`model_infeasible`** (documented Days 4–5 → Sprint 28 deferrals: #1393+#1335 and the CGE singular-Jacobian degeneracy). Same story for Solve (+2 → 105). The gap to target is exactly the deferred work.

## Scope notes
- **Task 4 (Priority 4 close)** done via PR #1422 (launch #1378 → match).
- **Task 5 (merge P7 #1387)** N/A — #1387 was never implemented (Day 6 diagnosed + reverted → Sprint 28 carryforward).
- Incidental golden regenerations from the retest (`dinam_mcp.gms`, `fawley`/`otpop` `_mcp_presolve.gms`) were **reverted** — a checkpoint measures, it doesn't sweep goldens; those are pre-existing staleness + #1378 presolve side-effects on non-match models (carryforward housekeeping).

## Test plan
- Docs + DB measurement only; the full pipeline retest *is* the verification. No `src/` change → no quality-gate run required.