### PR TITLE
Sprint 28 Day 1: KKT-residual harness — CLI + dual-transfer reuse + self-check

### DIFF
--- a/docs/planning/EPIC_4/SPRINT_28/PRIORITY_9_KKT_RESIDUAL_HARNESS_DESIGN.md
+++ b/docs/planning/EPIC_4/SPRINT_28/PRIORITY_9_KKT_RESIDUAL_HARNESS_DESIGN.md
@@ -65,7 +65,9 @@ In Sprint 27 (Day 9, launch) inequality/bound marginals were transferred by hand
 
 ### Reuse of the `--nlp-presolve` machinery (Unknown 9.1 Q4)
 
-The existing `_emit_nlp_presolve` path (`src/emit/emit_gams.py`) already `$include`s the source NLP and warm-starts the MCP **primals**. The harness reuses that for primal transfer and adds the **dual** transfer above (presolve does not load `.m` into the multipliers). This keeps the harness aligned with the production emit rather than maintaining a parallel warm-start.
+> **Day-1 correction (PR24, 2026-06-12):** this paragraph's original claim — "presolve does not load `.m` into the multipliers" — is **empirically false**. `_emit_nlp_presolve` (`src/emit/emit_gams.py:1067–1130`) **already** generates the full dual transfer (`nu_<eq>.l = eq.m`, `lam_<eq>.l = abs(eq.m)`, `piL_*`/`piU_*` from variable marginals), confirmed in `launch_mcp_presolve.gms` (nu=8, lam=2, piL=13, piU=6). **Architecture A (chosen, user-approved):** the harness **reuses the production `--nlp-presolve` emit for both primal *and* dual warm-start** — it does not re-derive the transfer via `build_complementarity_pairs`. The harness's dual-transfer layer (`extract_dual_transfer`) *verifies* the production transfer is present; the §"Consistency self-check" below catches any gap (e.g. cesam's empty `nu_*`, korcge #1439). The `build_complementarity_pairs`-driven description in this §2 is retained as the conceptual mapping but is **not reimplemented** by the harness.
+
+The existing `_emit_nlp_presolve` path (`src/emit/emit_gams.py`) `$include`s the source NLP and warm-starts the MCP **primals and duals**. The harness reuses that whole transfer, keeping it aligned with the production emit rather than maintaining a parallel warm-start.
 
 ### Consistency self-check (the dual-transfer's own validity)
 

--- a/docs/planning/EPIC_4/SPRINT_28/SPRINT_LOG.md
+++ b/docs/planning/EPIC_4/SPRINT_28/SPRINT_LOG.md
@@ -59,4 +59,20 @@ The PR #1438 review (Copilot) raised two `--nlp-presolve` concerns on the refres
 - **korcge ordering — REAL latent emit bug, filed #1439.** The `--nlp-presolve` variant aborts (EXECERROR=5): `it(i)=yes$(e.l or m.l)` + the `.fx` fixups run **before** the `$include` with `.l=0`, so `it` is empty and vars fix to 0 → `1/xxd(i)`/`m(i)**(-rhoc)` div-by-zero. **Not blocking:** korcge solves **MODEL STATUS 1 Optimal** via the non-presolve file (`mcp_file_used = None`); the presolve variant is unused for its metrics; old golden was already broken (Locally Infeasible). Filed `ISSUE_1439_*.md` + GitHub #1439, wired into `PLAN.md`/`PLAN_PROMPTS.md` Day 0 + Day 12 (Priority 10 divergence detector). The reviewer correctly identified the mechanism.
 - **cesam empty `nu_*` transfer — BENIGN, no issue filed.** Despite the empty equality-multiplier warm-start, cesam's presolve MCP solves to **MODEL STATUS 1 Optimal** (primal + `piL_*`/`piU_*` bound-multiplier transfer suffices). Side-finding: cesam solves under presolve but is Infeasible under non-presolve (its pipeline path) — possibly recoverable via presolve; noted for the Priority 2/3 cesam2 work.
 
-### Next: Day 1 — begin building the KKT-residual harness (Priority 9, front-loaded Days 1–3).
+---
+
+## Day 1 — KKT-Residual Harness build (start) (2026-06-12)
+
+**Status:** 🟢 DONE — CLI + dual-transfer reuse/extraction + residual-only rewrite + consistency self-check landed (`scripts/diagnostics/kkt_residual.py`) with 16 unit tests; `make test` 4,795 passed (+16).
+
+### Architecture decision: **A — reuse the `--nlp-presolve` emit** (design §2.66 corrected, PR24)
+
+The design's §2.66 premise — *"presolve does not load `.m` into the multipliers"* — is **empirically false**: `_emit_nlp_presolve` (`src/emit/emit_gams.py:1067–1130`) already generates the complete dual transfer (`nu_<eq>.l = eq.m`, `lam_<eq>.l = abs(eq.m)`, `piL_*`/`piU_*` from variable marginals), confirmed in `launch_mcp_presolve.gms`. So the harness **reuses** the production transfer rather than re-deriving it via `build_complementarity_pairs` — simpler, DRY, production-aligned, and the consistency self-check catches any transfer gaps (e.g. cesam's empty `nu_*`, korcge #1439). User approved A. Design doc §2 annotated with the correction.
+
+### Built (Day 1)
+
+- `scripts/diagnostics/kkt_residual.py` — the CLI (`<model.gms> [--gdx] [--tol 1e-6] [--json] [--nlp-solver] [--no-cold-start]`); `emit_warmstarted_mcp` (reuse `translate_single_model(..., nlp_presolve=True)`); `extract_dual_transfer` (parse the four multiplier classes from the emit); `make_residual_only` (insert `mcp_model.iterlim = 0;` before the `Solve` → residual-only evaluation); `classify_consistency` (the §2 self-check → `dual_transfer_inconsistent`).
+- `tests/unit/diagnostics/test_kkt_residual_harness.py` — 16 unit tests. The **dual transfer on launch** check uses the committed `launch_mcp_presolve.gms` golden (no GAMS): extracts **nu=8, lam=2, piL=13, piU=6** (all four classes; `lam_*` use `abs()`).
+- `make typecheck`/`format`/`lint` clean (harness file ruff/black/mypy-clean; the only mypy notes are pre-existing in transitively-imported `scripts/gamslib/db_manager.py`, outside the gate scope).
+
+### Next: Day 2 — Case-(a/b/c) verdict + JSON/human output (run the residual-only MCP via GAMS, parse per-row residuals, apply the self-check then the verdict).

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import math
 import re
+import shutil
 import sys
 import tempfile
 from dataclasses import dataclass, field
@@ -206,6 +207,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "(residual + Case b/guard only; not honored in the Day-1 build)"
         ),
     )
+    parser.add_argument(
+        "--keep-files",
+        action="store_true",
+        help="keep the generated scratch MCP files (default: delete the scratch dir on exit)",
+    )
     return parser
 
 
@@ -243,41 +249,51 @@ def main(argv: list[str] | None = None) -> int:
     # Write to a scratch directory under PROJECT_ROOT/output (gitignored) — never
     # the committed golden dir, and never outside the repo: translate_single_model
     # reports output_path.relative_to(PROJECT_ROOT), so a /tmp path would raise.
+    # The scratch dir is deleted on exit unless --keep-files (cf. check_convexity.py).
     scratch_root = PROJECT_ROOT / "output"
     scratch_root.mkdir(exist_ok=True)
     scratch = Path(tempfile.mkdtemp(prefix=f"kkt_residual_{model_path.stem}_", dir=scratch_root))
-    presolve_path = scratch / f"{model_path.stem}_mcp_presolve.gms"
-    print(f"[kkt-residual] {model_path.name} — emitting warm-started MCP (--nlp-presolve)…")
-    result = emit_warmstarted_mcp(model_path, presolve_path)
-    if result.get("status") != "success":
-        err = result.get("error")
-        print(f"error: warm-started MCP emit failed: {err}", file=sys.stderr)
-        return 1
+    try:
+        presolve_path = scratch / f"{model_path.stem}_mcp_presolve.gms"
+        print(f"[kkt-residual] {model_path.name} — emitting warm-started MCP (--nlp-presolve)…")
+        result = emit_warmstarted_mcp(model_path, presolve_path)
+        if result.get("status") != "success":
+            err = result.get("error")
+            print(f"error: warm-started MCP emit failed: {err}", file=sys.stderr)
+            return 1
 
-    mcp_text = presolve_path.read_text(encoding="utf-8")
-    transfer = extract_dual_transfer(mcp_text)
-    print(f"[kkt-residual] dual transfer (reused from --nlp-presolve): {transfer.summary()}")
-    if transfer.is_empty:
+        mcp_text = presolve_path.read_text(encoding="utf-8")
+        transfer = extract_dual_transfer(mcp_text)
+        print(f"[kkt-residual] dual transfer (reused from --nlp-presolve): {transfer.summary()}")
+        if transfer.is_empty:
+            print(
+                "[kkt-residual] WARNING: empty dual transfer — the presolve emit produced "
+                "no multiplier warm-start; the self-check will gate any verdict.",
+                file=sys.stderr,
+            )
+
+        # Residual-only variant (iterlim=0) — the input to the Day-2 GAMS evaluation.
+        residual_path = scratch / f"{model_path.stem}_mcp_presolve_residual.gms"
+        residual_path.write_text(make_residual_only(mcp_text), encoding="utf-8")
+
+        if args.keep_files:
+            print(f"[kkt-residual] warm-started MCP:  {presolve_path}")
+            print(f"[kkt-residual] residual-only MCP: {residual_path}")
+        else:
+            print(
+                "[kkt-residual] scratch MCP files written + verified (use --keep-files to retain)"
+            )
+        # Days 2–3: run GAMS at iterlim=0 on the residual-only MCP, parse per-row
+        # residuals, run the consistency self-check (classify_consistency) + the
+        # Case-(a/b/c) verdict, and emit the JSON/human report.
         print(
-            "[kkt-residual] WARNING: empty dual transfer — the presolve emit produced "
-            "no multiplier warm-start; the self-check will gate any verdict.",
-            file=sys.stderr,
+            "[kkt-residual] Day-1 build: emit + dual-transfer reuse/extraction + "
+            "residual-only rewrite + self-check ready. Verdict + run land Days 2–3."
         )
-
-    # Residual-only variant (iterlim=0) — the input to the Day-2 GAMS evaluation.
-    residual_path = scratch / f"{model_path.stem}_mcp_presolve_residual.gms"
-    residual_path.write_text(make_residual_only(mcp_text), encoding="utf-8")
-
-    print(f"[kkt-residual] warm-started MCP:  {presolve_path}")
-    print(f"[kkt-residual] residual-only MCP: {residual_path}")
-    # Days 2–3: run GAMS at iterlim=0 on the residual-only MCP, parse per-row
-    # residuals, run the consistency self-check (classify_consistency) + the
-    # Case-(a/b/c) verdict, and emit the JSON/human report.
-    print(
-        "[kkt-residual] Day-1 build: emit + dual-transfer reuse/extraction + "
-        "residual-only rewrite + self-check ready. Verdict + run land Days 2–3."
-    )
-    return 0
+        return 0
+    finally:
+        if not args.keep_files:
+            shutil.rmtree(scratch, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -22,6 +22,7 @@ verdict + JSON/human output land on Days 2–3.
 from __future__ import annotations
 
 import argparse
+import math
 import re
 import sys
 import tempfile
@@ -135,8 +136,14 @@ def classify_consistency(
     wrong (not the emit): return ``"dual_transfer_inconsistent"`` so a bad
     transfer never masquerades as a Case-b emit bug. Returns ``None`` when the
     self-check passes (the stationarity verdict may proceed).
+
+    Fails **closed** on non-finite residuals: a ``NaN``/``inf`` row (e.g. from a
+    div-by-zero during residual evaluation, cf. korcge #1439) is offending —
+    ``abs(nan) > tol`` is ``False``, so it would otherwise slip through.
     """
-    offending = {k: v for k, v in constraint_residuals.items() if abs(v) > tol}
+    offending = {
+        k: v for k, v in constraint_residuals.items() if not math.isfinite(v) or abs(v) > tol
+    }
     return "dual_transfer_inconsistent" if offending else None
 
 
@@ -164,7 +171,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--gdx",
         metavar="SOLUTION.gdx",
-        help="pre-solved NLP solution (primals + marginals); if omitted, solve the NLP first",
+        help=(
+            "pre-solved NLP solution (primals + marginals); if omitted, solve the NLP "
+            "first (not honored in the Day-1 build)"
+        ),
     )
     parser.add_argument(
         "--tol",
@@ -175,7 +185,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
             f"{TOL_DEFAULT} once implemented; not honored in the Day-1 build)"
         ),
     )
-    parser.add_argument("--json", metavar="OUT.json", help="write the machine-readable report here")
+    parser.add_argument(
+        "--json",
+        metavar="OUT.json",
+        help="write the machine-readable report here (not honored in the Day-1 build)",
+    )
     parser.add_argument(
         "--nlp-solver",
         default=None,
@@ -187,7 +201,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--no-cold-start",
         action="store_true",
-        help="skip the cold-start MCP solve used to split Case a from Case c (residual + Case b/guard only)",
+        help=(
+            "skip the cold-start MCP solve used to split Case a from Case c "
+            "(residual + Case b/guard only; not honored in the Day-1 build)"
+        ),
     )
     return parser
 

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """KKT-residual verification harness (Sprint 28 Priority 9 / PR27).
 
 Formalizes Sprint 27's GDX warm-from-good-optimum experiment into the standard

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -1,0 +1,227 @@
+"""KKT-residual verification harness (Sprint 28 Priority 9 / PR27).
+
+Formalizes Sprint 27's GDX warm-from-good-optimum experiment into the standard
+Case-(a/b/c) emit-bug-vs-non-convexity discriminator.
+
+**Architecture A (chosen Sprint 28 Day 1):** the harness *reuses* the production
+``--nlp-presolve`` emit for the warm-start. The Day-1 finding (PR24) corrected the
+design doc's §2.66 premise — ``_emit_nlp_presolve`` (``src/emit/emit_gams.py``)
+already loads the NLP duals into the MCP multipliers (``nu_<eq>.l = eq.m``,
+``lam_<eq>.l = abs(eq.m)``, ``piL_*``/``piU_*`` from variable marginals), so the
+harness does not re-derive the dual transfer via ``build_complementarity_pairs``.
+It emits the MCP with ``--nlp-presolve`` (primal + dual warm-start), rewrites the
+``Solve`` to an ``iterlim=0`` residual evaluation, and reads the per-row residuals.
+
+See ``docs/planning/EPIC_4/SPRINT_28/PRIORITY_9_KKT_RESIDUAL_HARNESS_DESIGN.md``.
+
+Build status: Day 1 — CLI, dual-transfer reuse/extraction, residual-only rewrite,
+and the consistency self-check. The GAMS run + residual parse + Case-(a/b/c)
+verdict + JSON/human output land on Days 2–3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+TOL_DEFAULT = 1e-6
+DEFAULT_NLP_SOLVER = "CONOPT"
+MCP_MODEL_NAME = "mcp_model"
+
+# Headers the production --nlp-presolve emit writes around the dual transfer.
+DUAL_HEADER = "Transfer NLP duals to MCP multiplier initialization"
+BOUND_HEADER = "Transfer variable marginals to bound multipliers"
+
+# A multiplier warm-start statement, e.g. `nu_diweight.l(s) = diweight.m(s);`.
+_MULT_RE = re.compile(r"^(nu|lam|piL|piU)_\w+\.l\b.*=.*;")
+
+
+@dataclass
+class DualTransfer:
+    """The multiplier warm-start statements the ``--nlp-presolve`` emit produced.
+
+    Architecture A: the harness extracts (rather than re-derives) these from the
+    emitted ``*_mcp_presolve.gms`` to confirm the production transfer covers the
+    four multiplier classes before trusting any residual.
+    """
+
+    nu: list[str] = field(default_factory=list)  # equality multipliers (free)
+    lam: list[str] = field(default_factory=list)  # inequality (>= 0, abs of .m)
+    piL: list[str] = field(default_factory=list)  # lower-bound multipliers
+    piU: list[str] = field(default_factory=list)  # upper-bound multipliers
+
+    @property
+    def total(self) -> int:
+        return len(self.nu) + len(self.lam) + len(self.piL) + len(self.piU)
+
+    @property
+    def is_empty(self) -> bool:
+        return self.total == 0
+
+    def summary(self) -> str:
+        return (
+            f"nu={len(self.nu)} lam={len(self.lam)} "
+            f"piL={len(self.piL)} piU={len(self.piU)} (total {self.total})"
+        )
+
+
+def extract_dual_transfer(mcp_presolve_text: str) -> DualTransfer:
+    """Extract the multiplier warm-start statements from a ``--nlp-presolve`` emit.
+
+    Pure string parse (no GAMS): scans for ``nu_*.l = … ;`` / ``lam_*.l = … ;`` /
+    ``piL_*.l = … ;`` / ``piU_*.l = … ;`` assignments. This is the harness's
+    dual-transfer *verification* layer under Architecture A — it confirms the
+    production transfer is present (an empty result is a flag, cf. cesam's empty
+    ``nu_*`` block found at Day 0).
+    """
+    transfer = DualTransfer()
+    bucket = {
+        "nu": transfer.nu,
+        "lam": transfer.lam,
+        "piL": transfer.piL,
+        "piU": transfer.piU,
+    }
+    for raw in mcp_presolve_text.splitlines():
+        line = raw.strip()
+        m = _MULT_RE.match(line)
+        if m is not None:
+            bucket[m.group(1)].append(line)
+    return transfer
+
+
+def make_residual_only(mcp_text: str, model_name: str = MCP_MODEL_NAME) -> str:
+    """Rewrite the emitted MCP so PATH evaluates residuals at the warm-start point
+    without iterating: insert ``<model>.iterlim = 0;`` immediately before the
+    ``Solve <model> using MCP;`` statement.
+
+    ``iterlim = 0`` makes PATH report the system value at the start point (the
+    transferred NLP KKT point) rather than solving — the residual-only evaluation
+    the Case-(a/b/c) verdict reads. Raises ``ValueError`` if the Solve isn't found.
+    """
+    solve_re = re.compile(
+        rf"^([ \t]*)Solve\s+{re.escape(model_name)}\s+using\s+MCP\s*;",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    def repl(match: re.Match[str]) -> str:
+        indent = match.group(1)
+        return f"{indent}{model_name}.iterlim = 0;\n{match.group(0)}"
+
+    new_text, n = solve_re.subn(repl, mcp_text)
+    if n == 0:
+        raise ValueError(
+            f"no `Solve {model_name} using MCP;` statement found to rewrite "
+            "for residual-only (iterlim=0) evaluation"
+        )
+    return new_text
+
+
+def classify_consistency(
+    constraint_residuals: dict[str, float], tol: float = TOL_DEFAULT
+) -> str | None:
+    """Dual-transfer consistency self-check (design §2).
+
+    The transferred NLP solution already satisfies primal feasibility +
+    complementary slackness, so every *constraint*/*complementarity* row must be
+    ``≈ 0`` at the warm-start point. If any exceeds ``tol`` the *transfer* is
+    wrong (not the emit): return ``"dual_transfer_inconsistent"`` so a bad
+    transfer never masquerades as a Case-b emit bug. Returns ``None`` when the
+    self-check passes (the stationarity verdict may proceed).
+    """
+    offending = {k: v for k, v in constraint_residuals.items() if abs(v) > tol}
+    return "dual_transfer_inconsistent" if offending else None
+
+
+def emit_warmstarted_mcp(model_path: Path, out_path: Path) -> dict[str, object]:
+    """Emit the MCP with ``--nlp-presolve`` (primal + dual warm-start) via the
+    production emit path — Architecture A reuse. Returns the translate result
+    dict (``status``/``output_file``/``error``).
+    """
+    from scripts.gamslib.batch_translate import translate_single_model
+
+    return translate_single_model(model_path, out_path, nlp_presolve=True)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kkt_residual.py",
+        description=(
+            "KKT-residual verification harness (Sprint 28 Priority 9 / PR27): "
+            "warm-start the MCP from the NLP KKT point and evaluate per-row "
+            "residuals to classify Case (a) healthy / (b) emit bug / (c) "
+            "non-convexity."
+        ),
+    )
+    parser.add_argument("model", help="source NLP model (.gms) the pipeline translates")
+    parser.add_argument(
+        "--gdx",
+        metavar="SOLUTION.gdx",
+        help="pre-solved NLP solution (primals + marginals); if omitted, solve the NLP first",
+    )
+    parser.add_argument(
+        "--tol",
+        type=float,
+        default=TOL_DEFAULT,
+        help=f"per-row residual tolerance (default {TOL_DEFAULT})",
+    )
+    parser.add_argument("--json", metavar="OUT.json", help="write the machine-readable report here")
+    parser.add_argument(
+        "--nlp-solver",
+        default=DEFAULT_NLP_SOLVER,
+        help=f"NLP solver for the no---gdx path (default {DEFAULT_NLP_SOLVER})",
+    )
+    parser.add_argument(
+        "--no-cold-start",
+        action="store_true",
+        help="skip the cold-start MCP solve used to split Case a from Case c (residual + Case b/guard only)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    model_path = Path(args.model)
+    if not model_path.exists():
+        print(f"error: model not found: {model_path}", file=sys.stderr)
+        return 2
+
+    out_path = PROJECT_ROOT / "data" / "gamslib" / "mcp" / f"{model_path.stem}_mcp_presolve.gms"
+    print(f"[kkt-residual] {model_path.name} — emitting warm-started MCP (--nlp-presolve)…")
+    result = emit_warmstarted_mcp(model_path, out_path)
+    if result.get("status") != "success":
+        err = result.get("error")
+        print(f"error: warm-started MCP emit failed: {err}", file=sys.stderr)
+        return 1
+
+    mcp_text = out_path.read_text(encoding="utf-8")
+    transfer = extract_dual_transfer(mcp_text)
+    print(f"[kkt-residual] dual transfer (reused from --nlp-presolve): {transfer.summary()}")
+    if transfer.is_empty:
+        print(
+            "[kkt-residual] WARNING: empty dual transfer — the presolve emit produced "
+            "no multiplier warm-start; the self-check will gate any verdict.",
+            file=sys.stderr,
+        )
+
+    # Residual-only variant (iterlim=0) — the input to the Day-2 GAMS evaluation.
+    make_residual_only(mcp_text)
+
+    # Days 2–3: run GAMS at iterlim=0, parse per-row residuals, run the
+    # consistency self-check (classify_consistency) + the Case-(a/b/c) verdict,
+    # and emit the JSON/human report.
+    print(
+        "[kkt-residual] Day-1 build: CLI + dual-transfer reuse/extraction + "
+        "residual-only rewrite + self-check ready. Verdict + run land Days 2–3."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -170,13 +170,19 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--tol",
         type=float,
         default=None,
-        help=f"per-row residual tolerance (Day-2/3 verdict; default {TOL_DEFAULT})",
+        help=(
+            f"per-row residual tolerance for the Day-2/3 verdict (will default to "
+            f"{TOL_DEFAULT} once implemented; not honored in the Day-1 build)"
+        ),
     )
     parser.add_argument("--json", metavar="OUT.json", help="write the machine-readable report here")
     parser.add_argument(
         "--nlp-solver",
         default=None,
-        help=f"NLP solver for the path that solves the NLP when --gdx is not supplied (default {DEFAULT_NLP_SOLVER})",
+        help=(
+            "NLP solver for the path that solves the NLP when --gdx is not supplied "
+            f"(will default to {DEFAULT_NLP_SOLVER} once implemented; not honored in the Day-1 build)"
+        ),
     )
     parser.add_argument(
         "--no-cold-start",
@@ -217,8 +223,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: model not found: {model_path}", file=sys.stderr)
         return 2
 
-    # Write to a scratch directory — never the committed golden dir.
-    scratch = Path(tempfile.mkdtemp(prefix=f"kkt_residual_{model_path.stem}_"))
+    # Write to a scratch directory under PROJECT_ROOT/output (gitignored) — never
+    # the committed golden dir, and never outside the repo: translate_single_model
+    # reports output_path.relative_to(PROJECT_ROOT), so a /tmp path would raise.
+    scratch_root = PROJECT_ROOT / "output"
+    scratch_root.mkdir(exist_ok=True)
+    scratch = Path(tempfile.mkdtemp(prefix=f"kkt_residual_{model_path.stem}_", dir=scratch_root))
     presolve_path = scratch / f"{model_path.stem}_mcp_presolve.gms"
     print(f"[kkt-residual] {model_path.name} — emitting warm-started MCP (--nlp-presolve)…")
     result = emit_warmstarted_mcp(model_path, presolve_path)

--- a/scripts/diagnostics/kkt_residual.py
+++ b/scripts/diagnostics/kkt_residual.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -168,14 +169,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--tol",
         type=float,
-        default=TOL_DEFAULT,
-        help=f"per-row residual tolerance (default {TOL_DEFAULT})",
+        default=None,
+        help=f"per-row residual tolerance (Day-2/3 verdict; default {TOL_DEFAULT})",
     )
     parser.add_argument("--json", metavar="OUT.json", help="write the machine-readable report here")
     parser.add_argument(
         "--nlp-solver",
-        default=DEFAULT_NLP_SOLVER,
-        help=f"NLP solver for the no---gdx path (default {DEFAULT_NLP_SOLVER})",
+        default=None,
+        help=f"NLP solver for the path that solves the NLP when --gdx is not supplied (default {DEFAULT_NLP_SOLVER})",
     )
     parser.add_argument(
         "--no-cold-start",
@@ -187,20 +188,46 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
+
+    # Day-1 scope is emit + dual-transfer extraction + the residual-only rewrite.
+    # The flags that drive the GAMS run / verdict / report are NOT honored yet —
+    # fail fast rather than silently ignore them (they land Days 2–3).
+    pending = [
+        name
+        for name, used in (
+            ("--gdx", args.gdx is not None),
+            ("--json", args.json is not None),
+            ("--tol", args.tol is not None),
+            ("--nlp-solver", args.nlp_solver is not None),
+            ("--no-cold-start", args.no_cold_start),
+        )
+        if used
+    ]
+    if pending:
+        print(
+            "error: the Day-1 build only emits the warm-started MCP + the "
+            "residual-only variant; these options are not implemented yet "
+            f"(land Days 2–3): {', '.join(pending)}",
+            file=sys.stderr,
+        )
+        return 2
+
     model_path = Path(args.model)
     if not model_path.exists():
         print(f"error: model not found: {model_path}", file=sys.stderr)
         return 2
 
-    out_path = PROJECT_ROOT / "data" / "gamslib" / "mcp" / f"{model_path.stem}_mcp_presolve.gms"
+    # Write to a scratch directory — never the committed golden dir.
+    scratch = Path(tempfile.mkdtemp(prefix=f"kkt_residual_{model_path.stem}_"))
+    presolve_path = scratch / f"{model_path.stem}_mcp_presolve.gms"
     print(f"[kkt-residual] {model_path.name} — emitting warm-started MCP (--nlp-presolve)…")
-    result = emit_warmstarted_mcp(model_path, out_path)
+    result = emit_warmstarted_mcp(model_path, presolve_path)
     if result.get("status") != "success":
         err = result.get("error")
         print(f"error: warm-started MCP emit failed: {err}", file=sys.stderr)
         return 1
 
-    mcp_text = out_path.read_text(encoding="utf-8")
+    mcp_text = presolve_path.read_text(encoding="utf-8")
     transfer = extract_dual_transfer(mcp_text)
     print(f"[kkt-residual] dual transfer (reused from --nlp-presolve): {transfer.summary()}")
     if transfer.is_empty:
@@ -211,13 +238,16 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     # Residual-only variant (iterlim=0) — the input to the Day-2 GAMS evaluation.
-    make_residual_only(mcp_text)
+    residual_path = scratch / f"{model_path.stem}_mcp_presolve_residual.gms"
+    residual_path.write_text(make_residual_only(mcp_text), encoding="utf-8")
 
-    # Days 2–3: run GAMS at iterlim=0, parse per-row residuals, run the
-    # consistency self-check (classify_consistency) + the Case-(a/b/c) verdict,
-    # and emit the JSON/human report.
+    print(f"[kkt-residual] warm-started MCP:  {presolve_path}")
+    print(f"[kkt-residual] residual-only MCP: {residual_path}")
+    # Days 2–3: run GAMS at iterlim=0 on the residual-only MCP, parse per-row
+    # residuals, run the consistency self-check (classify_consistency) + the
+    # Case-(a/b/c) verdict, and emit the JSON/human report.
     print(
-        "[kkt-residual] Day-1 build: CLI + dual-transfer reuse/extraction + "
+        "[kkt-residual] Day-1 build: emit + dual-transfer reuse/extraction + "
         "residual-only rewrite + self-check ready. Verdict + run land Days 2–3."
     )
     return 0

--- a/tests/unit/diagnostics/test_kkt_residual_harness.py
+++ b/tests/unit/diagnostics/test_kkt_residual_harness.py
@@ -1,0 +1,136 @@
+"""Unit tests for the KKT-residual harness (Sprint 28 Priority 9 / PR27), Day 1.
+
+Covers the Day-1 build: the dual-transfer reuse/extraction (Architecture A), the
+residual-only (iterlim=0) rewrite, and the dual-transfer consistency self-check.
+The "dual transfer on launch" check uses the committed ``launch_mcp_presolve.gms``
+golden — a real ``--nlp-presolve`` emit — so it needs no GAMS.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts" / "diagnostics"))
+
+from kkt_residual import (  # noqa: E402  (path set above)
+    DualTransfer,
+    classify_consistency,
+    extract_dual_transfer,
+    make_residual_only,
+)
+
+LAUNCH_PRESOLVE = PROJECT_ROOT / "data" / "gamslib" / "mcp" / "launch_mcp_presolve.gms"
+
+
+class TestExtractDualTransferOnLaunch:
+    """Architecture A: the harness reuses the production ``--nlp-presolve`` dual
+    transfer. On launch it must extract all four multiplier classes."""
+
+    def test_launch_golden_present(self) -> None:
+        assert LAUNCH_PRESOLVE.exists(), f"missing fixture: {LAUNCH_PRESOLVE}"
+
+    def test_extracts_all_four_multiplier_classes(self) -> None:
+        text = LAUNCH_PRESOLVE.read_text(encoding="utf-8")
+        transfer = extract_dual_transfer(text)
+        # launch warm-starts equalities (nu_*), inequalities (lam_*), and bounds.
+        assert transfer.nu, "expected nu_* equality-multiplier transfers"
+        assert transfer.lam, "expected lam_* inequality-multiplier transfers"
+        assert transfer.piL, "expected piL_* lower-bound multiplier transfers"
+        assert transfer.piU, "expected piU_* upper-bound multiplier transfers"
+        assert not transfer.is_empty
+        assert transfer.total == (
+            len(transfer.nu) + len(transfer.lam) + len(transfer.piL) + len(transfer.piU)
+        )
+
+    def test_lam_transfers_use_abs(self) -> None:
+        # Inequality marginals are loaded with abs() (GAMS =g=/=l= sign convention).
+        text = LAUNCH_PRESOLVE.read_text(encoding="utf-8")
+        transfer = extract_dual_transfer(text)
+        assert all("abs(" in stmt for stmt in transfer.lam)
+
+    def test_only_multiplier_assignments_captured(self) -> None:
+        # Stray non-multiplier lines must not leak into the transfer.
+        text = LAUNCH_PRESOLVE.read_text(encoding="utf-8")
+        transfer = extract_dual_transfer(text)
+        for stmt in transfer.nu + transfer.lam + transfer.piL + transfer.piU:
+            assert stmt.startswith(("nu_", "lam_", "piL_", "piU_"))
+            assert ".l" in stmt and stmt.endswith(";")
+
+
+class TestExtractDualTransferEdgeCases:
+    def test_empty_text_is_empty(self) -> None:
+        assert extract_dual_transfer("").is_empty
+
+    def test_no_multiplier_lines_is_empty(self) -> None:
+        text = "Equations stat_x;\nstat_x.. x =E= 0;\nSolve mcp_model using MCP;\n"
+        transfer = extract_dual_transfer(text)
+        assert transfer.is_empty
+        assert transfer.total == 0
+
+    def test_classifies_by_prefix(self) -> None:
+        text = (
+            "nu_eq.l(i) = eq.m(i);\n"
+            "lam_cap.l(i) = abs(cap.m(i));\n"
+            "piL_x.l(i) = x.m(i);\n"
+            "piU_x.l(i) = -(x.m(i));\n"
+        )
+        transfer = extract_dual_transfer(text)
+        assert (len(transfer.nu), len(transfer.lam), len(transfer.piL), len(transfer.piU)) == (
+            1,
+            1,
+            1,
+            1,
+        )
+
+
+class TestMakeResidualOnly:
+    def test_inserts_iterlim_before_solve(self) -> None:
+        text = "Model mcp_model / all /;\nSolve mcp_model using MCP;\nDisplay x.l;\n"
+        out = make_residual_only(text)
+        assert "mcp_model.iterlim = 0;" in out
+        # iterlim must precede the Solve.
+        assert out.index("mcp_model.iterlim = 0;") < out.index("Solve mcp_model using MCP;")
+
+    def test_preserves_indentation(self) -> None:
+        text = "  Solve mcp_model using MCP;\n"
+        out = make_residual_only(text)
+        assert "  mcp_model.iterlim = 0;\n  Solve mcp_model using MCP;" in out
+
+    def test_raises_without_solve(self) -> None:
+        with pytest.raises(ValueError, match="no `Solve"):
+            make_residual_only("Equations stat_x;\nstat_x.. x =E= 0;\n")
+
+    def test_real_launch_golden_rewrites_once(self) -> None:
+        text = LAUNCH_PRESOLVE.read_text(encoding="utf-8")
+        out = make_residual_only(text)
+        assert out.count("mcp_model.iterlim = 0;") == 1
+
+
+class TestClassifyConsistency:
+    def test_passes_when_all_within_tol(self) -> None:
+        assert classify_consistency({"eq1": 1e-9, "eq2": -5e-10}) is None
+
+    def test_flags_when_a_row_exceeds_tol(self) -> None:
+        assert classify_consistency({"eq1": 1e-9, "comp_cap": 0.4}) == "dual_transfer_inconsistent"
+
+    def test_tol_is_respected(self) -> None:
+        # 1e-4 is fine at the default tol's neighbour but flagged at a tighter tol.
+        residuals = {"eq1": 1e-4}
+        assert classify_consistency(residuals, tol=1e-3) is None
+        assert classify_consistency(residuals, tol=1e-6) == "dual_transfer_inconsistent"
+
+    def test_empty_residuals_pass(self) -> None:
+        assert classify_consistency({}) is None
+
+
+def test_dual_transfer_dataclass_summary() -> None:
+    transfer = DualTransfer(nu=["a"], lam=["b", "c"], piL=[], piU=["d"])
+    assert transfer.total == 4
+    assert not transfer.is_empty
+    assert "total 4" in transfer.summary()

--- a/tests/unit/diagnostics/test_kkt_residual_harness.py
+++ b/tests/unit/diagnostics/test_kkt_residual_harness.py
@@ -187,3 +187,19 @@ def test_no_args_defaults_are_inert_sentinels() -> None:
     assert args.gdx is None
     assert args.json is None
     assert args.no_cold_start is False
+
+
+class TestKeepFiles:
+    def test_default_is_cleanup(self) -> None:
+        assert build_arg_parser().parse_args(["model.gms"]).keep_files is False
+
+    def test_flag_sets_keep(self) -> None:
+        assert build_arg_parser().parse_args(["model.gms", "--keep-files"]).keep_files is True
+
+    def test_keep_files_is_an_active_day1_flag(self) -> None:
+        # --keep-files controls cleanup *now* — it must NOT be a deferred flag, so
+        # its help must not carry the "not honored in the Day-1 build" disclaimer,
+        # and passing it alone must not trip the fail-fast path.
+        help_text = " ".join(build_arg_parser().format_help().split())
+        keep_help = help_text.split("--keep-files")[1].split("--")[0]
+        assert "not honored in the Day-1 build" not in keep_help

--- a/tests/unit/diagnostics/test_kkt_residual_harness.py
+++ b/tests/unit/diagnostics/test_kkt_residual_harness.py
@@ -20,8 +20,10 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts" / "diagnostics"))
 
 from kkt_residual import (  # noqa: E402  (path set above)
     DualTransfer,
+    build_arg_parser,
     classify_consistency,
     extract_dual_transfer,
+    main,
     make_residual_only,
 )
 
@@ -134,3 +136,36 @@ def test_dual_transfer_dataclass_summary() -> None:
     assert transfer.total == 4
     assert not transfer.is_empty
     assert "total 4" in transfer.summary()
+
+
+class TestCliFailFast:
+    """Day-1 `main()` must fail fast (not silently ignore) on the flags whose
+    behavior lands Days 2–3 — these checks run before any emit/GAMS work."""
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ["--gdx", "sol.gdx"],
+            ["--json", "out.json"],
+            ["--tol", "1e-4"],
+            ["--nlp-solver", "CONOPT"],
+            ["--no-cold-start"],
+        ],
+    )
+    def test_unimplemented_flags_fail_fast(self, extra: list[str]) -> None:
+        # Returns non-zero before touching the (nonexistent) model file or GAMS.
+        assert main(["does_not_exist.gms", *extra]) == 2
+
+    def test_help_text_has_no_typo(self) -> None:
+        help_text = build_arg_parser().format_help()
+        assert "no---gdx" not in help_text
+
+
+def test_no_args_defaults_are_inert_sentinels() -> None:
+    # tol/nlp-solver default to None (sentinels) so an explicit value is detectable.
+    args = build_arg_parser().parse_args(["model.gms"])
+    assert args.tol is None
+    assert args.nlp_solver is None
+    assert args.gdx is None
+    assert args.json is None
+    assert args.no_cold_start is False

--- a/tests/unit/diagnostics/test_kkt_residual_harness.py
+++ b/tests/unit/diagnostics/test_kkt_residual_harness.py
@@ -160,6 +160,13 @@ class TestCliFailFast:
         help_text = build_arg_parser().format_help()
         assert "no---gdx" not in help_text
 
+    def test_deferred_flag_help_does_not_claim_an_active_default(self) -> None:
+        # --tol/--nlp-solver argparse-default to None (sentinels) in Day 1, so the
+        # help must not imply the documented value is the *current* default.
+        # Collapse argparse's line-wrapping before matching the phrase.
+        help_text = " ".join(build_arg_parser().format_help().split())
+        assert help_text.count("not honored in the Day-1 build") >= 2
+
 
 def test_no_args_defaults_are_inert_sentinels() -> None:
     # tol/nlp-solver default to None (sentinels) so an explicit value is detectable.

--- a/tests/unit/diagnostics/test_kkt_residual_harness.py
+++ b/tests/unit/diagnostics/test_kkt_residual_harness.py
@@ -130,6 +130,15 @@ class TestClassifyConsistency:
     def test_empty_residuals_pass(self) -> None:
         assert classify_consistency({}) is None
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_residuals_fail_closed(self, bad: float) -> None:
+        # abs(nan) > tol is False — a NaN/inf row must still be treated as
+        # offending (fail closed), not silently pass the self-check.
+        assert classify_consistency({"stat_x": bad}) == "dual_transfer_inconsistent"
+
+    def test_finite_within_tol_still_passes_alongside_nothing(self) -> None:
+        assert classify_consistency({"eq1": 0.0, "eq2": 1e-9}) is None
+
 
 def test_dual_transfer_dataclass_summary() -> None:
     transfer = DualTransfer(nu=["a"], lam=["b", "c"], piL=[], piU=["d"])
@@ -163,9 +172,11 @@ class TestCliFailFast:
     def test_deferred_flag_help_does_not_claim_an_active_default(self) -> None:
         # --tol/--nlp-solver argparse-default to None (sentinels) in Day 1, so the
         # help must not imply the documented value is the *current* default.
-        # Collapse argparse's line-wrapping before matching the phrase.
+        # Collapse argparse's line-wrapping before matching the phrase. Every
+        # fail-fast flag (--gdx/--json/--tol/--nlp-solver/--no-cold-start) must
+        # say so in its help, so the docs match main()'s behavior.
         help_text = " ".join(build_arg_parser().format_help().split())
-        assert help_text.count("not honored in the Day-1 build") >= 2
+        assert help_text.count("not honored in the Day-1 build") >= 5
 
 
 def test_no_args_defaults_are_inert_sentinels() -> None:


### PR DESCRIPTION
## Summary

Sprint 28 **Day 1** — start building the Priority-9 KKT-residual harness (`scripts/diagnostics/kkt_residual.py`). Day-1 scope per the plan: the CLI, the dual-transfer mechanism, and the consistency self-check, unit-tested on launch.

## Architecture A (reuse the `--nlp-presolve` emit) — design §2.66 corrected (PR24)

The design's §2.66 premise — *"presolve does not load `.m` into the multipliers"* — is **empirically false**. `_emit_nlp_presolve` (`src/emit/emit_gams.py:1067–1130`) **already** generates the full dual transfer (`nu_<eq>.l = eq.m`, `lam_<eq>.l = abs(eq.m)`, `piL_*`/`piU_*` from variable marginals), confirmed in `launch_mcp_presolve.gms`. So (with user approval) the harness **reuses** the production transfer rather than re-deriving it via `build_complementarity_pairs` — simpler, DRY, production-aligned, and the consistency self-check catches any transfer gap (e.g. cesam's empty `nu_*`, korcge #1439). The design doc §2.66 is annotated with the correction.

## Built

- **`scripts/diagnostics/kkt_residual.py`** — CLI (`<model.gms> [--gdx] [--tol 1e-6] [--json] [--nlp-solver] [--no-cold-start]`); `emit_warmstarted_mcp` (reuse `translate_single_model(..., nlp_presolve=True)`); `extract_dual_transfer` (parse the four multiplier classes); `make_residual_only` (insert `mcp_model.iterlim = 0;` before the `Solve` → residual-only evaluation); `classify_consistency` (the §2 self-check → `dual_transfer_inconsistent`).
- **`tests/unit/diagnostics/test_kkt_residual_harness.py`** — 16 unit tests. The **dual transfer on launch** check uses the committed `launch_mcp_presolve.gms` golden (no GAMS): extracts **nu=8, lam=2, piL=13, piU=6** (all four classes; `lam_*` use `abs()`).
- SPRINT_LOG Day-1 entry + the design §2.66 correction.

**Days 2–3** add the GAMS `iterlim=0` run, per-row residual parse, the Case-(a/b/c) verdict, and the JSON/human output.

## Test plan

- [x] `make typecheck && make format && make lint && make test` all PASS — **4795 passed** (+16), typecheck/format/lint clean
- [x] Harness file ruff/black/mypy-clean (the only mypy notes are pre-existing in transitively-imported `scripts/gamslib/db_manager.py`, outside the gate scope)
- [x] CLI `--help` works; the pure functions (`extract_dual_transfer`/`make_residual_only`/`classify_consistency`) are unit-tested without GAMS
- [x] Dual transfer verified on launch (all four multiplier classes)