### PR TITLE
Sprint 27 Day 12 (#1224): render parameter-valued index offsets; mine → +1 Translate

### DIFF
--- a/docs/issues/ISSUE_1224_mine-paramref-index-offset-unsupported.md
+++ b/docs/issues/ISSUE_1224_mine-paramref-index-offset-unsupported.md
@@ -1,11 +1,58 @@
 # mine: Parameter-Valued Index Offsets Unsupported
 
 **GitHub Issue:** [#1224](https://github.com/jeffreyhorn/nlp2mcp/issues/1224)
-**Status:** OPEN — Translation failure (unsupported offset expression)
+**Status:** TRANSLATE FIXED (Sprint 27 Day 12, 2026-06-08) — mine now translates + compiles clean (+1 Translate). Correct SOLVE (the parameter-valued-offset KKT cross-term) is DEFERRED to Sprint 28; mine's next failure mode is `model_infeasible` (see below).
 **Severity:** Medium — Translation aborts with internal error
 **Date:** 2026-04-07
-**Last Updated:** 2026-04-07
+**Last Updated:** 2026-06-08 (Sprint 27 Day 12 — emit-render fix lands +1 Translate; Solve cross-term → Sprint 28)
 **Affected Models:** mine
+
+---
+
+## Sprint 27 Day 12 resolution (2026-06-08) — emit-render fix → +1 Translate; Solve → Sprint 28
+
+**Corrected fix surface (NOT the prep-doc guess).** The Day-11/Day-12 prompt + KU 6.1 anticipated the fix at `src/ad/constraint_jacobian.py:_try_eval_offset:133` + `src/ad/derivative_rules.py:2793` (the AD/Jacobian path, evaluating the offset to a constant). Empirically that is wrong for mine: the `pr` equation is kept **symbolic over `k`** in the MCP, so its complementarity `comp_pr(k,l,i,j)` is emitted with `k` unbound — the offset `li(k)` can NEVER be reduced to a constant at emit time. The hard error is raised in **`src/ir/ast.py` `IndexOffset.to_gams_string()`** (the `else` branch), NOT in the AD layer (translation reaches the emit phase before crashing).
+
+**Fix (Approach 2, minimal): render parameter-valued offsets.** GAMS natively accepts a parameter expression as a lead/lag amount and evaluates it at runtime (`x(l, i+li(k), j+lj(k))` is valid GAMS). So `IndexOffset.to_gams_string()` gains a `ParamRef` branch that renders `base+param(idx)` (mirroring the existing `Call` branch; `_offset_expr_to_string` already knew how to render a `ParamRef`). No enumeration/constant-evaluation needed; `k` stays symbolic.
+
+- **Result:** mine emits `comp_pr(k,l,i,j)$(...).. x(l,i+li(k),j+lj(k)) - x(l+1,i,j) =G= 0;`, translates, and **compiles clean** (`action=c`, 0 errors). **+1 Translate** (`translate_internal_error` → `translate_success`).
+- **Blast radius: additive / zero-regression.** The `ParamRef` branch only fires where `to_gams_string()` previously *raised*; any model that translates today has no parameter-valued offset (it would have crashed), so no translating model is affected.
+
+**KU 6.2 — mine's next failure mode: `model_infeasible`.** The emitted MCP solves to MODEL STATUS 4 Infeasible. The `stat_x(l,i,j)` cross-term from `pr` is incomplete: the Jacobian does not **invert** the parameter-valued offset (it emits `sum(k, lam_pr(k,l,i,j))` instead of `sum(k, lam_pr(k, l, i-li(k), j-lj(k)))`) and drops the `-sum(k, lam_pr(k, l-1, i, j))` contribution from the `-x(l+1,i,j)` term. Producing the correct stationarity for parameter-valued offsets requires the AD cross-term inversion at `src/ad/constraint_jacobian.py` / `src/ad/derivative_rules.py:2793` — the deeper change the prep doc named. **Deferred to Sprint 28** (the conditional Solve gain).
+
+## Phase 0: Acceptance Gate
+
+**Authored:** 2026-06-08 (Sprint 27 Day 12). The landed fix touches `src/ir/ast.py` only — outside the PR20-gated `src/{ad,kkt,emit}` set — so a Phase 0 gate is not strictly required, but recorded here for completeness.
+
+### Hand-Derived KKT Shape
+
+This fix is **emit-only** (string rendering); it does NOT change the KKT shape. The `pr` constraint `x(l, i+li(k), j+lj(k)) - x(l+1,i,j) ≥ 0 ⊥ lam_pr(k,l,i,j) ≥ 0` is preserved verbatim — only its GAMS *string* now renders the parameter-valued offset instead of crashing. (The *correct* `stat_x` cross-term — `sum(k, lam_pr(k,l,i-li(k),j-lj(k))) - sum(k, lam_pr(k,l-1,i,j))` — is the Sprint 28 Solve fix, NOT this PR.)
+
+### Expected Emit Pattern
+
+```gams
+comp_pr(k,l,i,j)$(...).. x(l,i+li(k),j+lj(k)) - x(l+1,i,j) =G= 0;
+```
+i.e. the lead/lag amount is the parameter expression `li(k)`/`lj(k)`, rendered as `base+param(idx)`. Constant offsets (`t+1`, `t-3`) and symbol offsets (`i+j`) render unchanged.
+
+### Verification Methodology
+
+```bash
+# 1. mine translates + compiles clean (was: "Complex offset expressions not yet supported").
+.venv/bin/python -m src.cli data/gamslib/raw/mine.gms -o /tmp/mine_mcp.gms --skip-convexity-check --quiet
+grep -E 'i\+li\(k\)|j\+lj\(k\)' /tmp/mine_mcp.gms            # expect: present in comp_pr
+gams /tmp/mine_mcp.gms a=c lo=2 | grep -cE '\*\*\*\* .*Error' # expect: 0
+
+# 2. Const/symbol offsets unchanged (unit test).
+.venv/bin/python -m pytest tests/unit/ir/test_index_offset_paramref.py -q
+
+# 3. mine's next failure mode (KU 6.2).
+gams /tmp/mine_mcp.gms lo=2 | grep 'MODEL STATUS'           # expect: 4 Infeasible (Sprint 28 Solve)
+```
+
+### PROCEED/REPLAN Signal
+
+**PROCEED** if: (a) mine translates + compiles clean (0 errors); (b) parameter-valued offsets render as `base+param(idx)`; (c) Const/symbol offset rendering unchanged (regression). **All met (Day 12).** **REPLAN** if any currently-translating model regresses (impossible by construction — the branch only fires where emit previously raised).
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/KNOWN_UNKNOWNS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/KNOWN_UNKNOWNS.md
@@ -1202,7 +1202,9 @@ Sprint planning + AD/KKT engineer
 
 ### Verification Results
 
-🔍 **Status:** INCOMPLETE
+✅ **Status:** VERIFIED (Sprint 27 Day 12, 2026-06-08) — **mine's next failure mode is `model_infeasible` (MODEL STATUS 4).**
+
+After the #1224 emit-render fix (`IndexOffset.to_gams_string()` renders parameter-valued offsets like `i+li(k)`), mine translates + compiles clean (**+1 Translate**) and solves to **MODEL STATUS 4 Infeasible**. Root cause of the infeasibility (the conditional Solve gain that does NOT land): the `stat_x` cross-term from the `pr` constraint does not invert the parameter-valued offset — it emits `sum(k, lam_pr(k,l,i,j))` instead of the correct `sum(k, lam_pr(k, l, i-li(k), j-lj(k)))`, and drops the `-sum(k, lam_pr(k, l-1, i, j))` term. Fixing the KKT cross-term for parameter-valued offsets (the AD/Jacobian path the prep doc named, `constraint_jacobian.py` / `derivative_rules.py:2793`) is **deferred to Sprint 28** (see ISSUE_1224 "Day 12 resolution"). The actual *translate* fix surface was `src/ir/ast.py` (emit render), NOT the AD layer the prep doc guessed.
 
 ---
 

--- a/docs/planning/EPIC_4/SPRINT_27/PLAN.md
+++ b/docs/planning/EPIC_4/SPRINT_27/PLAN.md
@@ -292,12 +292,16 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 
 ---
 
-## 13. Day 13 — Final Pipeline Retest + SPRINT_LOG.md + SPRINT_RETROSPECTIVE.md (~8h)
+## 13. Day 13 — Slipped #1400/#1374 + Final Pipeline Retest + SPRINT_LOG.md + SPRINT_RETROSPECTIVE.md (~8h, tight)
 
-**Focus:** Final checkpoint; close Sprint 27; author retrospective; record carryforwards for Sprint 28.
+**Focus:** Land the Day-12 slips (#1400, #1374); final checkpoint; close Sprint 27; author retrospective; record carryforwards for Sprint 28.
+
+> ⚠️ **Carryforward from Day 12 (2026-06-08):** **#1400 (Priority 8) and #1374 (Priority 9) were NOT done on Day 12** — Day 12 was consumed by the full #1224 implementation (itself carried from Day 11). They slip here. Do them **before** the final retest (so the retest reflects them — #1374 changes emit goldens; #1400 is scripts-only). Day 13 is now overcommitted (slips + retest + retrospective ≈ 13h): if time runs out, **#1374 is the slip valve — defer its remaining/all shapes to Sprint 28** (the plan already allows "#1374 remaining shapes → Sprint 28"); #1400 is small (scripts-only) and should land. The final retest + retrospective + SPRINT_LOG are non-negotiable (they close the sprint).
 
 | Task | Effort | Notes |
 |---|---|---|
+| **#1400 (Priority 8, slipped from Day 12) — pipeline absolute-path leak fix** at `scripts/gamslib/run_full_test.py:899` (`mcp_file_used`) | 2h | Scripts-only; do before the final retest. KU 8.1/8.2. Per `PROJECT_PLAN.md` Priority 8 |
+| **#1374 (Priority 9, slipped from Day 12) — emit duplicate-init audit** + targeted `src/emit/` fix for the most common 1–2 shapes | 3h | Changes emit goldens → must precede the final retest. **Slip valve: defer to Sprint 28 if Day 13 overruns.** KU 9.4 |
 | **Run PR22 audit script** (`--since-commit <Day-0 SHA>`) → final retest comparison surface | 0.5h | |
 | **Final pipeline retest** under 3 `PYTHONHASHSEED` values (PR12 determinism guard) | 3h | Determinism acceptance criterion verification |
 | Author Sprint 27 SPRINT_LOG.md final-day entry: headline metrics, bucket-provenance Sprint 26 final → Sprint 27 final, per-priority deliverables | 2h | |
@@ -305,6 +309,8 @@ Per `docs/planning/EPIC_4/SPRINT_27/BASELINE_METRICS.md` §2 — Sprint 27 Day 0
 | Buffer / Sprint 28 carryforward filings (issues that REPLANned or didn't fit budget) | 0.5h | Includes: #1385 cross-terms + #1393+#1335 (P3 re-plan); **dinam/gangesx/turkpow residual non-#1398 path_syntax_error** (Day 2 finding — pre-existing GAMS errors in non-Pattern-C equations, model-dependent codes; #1398 emit is correct but these models carry independent errors) |
 
 **Day 13 success criteria:**
+- [ ] **#1400 (slipped from Day 12) landed** — pipeline `mcp_file_used` no longer leaks absolute paths; KU 8.1/8.2 ✅.
+- [ ] **#1374 (slipped from Day 12) landed OR formally deferred to Sprint 28** (the slip valve) — audit recorded either way; KU 9.4 ✅.
 - [ ] All Sprint 27 acceptance criteria met OR explicitly carried forward to Sprint 28 with formal Phase 0 filing.
 - [ ] Final metrics: Solve ≥ 111, Match ≥ 66, path_syntax_error ≤ 6, model_infeasible ≤ 3, Translate ≥ 135/142, Parse ≥ 142/142, Tests ≥ 4,750.
 - [ ] Determinism: byte-identical `gamslib_status.json` under ≥ 3 `PYTHONHASHSEED` values (modulo wall-time).

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -556,7 +556,7 @@ Compared the retest DB against the committed (Day-9) `gamslib_status.json`:
 
 ### Deliverables
 - `src/ir/ast.py` (`IndexOffset.to_gams_string()` ParamRef branch).
-- `tests/unit/ir/test_index_offset_paramref.py` (4 tests: ParamRef renders, Const/symbol unchanged, circular ParamRef rejected, mine translates end-to-end).
+- `tests/unit/ir/test_index_offset_paramref.py` (5 tests: ParamRef lead renders, ParamRef lag `i-li(k)` renders, Const/symbol unchanged, circular ParamRef rejected, mine translates end-to-end).
 - `docs/issues/ISSUE_1224_*.md` (resolution + Phase 0 section); KNOWN_UNKNOWNS KU 6.2 ✅.
 
 ### KUs verified

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -541,32 +541,36 @@ Compared the retest DB against the committed (Day-9) `gamslib_status.json`:
 
 ---
 
-## Day 12 — Priority 6 close + Priority 8 #1400 + Priority 9 #1374
+## Day 12 — Priority 6 #1224 FULL (carried from Day 11): +1 Translate (mine); #1400/#1374 → Day 13
 
-**Date:** TBD
-**Status:** 🔵 NOT STARTED
+**Date:** 2026-06-08
+**Status:** 🟢 #1224 DONE (+1 Translate) — the non-negotiable Day-12 deliverable landed. **#1400 + #1374 slip to Day 13 buffer** per the PLAN §12 slip guidance (the #1224 carryforward consumed the day's budget).
 **Hours budgeted:** ≤ 10
-**Hours actual:** —
 
-### Tasks completed
-- _(to be filled in)_
+### #1224 mine — parameter-valued index offsets → +1 Translate (PR #TBD)
+- **Bug:** mine's `pr(k,l+1,i,j)$c(l,i,j).. x(l, i+li(k), j+lj(k)) =g= x(l+1,i,j)` uses parameter-valued offsets (`li(k)`/`lj(k)`). Translation aborted with `NotImplementedError: Complex offset expressions not yet supported: ParamRef(li(k))`.
+- **Corrected fix surface** (NOT the prep-doc guess `_try_eval_offset` / `derivative_rules.py:2793`): the `pr` complementarity is kept **symbolic over `k`**, so the offset can never reduce to a constant at emit; the hard error is in **`src/ir/ast.py` `IndexOffset.to_gams_string()`** (the emit phase, reached past AD). GAMS natively accepts a parameter lead/lag amount, so the fix adds a `ParamRef` branch rendering `base+li(k)` (mirrors the existing `Call` branch).
+- **Result: +1 Translate** — mine `translate_internal_error` → `translate_success`, **compiles clean** (`action=c`, 0 errors). **Additive / zero-regression** blast radius: the branch only fires where emit previously *raised*, so no currently-translating model is affected (none have parameter-valued offsets).
+- **KU 6.2 (next failure mode): `model_infeasible`.** The emitted MCP solves MS 4 Infeasible — `stat_x`'s `pr` cross-term doesn't invert the parameter-valued offset (`sum(k, lam_pr(k,l,i,j))` instead of `sum(k, lam_pr(k,l,i-li(k),j-lj(k)))`) and drops the `-sum(k, lam_pr(k,l-1,i,j))` term. The correct stationarity (the AD/Jacobian path the prep doc named) is the **conditional Solve gain → Sprint 28**.
+- KU 6.1 ✅ (STANDALONE confirmed — fix is `src/ir/ast.py`, no `index_mapping.py`/#1385 overlap). KU 6.2 ✅ VERIFIED (`model_infeasible`).
 
 ### Deliverables
-- _(to be filled in)_
+- `src/ir/ast.py` (`IndexOffset.to_gams_string()` ParamRef branch).
+- `tests/unit/ir/test_index_offset_paramref.py` (4 tests: ParamRef renders, Const/symbol unchanged, circular ParamRef rejected, mine translates end-to-end).
+- `docs/issues/ISSUE_1224_*.md` (resolution + Phase 0 section); KNOWN_UNKNOWNS KU 6.2 ✅.
 
 ### KUs verified
-- _(target: KUs 6.2, 8.1, 8.2, 9.4)_
+- **KU 6.1** ✅ (STANDALONE), **KU 6.2** ✅ (`model_infeasible` next failure mode).
 
 ### Carryforward to Day 13
-- _(to be filled in)_
+- **#1400 (Priority 8) + #1374 (Priority 9)** slip to Day 13 per the PLAN §12 slip guidance — Day 12 was the full-#1224 carryforward from Day 11.
+- **Sprint 28:** #1224 Solve (parameter-valued-offset KKT cross-term inversion), plus the prior carryforwards (#1390, #1393+#1335, #1387, #1388, camcge CGE).
 
 ### #1400 absolute-path-leak audit-grep result
-_(paste `grep -oE '"[^"]+": "/[^"]+"' data/gamslib/gamslib_status.json | sort -u` output)_
+_(deferred to Day 13)_
 
 ### #1374 corpus-sweep results
-- **Total models scanned:** TBD
-- **Models with duplicate-init pattern:** TBD
-- **Distinct shapes found:** TBD
+- _(deferred to Day 13)_
 - **Sprint 27 fix scope:** TBD shapes (most common)
 - **Sprint 28 carryforward:** TBD shapes
 

--- a/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_27/SPRINT_LOG.md
@@ -547,7 +547,7 @@ Compared the retest DB against the committed (Day-9) `gamslib_status.json`:
 **Status:** 🟢 #1224 DONE (+1 Translate) — the non-negotiable Day-12 deliverable landed. **#1400 + #1374 slip to Day 13 buffer** per the PLAN §12 slip guidance (the #1224 carryforward consumed the day's budget).
 **Hours budgeted:** ≤ 10
 
-### #1224 mine — parameter-valued index offsets → +1 Translate (PR #TBD)
+### #1224 mine — parameter-valued index offsets → +1 Translate (PR #1426)
 - **Bug:** mine's `pr(k,l+1,i,j)$c(l,i,j).. x(l, i+li(k), j+lj(k)) =g= x(l+1,i,j)` uses parameter-valued offsets (`li(k)`/`lj(k)`). Translation aborted with `NotImplementedError: Complex offset expressions not yet supported: ParamRef(li(k))`.
 - **Corrected fix surface** (NOT the prep-doc guess `_try_eval_offset` / `derivative_rules.py:2793`): the `pr` complementarity is kept **symbolic over `k`**, so the offset can never reduce to a constant at emit; the hard error is in **`src/ir/ast.py` `IndexOffset.to_gams_string()`** (the emit phase, reached past AD). GAMS natively accepts a parameter lead/lag amount, so the fix adds a `ParamRef` branch rendering `base+li(k)` (mirrors the existing `Call` branch).
 - **Result: +1 Translate** — mine `translate_internal_error` → `translate_success`, **compiles clean** (`action=c`, 0 errors). **Additive / zero-regression** blast radius: the branch only fires where emit previously *raised*, so no currently-translating model is affected (none have parameter-valued offsets).

--- a/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
+++ b/docs/planning/EPIC_4/SPRINT_27/prompts/PLAN_PROMPTS.md
@@ -395,16 +395,21 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 
 ---
 
-## Day 13 Prompt — Final Retest + SPRINT_LOG + SPRINT_RETROSPECTIVE (~8h)
+## Day 13 Prompt — Slipped #1400/#1374 + Final Retest + SPRINT_LOG + SPRINT_RETROSPECTIVE (~8h, tight)
 
-**Context:** Final pipeline retest under multiple `PYTHONHASHSEED` values. Author Sprint 27 SPRINT_LOG.md final-day entry + Sprint 27 SPRINT_RETROSPECTIVE.md. File Sprint 28 carryforwards.
+**Context:** **First land the Day-12 slips — #1400 (Priority 8) and #1374 (Priority 9), which were NOT done on Day 12** (Day 12 was consumed by the full #1224 carried from Day 11). Do them **before** the final retest (#1374 changes emit goldens; #1400 is scripts-only). Then run the final pipeline retest under multiple `PYTHONHASHSEED` values, author the Sprint 27 SPRINT_LOG.md final-day entry + SPRINT_RETROSPECTIVE.md, and file Sprint 28 carryforwards. **Day 13 is overcommitted** (slips + retest + retrospective ≈ 13h): if time runs out, **#1374 is the slip valve — formally defer its remaining/all shapes to Sprint 28**; #1400 is small and should land; the retest + retrospective + SPRINT_LOG close the sprint and are non-negotiable.
 
 **Read first:**
-- `docs/planning/EPIC_4/SPRINT_27/PLAN.md` §13 "Day 13"
+- `docs/planning/EPIC_4/SPRINT_27/PLAN.md` §13 "Day 13" (note the Day-12 carryforward callout)
+- `docs/planning/EPIC_4/PROJECT_PLAN.md` §"Sprint 27" §"Priority 8" (#1400 corrected scope — `scripts/gamslib/run_full_test.py:899` `mcp_file_used` only) + §"Priority 9" (#1374)
+- `docs/planning/EPIC_4/SPRINT_27/KNOWN_UNKNOWNS.md` Unknown 8.1, 8.2, 9.4
 - `docs/planning/EPIC_4/SPRINT_26/SPRINT_RETROSPECTIVE.md` (structural reference)
 - Sprint 27 SPRINT_LOG.md (cumulative entries from Days 0–12)
 
 **Tasks:**
+
+0a. **#1400 (Priority 8, slipped from Day 12) fix** at `scripts/gamslib/run_full_test.py:899`. Choose KU 8.2 implementation: basename only (always `data/gamslib/mcp/<model>_mcp_presolve.gms`) OR `PROJECT_ROOT`-relative. Run the audit grep against a recent pipeline JSON: `grep -oE '"[^"]+": "/[^"]+"' data/gamslib/gamslib_status.json | sort -u`. If `mcp_file_used` is the only leak field, KU 8.1 ✅ VERIFIED at corrected scope.
+0b. **#1374 (Priority 9, slipped from Day 12) corpus sweep** — scan all translating `*_mcp.gms` artifacts for duplicate `var.l(idx) = val` patterns. Document count + shapes. Apply targeted `src/emit/` fix for the most common 1–2 shapes (regenerate affected goldens **before** the retest). KU 9.4 ✅. **Slip valve: if Day 13 overruns, record the audit and formally defer the fix to Sprint 28.**
 
 1. **Final PR22 audit script:**
    ```bash
@@ -419,6 +424,8 @@ The prompts are designed for **direct invocation** — the engineer copies the d
 6. Final SPRINT_LOG.md commit.
 
 **Success criteria (Day 13):**
+- [ ] **#1400 (slipped from Day 12) landed** — `mcp_file_used` no longer leaks absolute paths (KU 8.1/8.2 ✅).
+- [ ] **#1374 (slipped from Day 12) landed OR formally deferred to Sprint 28** — audit recorded either way (KU 9.4 ✅).
 - [ ] Final metrics meet acceptance criteria: Solve ≥ 111, Match ≥ 66, path_syntax_error ≤ 6, model_infeasible ≤ 3, Translate ≥ 135/142, Parse ≥ 142/142, Tests ≥ 4,750.
 - [ ] Determinism: byte-identical `gamslib_status.json` under 3 `PYTHONHASHSEED` values.
 - [ ] All 28 Sprint 27 KUs ✅ VERIFIED.

--- a/src/ir/ast.py
+++ b/src/ir/ast.py
@@ -536,10 +536,12 @@ class IndexOffset(Expr):
                         return f"{self.base}+{int(offset_val)}"
                     else:
                         return f"{self.base}{int(offset_val)}"
-            elif isinstance(inner, (Call, Binary)):
+            elif isinstance(inner, (Call, Binary, ParamRef)):
                 # Sprint 20 Day 3: Handle Unary("-", Call(...)) and Unary("-", Binary(...)) patterns
                 # e.g., sparta: t-(ord(l)-1) → Unary("-", Binary("-", Call("ord", ...), Const(1)))
                 # e.g., tabora: t-ord(a) → Unary("-", Call("ord", ...))
+                # Issue #1224: also Unary("-", ParamRef(...)) — the parameter-valued
+                # LAG form, e.g. `i-li(k)` → Unary("-", ParamRef("li", ("k",))).
                 # Circular not supported for complex expressions
                 if self.circular:
                     raise NotImplementedError(
@@ -566,25 +568,17 @@ class IndexOffset(Expr):
             offset_str = self._offset_expr_to_string(self.offset)
             # Wrap complex offset in parentheses for clarity
             return f"{self.base}+({offset_str})"
-        elif isinstance(self.offset, Call):
-            # Sprint 20 Day 3: Handle Call(...) pattern (direct call without unary minus)
-            # e.g., t+ord(i)
-            if self.circular:
-                raise NotImplementedError(
-                    f"Circular lead/lag with Call offset not supported: {self.offset}"
-                )
-            offset_str = self._offset_expr_to_string(self.offset)
-            return f"{self.base}+{offset_str}"
-        elif isinstance(self.offset, ParamRef):
-            # Issue #1224: parameter-valued offset, e.g. mine's `i + li(k)` where
-            # `li(k)` is a parameter giving the lead amount per neighbor `k`.
-            # GAMS accepts a parameter expression as a lead/lag amount and
-            # evaluates it at runtime, so the equation domain index `k` can stay
-            # symbolic — render `base+li(k)` directly rather than requiring a
+        elif isinstance(self.offset, (Call, ParamRef)):
+            # Sprint 20 Day 3: Call(...) pattern (direct call without unary minus),
+            # e.g. t+ord(i). Issue #1224: ParamRef(...) pattern, e.g. mine's
+            # i+li(k) — GAMS accepts a parameter expression as a lead/lag amount
+            # and evaluates it at runtime, so the equation domain index `k` can
+            # stay symbolic; render `base+li(k)` directly rather than requiring a
             # constant integer offset.
             if self.circular:
                 raise NotImplementedError(
-                    f"Circular lead/lag with ParamRef offset not supported: {self.offset}"
+                    f"Circular lead/lag with {type(self.offset).__name__} offset "
+                    f"not supported: {self.offset}"
                 )
             offset_str = self._offset_expr_to_string(self.offset)
             return f"{self.base}+{offset_str}"

--- a/src/ir/ast.py
+++ b/src/ir/ast.py
@@ -575,6 +575,19 @@ class IndexOffset(Expr):
                 )
             offset_str = self._offset_expr_to_string(self.offset)
             return f"{self.base}+{offset_str}"
+        elif isinstance(self.offset, ParamRef):
+            # Issue #1224: parameter-valued offset, e.g. mine's `i + li(k)` where
+            # `li(k)` is a parameter giving the lead amount per neighbor `k`.
+            # GAMS accepts a parameter expression as a lead/lag amount and
+            # evaluates it at runtime, so the equation domain index `k` can stay
+            # symbolic — render `base+li(k)` directly rather than requiring a
+            # constant integer offset.
+            if self.circular:
+                raise NotImplementedError(
+                    f"Circular lead/lag with ParamRef offset not supported: {self.offset}"
+                )
+            offset_str = self._offset_expr_to_string(self.offset)
+            return f"{self.base}+{offset_str}"
         else:
             # Complex expression - not supported
             raise NotImplementedError(

--- a/tests/unit/ir/test_index_offset_paramref.py
+++ b/tests/unit/ir/test_index_offset_paramref.py
@@ -1,0 +1,87 @@
+"""Sprint 27 #1224: `IndexOffset.to_gams_string()` must render parameter-valued
+offsets (e.g. mine's `i + li(k)`), not raise "Complex offset expressions not
+yet supported".
+
+mine (GAMSlib "Opencast Mining") uses parameter-valued index offsets:
+
+    pr(k,l+1,i,j)$c(l,i,j).. x(l, i+li(k), j+lj(k)) =g= x(l+1,i,j);
+
+where `li(k)`/`lj(k)` are parameters giving the per-neighbor lead amount. The
+equation domain index `k` stays symbolic in the MCP, so the offset cannot be
+reduced to a constant — but GAMS accepts a parameter expression as a lead/lag
+amount and evaluates it at runtime. Before the fix, emit aborted with
+`NotImplementedError: Complex offset expressions not yet supported:
+ParamRef(li(k))`. The fix renders `base+li(k)` directly.
+
+NOTE: this fix delivers translation only (+1 Translate). The KKT cross-term
+for a parameter-valued offset is not yet inverted in the Jacobian, so mine's
+emitted MCP is still `model_infeasible` — that deeper AD change is deferred to
+Sprint 28 (see ISSUE_1224).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from src.ir.ast import Const, IndexOffset, ParamRef, SymbolRef
+
+
+def test_paramref_offset_renders():
+    """#1224: a ParamRef offset renders as `base+param(idx)` (GAMS-valid)."""
+    assert (
+        IndexOffset(base="i", offset=ParamRef("li", ("k",)), circular=False).to_gams_string()
+        == "i+li(k)"
+    )
+    assert (
+        IndexOffset(base="j", offset=ParamRef("lj", ("k",)), circular=False).to_gams_string()
+        == "j+lj(k)"
+    )
+
+
+def test_const_and_symbol_offsets_unchanged():
+    """Regression: the existing Const/SymbolRef offset rendering is unchanged."""
+    assert IndexOffset(base="t", offset=Const(1), circular=False).to_gams_string() == "t+1"
+    assert IndexOffset(base="t", offset=Const(-3), circular=False).to_gams_string() == "t-3"
+    assert IndexOffset(base="i", offset=SymbolRef("j"), circular=False).to_gams_string() == "i+j"
+
+
+def test_circular_paramref_offset_unsupported():
+    """Circular (`++`/`--`) lead/lag with a ParamRef offset is still rejected
+    explicitly rather than silently mis-rendered."""
+    with pytest.raises(NotImplementedError):
+        IndexOffset(base="i", offset=ParamRef("li", ("k",)), circular=True).to_gams_string()
+
+
+@pytest.mark.integration
+def test_mine_translates_with_paramref_offset():
+    """#1224 end-to-end: the mine model translates (no 'Complex offset' abort)
+    and the `pr` complementarity renders the parameter-valued offsets."""
+    src = "data/gamslib/raw/mine.gms"
+    if not os.path.exists(src):
+        pytest.skip("data/gamslib/raw/mine.gms is gitignored on this runner.")
+
+    from src.ad.constraint_jacobian import compute_constraint_jacobian
+    from src.ad.gradient import compute_objective_gradient
+    from src.emit.emit_gams import emit_gams_mcp
+    from src.ir.normalize import normalize_model
+    from src.ir.parser import parse_model_file
+    from src.kkt.assemble import assemble_kkt_system
+
+    old = sys.getrecursionlimit()
+    sys.setrecursionlimit(50000)
+    try:
+        model = parse_model_file(src)
+        normalize_model(model)
+        j_eq, j_ineq = compute_constraint_jacobian(model)
+        grad = compute_objective_gradient(model)
+        kkt = assemble_kkt_system(model, grad, j_eq, j_ineq)
+        emit = emit_gams_mcp(kkt)
+    finally:
+        sys.setrecursionlimit(old)
+
+    assert (
+        "i+li(k)" in emit and "j+lj(k)" in emit
+    ), "mine's parameter-valued offsets must render in the emitted MCP."

--- a/tests/unit/ir/test_index_offset_paramref.py
+++ b/tests/unit/ir/test_index_offset_paramref.py
@@ -29,6 +29,7 @@ import pytest
 from src.ir.ast import Const, IndexOffset, ParamRef, SymbolRef
 
 
+@pytest.mark.unit
 def test_paramref_offset_renders():
     """#1224: a ParamRef offset renders as `base+param(idx)` (GAMS-valid)."""
     assert (
@@ -41,6 +42,7 @@ def test_paramref_offset_renders():
     )
 
 
+@pytest.mark.unit
 def test_paramref_lag_offset_renders():
     """#1224 (PR review): the LAG form `i-li(k)` is parsed as
     `Unary('-', ParamRef(...))` and must render as `i-li(k)`, not raise."""
@@ -50,6 +52,7 @@ def test_paramref_lag_offset_renders():
     assert lag.to_gams_string() == "i-li(k)"
 
 
+@pytest.mark.unit
 def test_const_and_symbol_offsets_unchanged():
     """Regression: the existing Const/SymbolRef offset rendering is unchanged."""
     assert IndexOffset(base="t", offset=Const(1), circular=False).to_gams_string() == "t+1"
@@ -57,6 +60,7 @@ def test_const_and_symbol_offsets_unchanged():
     assert IndexOffset(base="i", offset=SymbolRef("j"), circular=False).to_gams_string() == "i+j"
 
 
+@pytest.mark.unit
 def test_circular_paramref_offset_unsupported():
     """Circular (`++`/`--`) lead/lag with a ParamRef offset is still rejected
     explicitly rather than silently mis-rendered."""

--- a/tests/unit/ir/test_index_offset_paramref.py
+++ b/tests/unit/ir/test_index_offset_paramref.py
@@ -41,6 +41,15 @@ def test_paramref_offset_renders():
     )
 
 
+def test_paramref_lag_offset_renders():
+    """#1224 (PR review): the LAG form `i-li(k)` is parsed as
+    `Unary('-', ParamRef(...))` and must render as `i-li(k)`, not raise."""
+    from src.ir.ast import Unary
+
+    lag = IndexOffset(base="i", offset=Unary("-", ParamRef("li", ("k",))), circular=False)
+    assert lag.to_gams_string() == "i-li(k)"
+
+
 def test_const_and_symbol_offsets_unchanged():
     """Regression: the existing Const/SymbolRef offset rendering is unchanged."""
     assert IndexOffset(base="t", offset=Const(1), circular=False).to_gams_string() == "t+1"


### PR DESCRIPTION
## Summary

Fixes **#1224**: mine ("Opencast Mining") uses **parameter-valued index offsets** —
```gams
pr(k,l+1,i,j)$c(l,i,j).. x(l, i+li(k), j+lj(k)) =g= x(l+1,i,j);
```
where `li(k)`/`lj(k)` are parameters giving the per-neighbor lead amount. Translation aborted with `NotImplementedError: Complex offset expressions not yet supported: ParamRef(li(k))`. **mine now translates (+1 Translate).**

## Corrected fix surface

The Day-11/12 prompt + KU 6.1 guessed the fix at `src/ad/constraint_jacobian.py:_try_eval_offset` / `src/ad/derivative_rules.py:2793` (evaluate the offset to a constant). That's wrong for mine: the `pr` complementarity is kept **symbolic over `k`**, so the offset can never reduce to a constant at emit time. The hard error is raised in **`src/ir/ast.py` `IndexOffset.to_gams_string()`** (the emit phase — translation reaches emit before crashing; the AD layer does not crash).

GAMS natively accepts a parameter expression as a lead/lag amount and evaluates it at runtime (`x(i+li(k))` is valid GAMS), so the fix adds a `ParamRef` branch that renders `base+li(k)` — mirroring the existing `Call` branch (`_offset_expr_to_string` already rendered `ParamRef`).

## Result & blast radius

- **+1 Translate**: mine `translate_internal_error` → `translate_success`, **compiles clean** (`action=c`, 0 errors). Emits `comp_pr(k,l,i,j)$(...).. x(l,i+li(k),j+lj(k)) - x(l+1,i,j) =G= 0;`.
- **Additive / zero-regression**: the `ParamRef` branch only fires where `to_gams_string()` previously *raised*. Any model that translates today has no parameter-valued offset (it would have crashed), so no translating model is affected. Const/symbol offset rendering is unchanged (unit test).

## KU 6.2 — next failure mode: `model_infeasible`

The emitted MCP solves to **MODEL STATUS 4 Infeasible**. The `stat_x` cross-term from `pr` does not **invert** the parameter-valued offset — it emits `sum(k, lam_pr(k,l,i,j))` instead of `sum(k, lam_pr(k, l, i-li(k), j-lj(k)))`, and drops the `-sum(k, lam_pr(k, l-1, i, j))` term. Producing the correct stationarity (the AD/Jacobian cross-term inversion the prep doc named) is the **conditional Solve gain → Sprint 28** (`ISSUE_1224` "Day 12 resolution").

KU 6.1 ✅ STANDALONE (fix is `src/ir/ast.py`; no `index_mapping.py`/#1385 overlap) · KU 6.2 ✅ (`model_infeasible`).

## Scope note

Per the Day-11 carryforward, Day 12 did the **full** #1224 (it was not started Day 11). **#1400 (Priority 8) and #1374 (Priority 9) slip to Day 13** per the PLAN §12 slip guidance.

## Test plan

- New `tests/unit/ir/test_index_offset_paramref.py` (4 tests): ParamRef renders `i+li(k)`; Const/symbol offsets unchanged; circular ParamRef rejected; mine translates end-to-end (skip-if-absent).
- `ISSUE_1224` updated with a `## Phase 0: Acceptance Gate` section (fix is `src/ir/`, outside the PR20-gated `src/{ad,kkt,emit}` set, but recorded for completeness).
- `make typecheck && make format && make lint` clean; `make test`: **4774 passed**.